### PR TITLE
Forward port "Set axis background to transparent in inlinebackend"

### DIFF
--- a/ipython_kernel/pylab/config.py
+++ b/ipython_kernel/pylab/config.py
@@ -54,7 +54,6 @@ class InlineBackend(InlineBackendConfig):
         # play nicely with white background in the Qt and notebook frontend
         'figure.facecolor': (1,1,1,0),
         'figure.edgecolor': (1,1,1,0),
-        'axes.facecolor': (1,1,1,0),
         # 12pt labels get cutoff on 6x4 logplots, so use 10pt.
         'font.size': 10,
         # 72 dpi matches SVG/qtconsole


### PR DESCRIPTION
See ipython/ipython/8336

```
Revert "Set axis background to transparent in inlinebackend"

This reverts commit 902c754fcbd0581ea33912e583cd3ccb8bdb9a5b.

Making axis transparent seem to confuse and annoy lot of people,

See #7964 (do not fix it, this will be a 4.0 or 5.0 thing),
the real fix would be to use matplotlib themes.
```
