### PR TITLE
Give abs json file path to nwe Qt console.

### DIFF
--- a/examples/embedding/internal_ipkernel.py
+++ b/examples/embedding/internal_ipkernel.py
@@ -45,7 +45,7 @@ class InternalIPKernel(object):
 
     def new_qt_console(self, evt=None):
         """start a new qtconsole connected to our kernel"""
-        return connect_qtconsole(self.ipkernel.connection_file, profile=self.ipkernel.profile)
+        return connect_qtconsole(self.ipkernel.abs_connection_file, profile=self.ipkernel.profile)
 
     def count(self, evt=None):
         self.namespace['app_counter'] += 1


### PR DESCRIPTION
Sometimes new Qt console process can't find the connection file in its path list. 

Use abs path to replace it.