### PR TITLE
Don't try to detect virtualenvs when starting a kernel

### DIFF
--- a/ipykernel/zmqshell.py
+++ b/ipykernel/zmqshell.py
@@ -467,14 +467,17 @@ class ZMQInteractiveShell(InteractiveShell):
     def get_parent(self):
         return self.parent_header
 
-    #-------------------------------------------------------------------------
-    # Things related to magics
-    #-------------------------------------------------------------------------
-
     def init_magics(self):
         super(ZMQInteractiveShell, self).init_magics()
         self.register_magics(KernelMagics)
         self.magics_manager.register_alias('ed', 'edit')
+
+    def init_virtualenv(self):
+        # Overridden not to do virtualenv detection, because it's probably
+        # not appropriate in a kernel. To use a kernel in a virtualenv, install
+        # it inside the virtualenv.
+        # http://ipython.readthedocs.org/en/latest/install/kernel_install.html
+        pass
 
 
 InteractiveShellABC.register(ZMQInteractiveShell)


### PR DESCRIPTION
I think automatically adding an active virtualenv to sys.path makes less sense in a kernel than it does in terminal IPython (and I'm less certain than I was even for terminal IPython).

If Jupyter is installed inside a virtualenv, it will still launch the default kernel in there too, but this would mean that you can no longer run e.g. 'jupyter console' with a virtualenv active and find packages from that virtualenv.