### PR TITLE
Deprecate ipyparallel-specific code

### DIFF
--- a/ipykernel/codeutil.py
+++ b/ipykernel/codeutil.py
@@ -13,6 +13,9 @@ Reference: A. Tremols, P Cogolo, "Python Cookbook," p 302-305
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
 
+import warnings
+warnings.warn("ipykernel.codeutil is deprecated. It has moved to ipyparallel.serialize", DeprecationWarning)
+
 import sys
 import types
 try:

--- a/ipykernel/datapub.py
+++ b/ipykernel/datapub.py
@@ -1,6 +1,9 @@
 """Publishing native (typically pickled) objects.
 """
 
+import warnings
+warnings.warn("ipykernel.datapub is deprecated. It has moved to ipyparallel.datapub", DeprecationWarning)
+
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
 
@@ -54,5 +57,7 @@ def publish_data(data):
     data : dict
         The data to be published. Think of it as a namespace.
     """
+    warnings.warn("ipykernel.datapub is deprecated. It has moved to ipyparallel.datapub", DeprecationWarning)
+    
     from ipykernel.zmqshell import ZMQInteractiveShell
     ZMQInteractiveShell.instance().data_pub.publish_data(data)

--- a/ipykernel/ipkernel.py
+++ b/ipykernel/ipkernel.py
@@ -124,10 +124,11 @@ class IPythonKernel(KernelBase):
     def init_metadata(self, parent):
         """Initialize metadata.
         
-        Run at the beginning of request handlers.
+        Run at the beginning of each execution request.
         """
         md = super(IPythonKernel, self).init_metadata(parent)
-        # FIXME: remove ipyparallel-specific code
+        # FIXME: remove deprecated ipyparallel-specific code
+        # This is required for ipyparallel < 5.0
         md.update({
             'dependencies_met' : True,
             'engine' : self.ident,
@@ -137,9 +138,10 @@ class IPythonKernel(KernelBase):
     def finish_metadata(self, parent, metadata, reply_content):
         """Finish populating metadata.
         
-        Run after completing a request handler.
+        Run after completing an execution request.
         """
-        # FIXME: remove ipyparallel-specific code:
+        # FIXME: remove deprecated ipyparallel-specific code
+        # This is required by ipyparallel < 5.0
         metadata['status'] = reply_content['status']
         if reply_content['status'] == 'error' and reply_content['ename'] == 'UnmetDependency':
                 metadata['dependencies_met'] = False

--- a/ipykernel/ipkernel.py
+++ b/ipykernel/ipkernel.py
@@ -11,7 +11,6 @@ from traitlets import Instance, Type, Any, List
 
 from .comm import CommManager
 from .kernelbase import Kernel as KernelBase
-from .serialize import serialize_object, unpack_apply_message
 from .zmqshell import ZMQInteractiveShell
 
 
@@ -51,8 +50,6 @@ class IPythonKernel(KernelBase):
         self.shell.displayhook.topic = self._topic('execute_result')
         self.shell.display_pub.session = self.session
         self.shell.display_pub.pub_socket = self.iopub_socket
-        self.shell.data_pub.session = self.session
-        self.shell.data_pub.pub_socket = self.iopub_socket
 
         # TMP - hack while developing
         self.shell._reply_content = None
@@ -315,6 +312,7 @@ class IPythonKernel(KernelBase):
         return r
 
     def do_apply(self, content, bufs, msg_id, reply_metadata):
+        from .serialize import serialize_object, unpack_apply_message
         shell = self.shell
         try:
             working = shell.user_ns

--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -348,7 +348,7 @@ class Kernel(SingletonConfigurable):
     def init_metadata(self, parent):
         """Initialize metadata.
         
-        Run at the beginning of request handlers.
+        Run at the beginning of execution requests.
         """
         return {
             'started': datetime.now(),
@@ -357,7 +357,7 @@ class Kernel(SingletonConfigurable):
     def finish_metadata(self, parent, metadata, reply_content):
         """Finish populating metadata.
         
-        Run after completing a request handler.
+        Run after completing an execution request.
         """
         return metadata
 

--- a/ipykernel/log.py
+++ b/ipykernel/log.py
@@ -2,6 +2,9 @@ from logging import INFO, DEBUG, WARN, ERROR, FATAL
 
 from zmq.log.handlers import PUBHandler
 
+import warnings
+warnings.warn("ipykernel.log is deprecated. It has moved to ipyparallel.engine.log", DeprecationWarning)
+
 class EnginePUBHandler(PUBHandler):
     """A simple PUBHandler subclass that sets root_topic"""
     engine=None

--- a/ipykernel/pickleutil.py
+++ b/ipykernel/pickleutil.py
@@ -4,6 +4,9 @@
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
 
+import warnings
+warnings.warn("ipykernel.pickleutil is deprecated. It has moved to ipyparallel.", DeprecationWarning)
+
 import copy
 import logging
 import sys

--- a/ipykernel/serialize.py
+++ b/ipykernel/serialize.py
@@ -3,6 +3,9 @@
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
 
+import warnings
+warnings.warn("ipykernel.serialize is deprecated. It has moved to ipyparallel.serialize", DeprecationWarning)
+
 try:
     import cPickle
     pickle = cPickle

--- a/ipykernel/zmqshell.py
+++ b/ipykernel/zmqshell.py
@@ -19,6 +19,7 @@ from __future__ import print_function
 import os
 import sys
 import time
+import warnings
 
 from zmq.eventloop import ioloop
 
@@ -46,7 +47,6 @@ from ipython_genutils.py3compat import unicode_type
 from traitlets import Instance, Type, Dict, CBool, CBytes, Any
 from IPython.utils.warn import error
 from ipykernel.displayhook import ZMQShellDisplayHook
-from ipykernel.datapub import ZMQDataPublisher
 from jupyter_client.session import extract_header
 from jupyter_client.session import Session
 
@@ -349,7 +349,7 @@ class ZMQInteractiveShell(InteractiveShell):
 
     displayhook_class = Type(ZMQShellDisplayHook)
     display_pub_class = Type(ZMQDisplayPublisher)
-    data_pub_class = Type(ZMQDataPublisher)
+    data_pub_class = Type('ipykernel.datapub.ZMQDataPublisher')
     kernel = Any()
     parent_header = Any()
 
@@ -402,6 +402,25 @@ class ZMQInteractiveShell(InteractiveShell):
     def init_hooks(self):
         super(ZMQInteractiveShell, self).init_hooks()
         self.set_hook('show_in_pager', page.as_hook(payloadpage.page), 99)
+    
+    def init_data_pub(self):
+        """Delay datapub init until request, for deprecation warnings"""
+        pass
+    
+    @property
+    def data_pub(self):
+        if not hasattr(self, '_data_pub'):
+            warnings.warn("InteractiveShell.data_pub is deprecated outside IPython parallel.", 
+                DeprecationWarning, stacklevel=2)
+            
+            self._data_pub = self.data_pub_class(parent=self)
+            self._data_pub.session = self.display_pub.session
+            self._data_pub.pub_socket = self.display_pub.pub_socket
+        return self._data_pub
+    
+    @data_pub.setter
+    def data_pub(self, pub):
+        self._data_pub = pub
 
     def ask_exit(self):
         """Engage the exit actions."""
@@ -458,7 +477,8 @@ class ZMQInteractiveShell(InteractiveShell):
         self.parent_header = parent
         self.displayhook.set_parent(parent)
         self.display_pub.set_parent(parent)
-        self.data_pub.set_parent(parent)
+        if hasattr(self, '_data_pub'):
+            self.data_pub.set_parent(parent)
         try:
             sys.stdout.set_parent(parent)
         except AttributeError:


### PR DESCRIPTION
- deprecation warnings on serialization, data pub
- Move ipyparallel-specific metadata to methods easier to override in subclasses
- deprecate handling messages not in spec: apply, clear, abort.

related: ipython/ipyparallel#61

closes #17