### PR TITLE
handle datetime in json_clean

### DIFF
--- a/ipykernel/jsonutil.py
+++ b/ipykernel/jsonutil.py
@@ -162,6 +162,8 @@ def json_clean(obj):
         for k,v in iteritems(obj):
             out[unicode_type(k)] = json_clean(v)
         return out
+    if isinstance(obj, datetime):
+        return obj.strftime(ISO8601)
     
     # we don't understand it, it's probably an unserializable object
     raise ValueError("Can't clean for JSON: %r" % obj)

--- a/ipykernel/tests/test_jsonutil.py
+++ b/ipykernel/tests/test_jsonutil.py
@@ -6,6 +6,7 @@
 
 import json
 from base64 import decodestring
+from datetime import datetime
 
 import nose.tools as nt
 
@@ -37,6 +38,7 @@ def test():
              ((x for x in range(3)), [0, 1, 2]),
              (iter([1, 2]), [1, 2]),
              (Int(5), 5),
+             (datetime(1991, 7, 3, 12, 00), "1991-07-03T12:00:00.000000"),
              ]
     
     for val, jval in pairs:


### PR DESCRIPTION
datetime objects are allowed, and serialized to ISO8601

closes ipython/ipywidgets#35