### PR TITLE
Avoid creating default connection dir if not needed

### DIFF
--- a/ipykernel/kernelapp.py
+++ b/ipykernel/kernelapp.py
@@ -115,9 +115,7 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp,
     # connection info:
     connection_dir = Unicode()
     def _connection_dir_default(self):
-        d = jupyter_runtime_dir()
-        ensure_dir_exists(d, 0o700)
-        return d
+        return jupyter_runtime_dir()
 
     @property
     def abs_connection_file(self):
@@ -201,7 +199,9 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp,
             self.connection_file = filefind(self.connection_file, ['.', self.connection_dir])
         except IOError:
             self.log.debug("Connection file not found: %s", self.connection_file)
-            # This means I own it, so I will clean it up:
+            # This means I own it, and I'll create it in this directory:
+            ensure_dir_exists(os.path.dirname(self.abs_connection_file), 0o700)
+            # Also, I will clean it up:
             atexit.register(self.cleanup_connection_file)
             return
         try:


### PR DESCRIPTION
If a connection file is specified with an absolute path via the '-f'
command line option, ipykernel still makes sure that the default connection
directory exists, even though it is not needed. Instead, simply create the
directory for the path to the connection file that we end up actually
using.

This introduces a slight change in behaviour in that if one specifies a
connection file via the '-f' option and the given directory does not
exist, it will be created instead of an error being generated.

In my case, I am specifying a different path to the connection file because the default path is not writable. While I could (and probably should) change the default path with the corresponding environment variables, it still left me wondering whether the default connection directory should be created even if it is not going to be used.