### PR TITLE
Accept matplotlib experimental keywords in InlineBackend

### DIFF
--- a/ipykernel/pylab/backend_inline.py
+++ b/ipykernel/pylab/backend_inline.py
@@ -15,7 +15,7 @@ from IPython.core.display import display
 from .config import InlineBackend
 
 
-def show(close=None):
+def show(close=None, block=None):
     """Show all figures as SVG/PNG payloads sent to the IPython clients.
 
     Parameters
@@ -24,6 +24,10 @@ def show(close=None):
       If true, a ``plt.close('all')`` call is automatically issued after
       sending all the figures. If this is set, the figures will entirely
       removed from the internal list of figures.
+    block : Not used.
+      The `block` parameter is a Matplotlib experimental parameter.
+      We accept it in the function signature for compatibility with other
+      backends.
     """
     if close is None:
         close = InlineBackend.instance().close_figures


### PR DESCRIPTION
closes ipython/ipython#8705
