### PR TITLE
Don't override default display name with default kernel name

### DIFF
--- a/ipykernel/kernelspec.py
+++ b/ipykernel/kernelspec.py
@@ -81,7 +81,7 @@ def write_kernel_spec(path=None, overrides=None):
     return path
 
 
-def install(kernel_spec_manager=None, user=False, kernel_name=None, display_name=None, prefix=None):
+def install(kernel_spec_manager=None, user=False, kernel_name=KERNEL_NAME, display_name=None, prefix=None):
     """Install the IPython kernelspec for Jupyter
     
     Parameters
@@ -108,9 +108,8 @@ def install(kernel_spec_manager=None, user=False, kernel_name=None, display_name
     """
     if kernel_spec_manager is None:
         kernel_spec_manager = KernelSpecManager()
-    if kernel_name is None:
-        kernel_name = KERNEL_NAME
-    elif display_name is None:
+
+    if (kernel_name != KERNEL_NAME) and (display_name is None):
         # kernel_name is specified and display_name is not
         # default display_name to kernel_name
         display_name = kernel_name


### PR DESCRIPTION
I installed the Python 2 kernel spec with:

```
python2 -m ipykernel.kernelspec --user
```

I noticed that the display name was showing up as 'python2' instead of 'Python 2'.

The name flag in the command line arguments now has an explicit default of `KERNEL_NAME`. This gets passed to install(), which expects None to mean the default. It treats it as a non-default name and sets the display name as well.

This changes the logic of install() so that the display name is not set to the default `KERNEL_NAME`, and it shows up as 'Python 2' again.