### PR TITLE
require IPython 4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ if 'develop' in sys.argv or any(a.startswith('bdist') for a in sys.argv):
 
 setuptools_args = {}
 install_requires = setuptools_args['install_requires'] = [
-    'ipython',
+    'ipython>=4.0.0.dev0',
     'traitlets',
     'jupyter_client',
 ]


### PR DESCRIPTION
dependency only lists ipython, which will not upgrade ipython past 3.x

Using 4.0dev, since '>=4.0' will reject '4.0b1' as < 4.0, eliminating the usefulness of the current `--pre` behavior. This is temporary, anyway, and should be bumped to 4.0-proper once we ship IPython.