### PR TITLE
Fix version attributes import

### DIFF
--- a/ipykernel/__init__.py
+++ b/ipykernel/__init__.py
@@ -1,2 +1,2 @@
-from ._version import *
+from ._version import version_info, __version__, kernel_protocol_version_info, kernel_protocol_version
 from .connect import *


### PR DESCRIPTION
`import *` doesn't import attributes which start with an underscore, so it
won't import `__version__`