### PR TITLE
Use iptest_stdstreams_fileno as a function

### DIFF
--- a/ipykernel/tests/utils.py
+++ b/ipykernel/tests/utils.py
@@ -36,7 +36,10 @@ def start_new_kernel(**kwargs):
 
     Integrates with our output capturing for tests.
     """
-    stdout = getattr(nose, 'iptest_stdstreams_fileno()', open(os.devnull))
+    try:
+        stdout = nose.iptest_stdstreams_fileno()
+    except AttributeError:
+        stdout = open(os.devnull)
     kwargs.update(dict(stdout=stdout, stderr=STDOUT))
     return manager.start_new_kernel(startup_timeout=STARTUP_TIMEOUT, **kwargs)
 

--- a/ipykernel/tests/utils.py
+++ b/ipykernel/tests/utils.py
@@ -36,7 +36,7 @@ def start_new_kernel(**kwargs):
 
     Integrates with our output capturing for tests.
     """
-    stdout = getattr(nose, 'iptest_stdstreams_fileno', open(os.devnull))
+    stdout = getattr(nose, 'iptest_stdstreams_fileno()', open(os.devnull))
     kwargs.update(dict(stdout=stdout, stderr=STDOUT))
     return manager.start_new_kernel(startup_timeout=STARTUP_TIMEOUT, **kwargs)
 


### PR DESCRIPTION
Not sure about this fix, but this fixed an issue I was facing. I got the following error before this fix:

```
  File "/usr/lib/python3.5/site-packages/ipykernel/tests/utils.py", line 41, in start_new_kernel
    return manager.start_new_kernel(startup_timeout=STARTUP_TIMEOUT, **kwargs)
  File "/usr/lib/python3.5/site-packages/jupyter_client/manager.py", line 430, in start_new_kernel
    km.start_kernel(**kwargs)
  File "/usr/lib/python3.5/site-packages/jupyter_client/manager.py", line 244, in start_kernel
    **kw)
  File "/usr/lib/python3.5/site-packages/jupyter_client/manager.py", line 190, in _launch_kernel
    return launch_kernel(kernel_cmd, **kw)
  File "/usr/lib/python3.5/site-packages/jupyter_client/launcher.py", line 123, in launch_kernel
    proc = Popen(cmd, **kwargs)
  File "/usr/lib64/python3.5/subprocess.py", line 914, in __init__
    errread, errwrite) = self._get_handles(stdin, stdout, stderr)
  File "/usr/lib64/python3.5/subprocess.py", line 1400, in _get_handles
    c2pwrite = stdout.fileno()
AttributeError: 'function' object has no attribute 'fileno'
```