### PR TITLE
Adding missing target name when creating a new comm from the front-end

### DIFF
--- a/ipykernel/comm/manager.py
+++ b/ipykernel/comm/manager.py
@@ -106,6 +106,7 @@ class CommManager(LoggingConfigurable):
                     kernel=self.kernel,
                     iopub_socket=self.iopub_socket,
                     primary=False,
+                    target_name=target_name,
         )
         self.register_comm(comm)
         if f is None:


### PR DESCRIPTION
@minrk @jdfreder 
We were missing the `target_name`attribute when creating a Comm on reception of `comm_open` messages.