### PR TITLE
depend on IPython 4.0 final

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ if 'develop' in sys.argv or any(a.startswith('bdist') for a in sys.argv):
 
 setuptools_args = {}
 install_requires = setuptools_args['install_requires'] = [
-    'ipython>=4.0.0.dev0',
+    'ipython>=4.0.0',
     'traitlets',
     'jupyter_client',
 ]


### PR DESCRIPTION
This shouldn't be merged yet, since 4.0f doesn't exist. But we should merge and make a new ipykernel release immediately when we cut IPython 4.0.