### PR TITLE
prevent IOThread from zombifying kernel

### DIFF
--- a/ipykernel/iostream.py
+++ b/ipykernel/iostream.py
@@ -5,6 +5,7 @@
 # Distributed under the terms of the Modified BSD License.
 
 from __future__ import print_function
+import atexit
 import os
 import threading
 import sys
@@ -116,9 +117,14 @@ class IOPubThread(object):
     def start(self):
         """Start the IOPub thread"""
         self.thread.start()
+        # make sure we don't prevent process exit
+        # I'm not sure why setting daemon=True above isn't enough, but it doesn't appear to be.
+        atexit.register(self.stop)
     
     def stop(self):
         """Stop the IOPub thread"""
+        if not self.thread.is_alive():
+            return
         self.io_loop.add_callback(self.io_loop.stop)
         self.thread.join()
     

--- a/ipykernel/tests/test_kernel.py
+++ b/ipykernel/tests/test_kernel.py
@@ -7,6 +7,7 @@
 import io
 import os.path
 import sys
+import time
 
 import nose.tools as nt
 
@@ -242,3 +243,19 @@ def test_complete():
         nt.assert_greater(len(matches), 0)
         for match in matches:
             nt.assert_equal(match[:2], 'a.')
+
+
+def test_shutdown():
+    """Kernel exits after polite shutdown_request"""
+    with new_kernel() as kc:
+        km = kc.parent
+        execute(u'a = 1', kc=kc)
+        wait_for_idle(kc)
+        kc.shutdown()
+        for i in range(100): # 10s timeout
+            if km.is_alive():
+                time.sleep(.1)
+            else:
+                break
+        nt.assert_false(km.is_alive())
+


### PR DESCRIPTION
by stopping the thread explicitly at exit

I'm not sure why or how the daemon thread is preventing exit, but it is.

Previously failing test included.