### PR TITLE
Import hooks to set up inline backend when matplotlib is loaded

### DIFF
--- a/ipykernel/kernelapp.py
+++ b/ipykernel/kernelapp.py
@@ -362,6 +362,15 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp,
                 self.log.debug('ipywidgets package not installed.  Widgets will not be available.')
         # END HARDCODED WIDGETS HACK
 
+    mpl_plots_inline = Bool(True, config=True,
+        help="Make matplotlib send plots to Jupyter frontends by default."
+    )
+
+    def init_mpl_shim(self):
+        if self.mpl_plots_inline:
+            from . import mplshim
+            mplshim.install_import_hook()
+
     @catch_config_error
     def initialize(self, argv=None):
         super(IPKernelApp, self).initialize(argv)
@@ -387,6 +396,7 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp,
             self.init_gui_pylab()
             self.init_extensions()
             self.init_code()
+            self.init_mpl_shim()
         # flush stdout/stderr, so that anything written to these streams during
         # initialization do not get associated with the first execution request
         sys.stdout.flush()

--- a/ipykernel/mplshim.py
+++ b/ipykernel/mplshim.py
@@ -1,0 +1,89 @@
+"""Import hooks to activate our inline backend when matplotlib is loaded
+"""
+
+import imp
+import sys
+
+def set_inline_backend(mpl):
+    from IPython.core.pylabtools import backends, configure_inline_support
+    from .kernelapp import IPKernelApp
+    mpl.interactive(True)
+    mpl.use(backends['inline'])
+    configure_inline_support(IPKernelApp.instance().shell, backends['inline'])
+
+class Py2MPLFinderShim(object):
+    @classmethod
+    def find_module(cls, fullname, path=None):
+        if (fullname != 'matplotlib') or (path is not None):
+            return None
+
+        try:
+            res = imp.find_module('matplotlib')
+        except ImportError:
+            return None
+        else:
+            return Py2MPLLoaderShim(*res)
+
+class Py2MPLLoaderShim(object):
+    def __init__(self, file, pathname, description):
+        self.file = file
+        self.pathname = pathname
+        self.description = description
+
+    def load_module(self, fullname):
+        # fullname should only ever be 'matplotlib' here
+        m = imp.load_module(fullname, self.file, self.pathname, self.description)
+        set_inline_backend(m)
+        return m
+
+try:
+    from importlib.machinery import PathFinder
+except ImportError:
+    # Python 2
+    finder_shim = Py2MPLFinderShim
+else:
+    class Py3MPLFinderShim(PathFinder):
+        # On Python 3.4 and above, find_spec() will be called
+        @classmethod
+        def find_spec(cls, fullname, path=None, target=None):
+            if (fullname != 'matplotlib') or (path is not None):
+                return None
+
+            spec = PathFinder.find_spec(fullname, path=None)
+            if spec is None:
+                return None
+
+            if spec.loader is not None:
+                spec.loader = Py3MPLLoaderShim(spec.loader)
+            return spec
+
+        # On Python 3.3 or below, find_module() will be called
+        @classmethod
+        def find_module(cls, fullname, path=None):
+            print(fullname, path)
+            if (fullname != 'matplotlib') or (path is not None):
+                return None
+
+            real_loader = PathFinder.find_module(fullname, path=None)
+            if real_loader is None:
+                return None
+            return Py3MPLLoaderShim(real_loader)
+
+    class Py3MPLLoaderShim(object):
+        def __init__(self, real_loader):
+            self.real_loader = real_loader
+
+        def load_module(self, fullname):
+            # fullname should only ever be 'matplotlib' here)
+            m = self.real_loader.load_module(fullname)
+            set_inline_backend(m)
+            return m
+
+
+    finder_shim = Py3MPLFinderShim
+
+def install_import_hook():
+    sys.meta_path.insert(0, finder_shim)
+
+def remove_import_hook():
+    sys.meta_path.remove(finder_shim)


### PR DESCRIPTION
Addresses ipython/ipython#6424

We believe that most people using matplotlib from a Jupyter frontend want plots to appear inline. Particularly when introducing new users to Python, we end up telling them to run `%matplotlib inline` with a "don't worry about what this does...", which feels wrong when we're trying to help them understand what they're doing.

This is an attempt to make inline plots the default when you use matplotlib in an IPython kernel. It installs import hooks to watch for matplotlib being imported, and sets up the inline backend when it is. There is a config option (`IPKernelApp.mpl_plots_inline`) to disable this behaviour. Specifying a backend with `%matplotlib` or `%pylab` should also override it.

We've discussed before whether this belongs in IPython or in matplotlib. I don't have a strong preference, but I got the impression that other people preferred it to be in IPython. If we decide to go the other way, I'm happy to help mpl do it.

Ping @mdboom and @tacaswell