### PR TITLE
Write connection file before writing its location to the log

### DIFF
--- a/ipykernel/kernelapp.py
+++ b/ipykernel/kernelapp.py
@@ -373,8 +373,10 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp,
         self.init_sockets()
         self.init_heartbeat()
         # writing/displaying connection info must be *after* init_sockets/heartbeat
-        self.log_connection_info()
         self.write_connection_file()
+        # Log connection info after writing connection file, so that the connection
+        # file is definitely available at the time someone reads the log.
+        self.log_connection_info()
         self.init_io()
         self.init_signal()
         self.init_kernel()


### PR DESCRIPTION
Is there a particular reason this is the other way around?

When the connection file is first written and then logged, then external programs could monitor the log output and use the connection file (e.g. connect a client) without race condition.