### PR TITLE
Add uncan_dict to uncan_map

### DIFF
--- a/ipykernel/pickleutil.py
+++ b/ipykernel/pickleutil.py
@@ -440,6 +440,7 @@ if buffer is not memoryview:
 
 uncan_map = {
     CannedObject : lambda obj, g: obj.get_object(g),
+    dict : uncan_dict,
 }
 
 # for use in _import_mapping:


### PR DESCRIPTION
This change is a result of investigating this StackOverflow question regarding `parallel.Reference` objects in a list of dictionaries: http://stackoverflow.com/questions/31343529/ipython-parallel-reference-with-map-vs-apply

```python
from IPython import parallel
from IPython.parallel import Client
from IPython.parallel import Reference

rc = Client()
dview = rc.direct_view()
dview.block = True

dview['l'] = [0, 1]
kws = [{'l': Reference('l')}]
def second(kws):
    l = kws['l']
    return l[1]

dview.map(second, kws) # results in TypeError: 'Reference' object does not support indexing
```
When a list of dictionaries is provided as an argument to a parallel map, the `Reference` objects in the `dict`s aren't reached by the `uncan` function. Adding `dict` to the list of uncanners produces the correct behavior:

```python
>>> dview.map(second, kws)
[1]
```