### PR TITLE
Don't get kernel_protocol_version from IPython

### DIFF
--- a/ipykernel/__init__.py
+++ b/ipykernel/__init__.py
@@ -1,2 +1,2 @@
-from ._version import version_info, __version__
+from ._version import *
 from .connect import *

--- a/ipykernel/_version.py
+++ b/ipykernel/_version.py
@@ -1,2 +1,5 @@
 version_info = (4, 1, 0, 'dev')
 __version__ = '.'.join(map(str, version_info))
+
+kernel_protocol_version_info = (5, 0)
+kernel_protocol_version = '%s.%s' % kernel_protocol_version_info

--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -21,7 +21,6 @@ from zmq.eventloop.zmqstream import ZMQStream
 
 from traitlets.config.configurable import SingletonConfigurable
 from IPython.core.error import StdinNotImplementedError
-from IPython.core import release
 from ipython_genutils import py3compat
 from ipython_genutils.py3compat import unicode_type, string_types
 from ipykernel.jsonutil import json_clean
@@ -31,6 +30,7 @@ from traitlets import (
 
 from jupyter_client.session import Session
 
+from ._version import kernel_protocol_version
 
 class Kernel(SingletonConfigurable):
 
@@ -465,7 +465,7 @@ class Kernel(SingletonConfigurable):
     @property
     def kernel_info(self):
         return {
-            'protocol_version': release.kernel_protocol_version,
+            'protocol_version': kernel_protocol_version,
             'implementation': self.implementation,
             'implementation_version': self.implementation_version,
             'language_info': self.language_info,


### PR DESCRIPTION
It's part of the kernel, not the core package.