### PR TITLE
Message hook in display publisher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 MANIFEST
 build
+cover
 dist
 _build
 docs/man/*.gz

--- a/ipykernel/displayhook.py
+++ b/ipykernel/displayhook.py
@@ -11,10 +11,11 @@ from ipython_genutils.py3compat import builtin_mod
 from traitlets import Instance, Dict, Any
 from jupyter_client.session import extract_header, Session
 
+
 class ZMQDisplayHook(object):
     """A simple displayhook that publishes the object's repr over a ZeroMQ
     socket."""
-    topic=b'execute_result'
+    topic = b'execute_result'
 
     def __init__(self, session, pub_socket):
         self.session = session
@@ -28,8 +29,8 @@ class ZMQDisplayHook(object):
         builtin_mod._ = obj
         sys.stdout.flush()
         sys.stderr.flush()
-        msg = self.session.send(self.pub_socket, u'execute_result', {u'data':repr(obj)},
-                               parent=self.parent_header, ident=self.topic)
+        self.session.send(self.pub_socket, u'execute_result', {u'data':repr(obj)},
+                          parent=self.parent_header, ident=self.topic)
 
     def set_parent(self, parent):
         self.parent_header = extract_header(parent)

--- a/ipykernel/tests/test_kernel.py
+++ b/ipykernel/tests/test_kernel.py
@@ -254,4 +254,3 @@ def test_shutdown():
             else:
                 break
         nt.assert_false(km.is_alive())
-

--- a/ipykernel/tests/test_message_spec.py
+++ b/ipykernel/tests/test_message_spec.py
@@ -15,7 +15,7 @@ import nose.tools as nt
 from nose.plugins.skip import SkipTest
 
 from traitlets import (
-    HasTraits, TraitError, Bool, Unicode, Dict, Integer, List, Enum,
+    HasTraits, TraitError, Bool, Unicode, Dict, Integer, List, Enum
 )
 from ipython_genutils.py3compat import string_types, iteritems
 

--- a/ipykernel/tests/test_serialize.py
+++ b/ipykernel/tests/test_serialize.py
@@ -8,7 +8,6 @@ from collections import namedtuple
 
 import nose.tools as nt
 
-# from unittest import TestCaes
 from ipykernel.serialize import serialize_object, deserialize_object
 from IPython.testing import decorators as dec
 from ipykernel.pickleutil import CannedArray, CannedClass, interactive
@@ -25,12 +24,6 @@ def roundtrip(obj):
     nt.assert_equals(remainder, [])
     return obj2
 
-class C(object):
-    """dummy class for """
-
-    def __init__(self, **kwargs):
-        for key,value in iteritems(kwargs):
-            setattr(self, key, value)
 
 SHAPES = ((100,), (1024,10), (10,8,6,5), (), (0,))
 DTYPES = ('uint8', 'float64', 'int32', [('g', 'float32')], '|S10')

--- a/ipykernel/tests/test_zmq_shell.py
+++ b/ipykernel/tests/test_zmq_shell.py
@@ -1,0 +1,188 @@
+""" Tests for zmq shell / display publisher. """
+
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+import os
+import unittest
+from traitlets import Int
+import zmq
+
+from ipykernel.zmqshell import ZMQDisplayPublisher
+from jupyter_client.session import Session
+
+
+class NoReturnDisplayHook:
+    """
+    A dummy DisplayHook which allows us to monitor
+    the number of times an object is called, but which
+    does *not* return a message when it is called.
+    """
+    call_count = 0
+
+    def __call__(self, obj):
+        self.call_count += 1
+
+
+class ReturnDisplayHook(NoReturnDisplayHook):
+    """
+    A dummy DisplayHook with the same counting ability
+    as its base class, but which also returns the same
+    message when it is called.
+    """
+    def __call__(self, obj):
+        super(ReturnDisplayHook, self).__call__(obj)
+        return obj
+
+
+class CounterSession(Session):
+    """
+    This is a simple subclass to allow us to count
+    the calls made to the session object by the display
+    publisher.
+    """
+    send_count = Int(0)
+
+    def send(self, *args, **kwargs):
+        """
+        A trivial override to just augment the existing call
+        with an increment to the send counter.
+        """
+        self.send_count += 1
+        super(CounterSession, self).send(*args, **kwargs)
+
+
+class ZMQDisplayPublisherTests(unittest.TestCase):
+    """
+    Tests the ZMQDisplayPublisher in zmqshell.py
+    """
+
+    def setUp(self):
+        self.context = zmq.Context()
+        self.socket = self.context.socket(zmq.PUB)
+        self.session = CounterSession()
+
+        self.disp_pub = ZMQDisplayPublisher(
+            session = self.session,
+            pub_socket = self.socket
+        )
+
+    def tearDown(self):
+        """
+        We need to close the socket in order to proceed with the
+        tests.
+        TODO - There is still an open file handler to '/dev/null',
+        presumably created by zmq.
+        """
+        self.disp_pub.clear_output()
+        self.socket.close()
+        self.context.term()
+
+    def test_display_publisher_creation(self):
+        """
+        Since there's no explicit constructor, here we confirm
+        that keyword args get assigned correctly, and override
+        the defaults.
+        """
+        self.assertEqual(self.disp_pub.session, self.session)
+        self.assertEqual(self.disp_pub.pub_socket, self.socket)
+
+    def test_thread_local_default(self):
+        """
+        Confirms that the thread_local attribute is correctly
+        initialised with an empty list for the display hooks
+        """
+        self.assertEqual(self.disp_pub.thread_local.hooks, [])
+
+    def test_publish(self):
+        """
+        Publish should prepare the message and eventually call
+        `send` by default.
+        """
+        data = dict(a = 1)
+
+        self.assertEqual(self.session.send_count, 0)
+        self.disp_pub.publish(data)
+        self.assertEqual(self.session.send_count, 1)
+
+    def test_display_hook_halts_send(self):
+        """
+        If a hook is installed, and on calling the object
+        it does *not* return a message, then we assume that
+        the message has been consumed, and should not be
+        processed (`sent`) in the normal manner.
+        """
+        data = dict(a = 1)
+        hook = NoReturnDisplayHook()
+
+        self.disp_pub.register_hook(hook)
+        self.assertEqual(hook.call_count, 0)
+        self.assertEqual(self.session.send_count, 0)
+
+        self.disp_pub.publish(data)
+
+        self.assertEqual(hook.call_count, 1)
+        self.assertEqual(self.session.send_count, 0)
+
+    def test_display_hook_return_calls_send(self):
+        """
+        If a hook is installed and on calling the object
+        it returns a new message, then we assume that this
+        is just a message transformation, and the message
+        should be sent in the usual manner.
+        """
+        data = dict(a=1)
+        hook = ReturnDisplayHook()
+
+        self.disp_pub.register_hook(hook)
+        self.assertEqual(hook.call_count, 0)
+        self.assertEqual(self.session.send_count, 0)
+
+        self.disp_pub.publish(data)
+
+        self.assertEqual(hook.call_count, 1)
+        self.assertEqual(self.session.send_count, 1)
+
+    def test_unregister_hook(self):
+        """
+        Once a hook is unregistered, it should not be called
+        during `publish`.
+        """
+        data = dict(a = 1)
+        hook = NoReturnDisplayHook()
+
+        self.disp_pub.register_hook(hook)
+        self.assertEqual(hook.call_count, 0)
+        self.assertEqual(self.session.send_count, 0)
+
+        self.disp_pub.publish(data)
+
+        self.assertEqual(hook.call_count, 1)
+        self.assertEqual(self.session.send_count, 0)
+
+        #
+        # After unregistering the `NoReturn` hook, any calls
+        # to publish should *not* got through the DisplayHook,
+        # but should instead hit the usual `session.send` call
+        # at the end.
+        #
+        # As a result, the hook call count should *not* increase,
+        # but the session send count *should* increase.
+        #
+        first = self.disp_pub.unregister_hook(hook)
+        self.disp_pub.publish(data)
+
+        self.assertTrue(first)
+        self.assertEqual(hook.call_count, 1)
+        self.assertEqual(self.session.send_count, 1)
+
+        #
+        # If a hook is not installed, `unregister_hook`
+        # should return false.
+        #
+        second = self.disp_pub.unregister_hook(hook)
+        self.assertFalse(second)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/ipykernel/tests/test_zmq_shell.py
+++ b/ipykernel/tests/test_zmq_shell.py
@@ -13,7 +13,7 @@ from ipykernel.zmqshell import ZMQDisplayPublisher
 from jupyter_client.session import Session
 
 
-class NoReturnDisplayHook:
+class NoReturnDisplayHook(object):
     """
     A dummy DisplayHook which allows us to monitor
     the number of times an object is called, but which

--- a/ipykernel/tests/test_zmq_shell.py
+++ b/ipykernel/tests/test_zmq_shell.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """ Tests for zmq shell / display publisher. """
 
 # Copyright (c) IPython Development Team.

--- a/ipykernel/zmqshell.py
+++ b/ipykernel/zmqshell.py
@@ -161,16 +161,11 @@ class ZMQDisplayPublisher(DisplayPublisher):
                found.
         """
 
-        index = -1
-        for idx, hk in enumerate(self.thread_local.hooks):
-            if hook == hk:
-                index = idx
-
-        if index >= 0:
-            self.thread_local.hooks.remove(index)
+        try:
+            self.thread_local.hooks.remove(hook)
             return True
-
-        return False
+        except ValueError:
+            return False
 
 
 @magics_class

--- a/ipykernel/zmqshell.py
+++ b/ipykernel/zmqshell.py
@@ -66,7 +66,7 @@ class ZMQDisplayPublisher(DisplayPublisher):
 
     # thread_local:
     # An attribute used to ensure the correct output message
-    # is processed. See ipykernel Issue #113 for a discussion.
+    # is processed. See ipykernel Issue 113 for a discussion.
     thread_local = Any()
 
     def set_parent(self, parent):
@@ -143,7 +143,34 @@ class ZMQDisplayPublisher(DisplayPublisher):
         Returning `None` will halt that execution path, and
         session.send will not be called.
         """
+
         self.thread_local.hooks.append(hook)
+
+    def unregister_hook(self, hook):
+        """
+        Un-registers a hook with the thread-local storage.
+
+        Parameters
+        ----------
+        hook: IPython.code.displayhook.DisplayHook
+              An instance of DisplayHook
+
+        Returns
+        -------
+        bool - `True` if the hook was removed, `False` if it wasn't
+               found.
+        """
+
+        index = -1
+        for idx, hk in enumerate(self.thread_local.hooks):
+            if hook == hk:
+                index = idx
+
+        if index >= 0:
+            self.thread_local.hooks.remove(index)
+            return True
+
+        return False
 
 
 @magics_class

--- a/ipykernel/zmqshell.py
+++ b/ipykernel/zmqshell.py
@@ -64,8 +64,9 @@ class ZMQDisplayPublisher(DisplayPublisher):
     parent_header = Dict({})
     topic = CBytes(b'display_data')
 
-    # An attribute in order to ensure the correct output message
-    # is used. See ipykernel Issue #113 for a discussion.
+    # threadlocal:
+    # An attribute used to ensure the correct output message
+    # is processed. See ipykernel Issue #113 for a discussion.
     threadlocal = Any()
 
     def set_parent(self, parent):
@@ -82,8 +83,9 @@ class ZMQDisplayPublisher(DisplayPublisher):
         """ Initialises the threadlocal attribute and
             gives it a 'hooks' attribute.
         """
-        self.threadlocal = local()
-        self.threadlocal.hooks = []
+        loc = local()
+        loc.hooks = []
+        return loc
 
     def publish(self, data, metadata=None, source=None):
         self._flush_streams()

--- a/ipykernel/zmqshell.py
+++ b/ipykernel/zmqshell.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """A ZMQ-based subclass of InteractiveShell.
 
 This code is meant to ease the refactoring of the base InteractiveShell into

--- a/ipykernel/zmqshell.py
+++ b/ipykernel/zmqshell.py
@@ -80,7 +80,7 @@ class ZMQDisplayPublisher(DisplayPublisher):
         sys.stderr.flush()
 
     @default('thread_local')
-    def _threadlocal_default(self):
+    def _thread_local_default(self):
         """ Initialises the threadlocal attribute and
             gives it a 'hooks' attribute.
         """
@@ -144,7 +144,6 @@ class ZMQDisplayPublisher(DisplayPublisher):
         Returning `None` will halt that execution path, and
         session.send will not be called.
         """
-
         self.thread_local.hooks.append(hook)
 
     def unregister_hook(self, hook):
@@ -161,7 +160,6 @@ class ZMQDisplayPublisher(DisplayPublisher):
         bool - `True` if the hook was removed, `False` if it wasn't
                found.
         """
-
         try:
             self.thread_local.hooks.remove(hook)
             return True
@@ -259,7 +257,7 @@ class KernelMagics(Magics):
         Note that %edit is also available through the alias %ed.
         """
 
-        opts,args = self.parse_options(parameter_s,'prn:')
+        opts,args = self.parse_options(parameter_s, 'prn:')
 
         try:
             filename, lineno, _ = CodeMagics._find_edit_target(self.shell, args, opts, last_call)

--- a/ipykernel/zmqshell.py
+++ b/ipykernel/zmqshell.py
@@ -131,12 +131,11 @@ class ZMQDisplayPublisher(DisplayPublisher):
 
         Parameters
         ----------
-        hook : IPython.core.displayhook.DisplayHook
-               An instance of DisplayHook.
+        hook : Any callable object
 
         Returns
         -------
-        None
+        Either a publishable message, or `None`.
 
         The DisplayHook objects must return a message from
         the __call__ method if they still require the
@@ -152,8 +151,8 @@ class ZMQDisplayPublisher(DisplayPublisher):
 
         Parameters
         ----------
-        hook: IPython.code.displayhook.DisplayHook
-              An instance of DisplayHook
+        hook: Any callable object which has previously been
+              registered as a hook.
 
         Returns
         -------

--- a/ipykernel/zmqshell.py
+++ b/ipykernel/zmqshell.py
@@ -20,6 +20,7 @@ import os
 import sys
 import time
 import warnings
+from threading import local
 
 from zmq.eventloop import ioloop
 
@@ -43,7 +44,9 @@ from ipykernel.jsonutil import json_clean, encode_images
 from IPython.utils.process import arg_split
 from ipython_genutils import py3compat
 from ipython_genutils.py3compat import unicode_type
-from traitlets import Instance, Type, Dict, CBool, CBytes, Any
+from traitlets import (
+    Instance, Type, Dict, CBool, CBytes, Any, default
+)
 from IPython.utils.warn import error
 from ipykernel.displayhook import ZMQShellDisplayHook
 from jupyter_client.session import extract_header
@@ -61,6 +64,10 @@ class ZMQDisplayPublisher(DisplayPublisher):
     parent_header = Dict({})
     topic = CBytes(b'display_data')
 
+    # An attribute in order to ensure the correct output message
+    # is used. See ipykernel Issue #113 for a discussion.
+    threadlocal = Any()
+
     def set_parent(self, parent):
         """Set the parent for outbound messages."""
         self.parent_header = extract_header(parent)
@@ -70,6 +77,14 @@ class ZMQDisplayPublisher(DisplayPublisher):
         sys.stdout.flush()
         sys.stderr.flush()
 
+    @default('threadlocal')
+    def _threadlocal_default(self):
+        """ Initialises the threadlocal attribute and
+            gives it a 'hooks' attribute.
+        """
+        self.threadlocal = local()
+        self.threadlocal.hooks = []
+
     def publish(self, data, metadata=None, source=None):
         self._flush_streams()
         if metadata is None:
@@ -78,9 +93,25 @@ class ZMQDisplayPublisher(DisplayPublisher):
         content = {}
         content['data'] = encode_images(data)
         content['metadata'] = metadata
+
+        # Use 2-stage process to send a message,
+        # in order to put it through the transform
+        # hooks before potentially sending.
+        msg = self.session.msg(
+            u'display_data', json_clean(content),
+            parent=self.parent_header
+        )
+
+        # Each transform either returns a new
+        # message or None. If None is returned,
+        # the message has been 'used' and we return.
+        for hook in self.threadlocal.hooks:
+            msg = hook.transform(msg)
+            if msg is None:
+                return
+
         self.session.send(
-            self.pub_socket, u'display_data', json_clean(content),
-            parent=self.parent_header, ident=self.topic,
+            self.pub_socket, msg, ident=self.topic
         )
 
     def clear_output(self, wait=False):
@@ -90,6 +121,11 @@ class ZMQDisplayPublisher(DisplayPublisher):
             self.pub_socket, u'clear_output', content,
             parent=self.parent_header, ident=self.topic,
         )
+
+    def register_hook(self, hook):
+        """ Registers a hook with the thread-local storage """
+        self.threadlocal.hooks.append(hook)
+
 
 @magics_class
 class KernelMagics(Magics):
@@ -398,22 +434,22 @@ class ZMQInteractiveShell(InteractiveShell):
     def init_hooks(self):
         super(ZMQInteractiveShell, self).init_hooks()
         self.set_hook('show_in_pager', page.as_hook(payloadpage.page), 99)
-    
+
     def init_data_pub(self):
         """Delay datapub init until request, for deprecation warnings"""
         pass
-    
+
     @property
     def data_pub(self):
         if not hasattr(self, '_data_pub'):
-            warnings.warn("InteractiveShell.data_pub is deprecated outside IPython parallel.", 
+            warnings.warn("InteractiveShell.data_pub is deprecated outside IPython parallel.",
                 DeprecationWarning, stacklevel=2)
-            
+
             self._data_pub = self.data_pub_class(parent=self)
             self._data_pub.session = self.display_pub.session
             self._data_pub.pub_socket = self.display_pub.pub_socket
         return self._data_pub
-    
+
     @data_pub.setter
     def data_pub(self, pub):
         self._data_pub = pub


### PR DESCRIPTION
This is the initial work for #113.

- [x] unregister hook.
- [x] unit-tests for both return possibilities from hooks.
- [ ] for the rare cases with multiple hooks, install new ones at the front, rather than the back?