### PR TITLE
cast buffers to bytes in CannedBytes

### DIFF
--- a/ipykernel/pickleutil.py
+++ b/ipykernel/pickleutil.py
@@ -16,7 +16,7 @@ except ImportError:
 
 from ipython_genutils import py3compat
 from ipython_genutils.importstring import import_item
-from ipython_genutils.py3compat import string_types, iteritems, buffer_to_bytes_py2
+from ipython_genutils.py3compat import string_types, iteritems, buffer_to_bytes, buffer_to_bytes_py2
 
 from . import codeutil  # This registers a hook when it's imported
 
@@ -290,7 +290,8 @@ class CannedArray(CannedObject):
 
 
 class CannedBytes(CannedObject):
-    wrap = bytes
+    wrap = staticmethod(buffer_to_bytes)
+
     def __init__(self, obj):
         self.buffers = [obj]
     

--- a/ipykernel/tests/test_pickleutil.py
+++ b/ipykernel/tests/test_pickleutil.py
@@ -1,4 +1,5 @@
 
+import os
 import pickle
 
 import nose.tools as nt
@@ -59,4 +60,9 @@ def test_closure():
     bar = loads(pfoo)
     nt.assert_equal(foo(), bar())
 
-    
+def test_uncan_bytes_buffer():
+    data = b'data'
+    canned = can(data)
+    canned.buffers = [memoryview(buf) for buf in canned.buffers]
+    out = uncan(canned)
+    nt.assert_equal(out, data)


### PR DESCRIPTION
otherwise memoryviews will come out as '<memoryview...>' on Python 2.

includes regression test

closes ipython/ipyparallel#30