### PR TITLE
use ctx.term to flush pipe messages

### DIFF
--- a/ipykernel/tests/test_kernel.py
+++ b/ipykernel/tests/test_kernel.py
@@ -75,10 +75,6 @@ def test_subprocess_print():
             "time.sleep(0.5),"
         ])
 
-        expected = '\n'.join([
-            "hello %s" % i for i in range(np)
-        ]) + '\n'
-
         msg_id, content = execute(kc=kc, code=code)
         stdout, stderr = assemble_output(iopub)
         nt.assert_equal(stdout.count("hello"), np, stdout)


### PR DESCRIPTION
tracker method doesn't appear to be reliable for small messages, since zmq does some optimizations to always copy small messages.

This means creating/destroying new context/socket for each subprocess message, which is inefficient but shouldn't be too costly.

I've run the tests with this on Jenkins with the same env that was failing previously. Prior to this patch, the failure occurred pretty consistently around 10% of the time. It's now passed 50 times and counting without failure, so the fix seems to be successful.

closes #98 (hopefully)