### PR TITLE
Cleanup

### DIFF
--- a/ipykernel/__init__.py
+++ b/ipykernel/__init__.py
@@ -1,2 +1,8 @@
-from ._version import version_info, __version__, kernel_protocol_version_info, kernel_protocol_version
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+from ._version import (
+    version_info, __version__,
+    kernel_protocol_version_info, kernel_protocol_version
+)
 from .connect import *

--- a/ipykernel/__init__.py
+++ b/ipykernel/__init__.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
 

--- a/ipykernel/__main__.py
+++ b/ipykernel/__main__.py
@@ -1,3 +1,6 @@
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License.
+
 if __name__ == '__main__':
     from ipykernel import kernelapp as app
     app.launch_new_instance()

--- a/ipykernel/__main__.py
+++ b/ipykernel/__main__.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
 

--- a/ipykernel/_version.py
+++ b/ipykernel/_version.py
@@ -1,3 +1,6 @@
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License.
+
 version_info = (4, 3, 0, 'dev')
 __version__ = '.'.join(map(str, version_info))
 

--- a/ipykernel/_version.py
+++ b/ipykernel/_version.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
 

--- a/ipykernel/codeutil.py
+++ b/ipykernel/codeutil.py
@@ -14,7 +14,10 @@ Reference: A. Tremols, P Cogolo, "Python Cookbook," p 302-305
 # Distributed under the terms of the Modified BSD License.
 
 import warnings
-warnings.warn("ipykernel.codeutil is deprecated. It has moved to ipyparallel.serialize", DeprecationWarning)
+warnings.warn(
+    'ipykernel.codeutil is deprecated. It has moved to ipyparallel.serialize',
+    DeprecationWarning
+)
 
 import sys
 import types

--- a/ipykernel/comm/__init__.py
+++ b/ipykernel/comm/__init__.py
@@ -1,2 +1,5 @@
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License.
+
 from .manager import *
 from .comm import *

--- a/ipykernel/comm/__init__.py
+++ b/ipykernel/comm/__init__.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
 

--- a/ipykernel/comm/comm.py
+++ b/ipykernel/comm/comm.py
@@ -34,15 +34,17 @@ class Comm(LoggingConfigurable):
             return self.kernel.session
 
     target_name = Unicode('comm')
-    target_module = Unicode(None, allow_none=True, help="""requirejs module from
-        which to load comm target.""")
+    target_module = Unicode(
+        None, allow_none=True,
+        help='requirejs module from which to load comm target.'
+    )
 
     topic = Bytes()
     def _topic_default(self):
         return ('comm-%s' % self.comm_id).encode('ascii')
 
-    _open_data = Dict(help="data dict, if any, to be included in comm_open")
-    _close_data = Dict(help="data dict, if any, to be included in comm_close")
+    _open_data = Dict(help='data dict, if any, to be included in comm_open')
+    _close_data = Dict(help='data dict, if any, to be included in comm_close')
 
     _msg_callback = Any()
     _close_callback = Any()
@@ -52,7 +54,7 @@ class Comm(LoggingConfigurable):
     def _comm_id_default(self):
         return uuid.uuid4().hex
 
-    primary = Bool(True, help="Am I the primary or secondary Comm?")
+    primary = Bool(True, help='Am I the primary or secondary Comm?)
 
     def __init__(self, target_name='', data=None, metadata=None, buffers=None, **kwargs):
         if target_name:
@@ -93,8 +95,8 @@ class Comm(LoggingConfigurable):
             data = self._open_data
         comm_manager = getattr(self.kernel, 'comm_manager', None)
         if comm_manager is None:
-            raise RuntimeError("Comms cannot be opened without a kernel "
-                        "and a comm_manager attached to that kernel.")
+            raise RuntimeError('Comms cannot be opened without a kernel '
+                        'and a comm_manager attached to that kernel.')
 
         comm_manager.register_comm(self)
         try:
@@ -151,13 +153,13 @@ class Comm(LoggingConfigurable):
 
     def handle_close(self, msg):
         """Handle a comm_close message"""
-        self.log.debug("handle_close[%s](%s)", self.comm_id, msg)
+        self.log.debug('handle_close[%s](%s)', self.comm_id, msg)
         if self._close_callback:
             self._close_callback(msg)
 
     def handle_msg(self, msg):
         """Handle a comm_msg message"""
-        self.log.debug("handle_msg[%s](%s)", self.comm_id, msg)
+        self.log.debug('handle_msg[%s](%s)', self.comm_id, msg)
         if self._msg_callback:
             if self.shell:
                 self.shell.events.trigger('pre_execute')

--- a/ipykernel/comm/comm.py
+++ b/ipykernel/comm/comm.py
@@ -54,7 +54,7 @@ class Comm(LoggingConfigurable):
     def _comm_id_default(self):
         return uuid.uuid4().hex
 
-    primary = Bool(True, help='Am I the primary or secondary Comm?)
+    primary = Bool(True, help='Am I the primary or secondary Comm?')
 
     def __init__(self, target_name='', data=None, metadata=None, buffers=None, **kwargs):
         if target_name:

--- a/ipykernel/comm/comm.py
+++ b/ipykernel/comm/comm.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Base class for a Comm"""
 
 # Copyright (c) IPython Development Team.

--- a/ipykernel/comm/manager.py
+++ b/ipykernel/comm/manager.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Base class to manage comms"""
 
 # Copyright (c) IPython Development Team.

--- a/ipykernel/comm/manager.py
+++ b/ipykernel/comm/manager.py
@@ -87,8 +87,8 @@ class CommManager(LoggingConfigurable):
         it will log messages if the comm cannot be found.
         """
         if comm_id not in self.comms:
-            self.log.warn("No such comm: %s", comm_id)
-            self.log.debug("Current comms: %s", lazy_keys(self.comms))
+            self.log.warn('No such comm: %s', comm_id)
+            self.log.debug('Current comms: %s', lazy_keys(self.comms))
             return
         # call, because we store weakrefs
         comm = self.comms[comm_id]
@@ -110,20 +110,20 @@ class CommManager(LoggingConfigurable):
         )
         self.register_comm(comm)
         if f is None:
-            self.log.error("No such comm target registered: %s", target_name)
+            self.log.error('No such comm target registered: %s', target_name)
         else:
             try:
                 f(comm, msg)
                 return
             except Exception:
-                self.log.error("Exception opening comm with target: %s", target_name, exc_info=True)
+                self.log.error('Exception opening comm with target: %s', target_name, exc_info=True)
 
         # Failure.
         try:
             comm.close()
         except:
-            self.log.error("""Could not close comm during `comm_open` failure
-                clean-up.  The comm may not have been opened yet.""", exc_info=True)
+            self.log.error('''Could not close comm during `comm_open` failure
+                clean-up.  The comm may not have been opened yet.''', exc_info=True)
 
     def comm_msg(self, stream, ident, msg):
         """Handler for comm_msg messages"""
@@ -136,7 +136,7 @@ class CommManager(LoggingConfigurable):
         try:
             comm.handle_msg(msg)
         except Exception:
-            self.log.error("Exception in comm_msg for %s", comm_id, exc_info=True)
+            self.log.error('Exception in comm_msg for %s', comm_id, exc_info=True)
 
     def comm_close(self, stream, ident, msg):
         """Handler for comm_close messages"""
@@ -145,14 +145,14 @@ class CommManager(LoggingConfigurable):
         comm = self.get_comm(comm_id)
         if comm is None:
             # no such comm
-            self.log.debug("No such comm to close: %s", comm_id)
+            self.log.debug('No such comm to close: %s', comm_id)
             return
         del self.comms[comm_id]
 
         try:
             comm.handle_close(msg)
         except Exception:
-            self.log.error("Exception handling comm_close for %s", comm_id, exc_info=True)
+            self.log.error('Exception handling comm_close for %s', comm_id, exc_info=True)
 
 
 __all__ = ['CommManager']

--- a/ipykernel/connect.py
+++ b/ipykernel/connect.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Connection file-related utilities for the kernel
 """
 

--- a/ipykernel/connect.py
+++ b/ipykernel/connect.py
@@ -1,5 +1,6 @@
 """Connection file-related utilities for the kernel
 """
+
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
 
@@ -19,7 +20,6 @@ import jupyter_client
 from jupyter_client import write_connection_file
 
 
-
 def get_connection_file(app=None):
     """Return the path to the connection file of an app
 
@@ -31,7 +31,7 @@ def get_connection_file(app=None):
     if app is None:
         from ipykernel.kernelapp import IPKernelApp
         if not IPKernelApp.initialized():
-            raise RuntimeError("app not specified, and not in a running Kernel")
+            raise RuntimeError('app not specified, and not in a running Kernel')
 
         app = IPKernelApp.instance()
     return filefind(app.connection_file, ['.', app.connection_dir])
@@ -39,7 +39,7 @@ def get_connection_file(app=None):
 
 def find_connection_file(filename='kernel-*.json', profile=None):
     """DEPRECATED: find a connection file, and return its absolute path.
-    
+
     THIS FUNCION IS DEPRECATED. Use juptyer_client.find_connection_file instead.
 
     Parameters
@@ -54,10 +54,13 @@ def find_connection_file(filename='kernel-*.json', profile=None):
     -------
     str : The absolute path of the connection file.
     """
-    
+
     import warnings
-    warnings.warn("""ipykernel.find_connection_file is deprecated, use jupyter_client.find_connection_file""",
-        DeprecationWarning, stacklevel=2)
+    warnings.warn(
+        'ipykernel.find_connection_file is deprecated,'
+        ' use jupyter_client.find_connection_file',
+        DeprecationWarning, stacklevel=2
+    )
     from IPython.core.application import BaseIPythonApplication as IPApp
     try:
         # quick check for absolute path, before going through logic
@@ -72,18 +75,27 @@ def find_connection_file(filename='kernel-*.json', profile=None):
             profile_dir = app.profile_dir
         else:
             # not running in IPython, use default profile
-            profile_dir = ProfileDir.find_profile_dir_by_name(get_ipython_dir(), 'default')
+            profile_dir = ProfileDir.find_profile_dir_by_name(
+                get_ipython_dir(),
+                'default'
+            )
     else:
         # find profiledir by profile name:
-        profile_dir = ProfileDir.find_profile_dir_by_name(get_ipython_dir(), profile)
+        profile_dir = ProfileDir.find_profile_dir_by_name(
+            get_ipython_dir(),
+            profile
+        )
     security_dir = profile_dir.security_dir
-    
-    return jupyter_client.find_connection_file(filename, path=['.', security_dir])
+
+    return jupyter_client.find_connection_file(
+        filename,
+        path=['.', security_dir]
+    )
 
 
 def _find_connection_file(connection_file, profile=None):
     """Return the absolute path for a connection file
-    
+
     - If nothing specified, return current Kernel's connection file
     - If profile specified, show deprecation warning about finding connection files in profiles
     - Otherwise, call jupyter_client.find_connection_file
@@ -95,7 +107,7 @@ def _find_connection_file(connection_file, profile=None):
         # connection file specified, allow shortnames:
         if profile is not None:
             warnings.warn(
-                "Finding connection file by profile is deprecated.",
+                'Finding connection file by profile is deprecated.',
                 DeprecationWarning, stacklevel=3,
             )
             return find_connection_file(connection_file, profile=profile)
@@ -165,8 +177,8 @@ def connect_qtconsole(connection_file=None, argv=None, profile=None):
     cf = _find_connection_file(connection_file, profile)
 
     cmd = ';'.join([
-        "from IPython.qt.console import qtconsoleapp",
-        "qtconsoleapp.main()"
+        'from IPython.qt.console import qtconsoleapp',
+        'qtconsoleapp.main()'
     ])
 
     return Popen([sys.executable, '-c', cmd, '--existing', cf] + argv,

--- a/ipykernel/datapub.py
+++ b/ipykernel/datapub.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Publishing native (typically pickled) objects.
 """
 

--- a/ipykernel/datapub.py
+++ b/ipykernel/datapub.py
@@ -2,7 +2,10 @@
 """
 
 import warnings
-warnings.warn("ipykernel.datapub is deprecated. It has moved to ipyparallel.datapub", DeprecationWarning)
+warnings.warn(
+    'ipykernel.datapub is deprecated. It has moved to ipyparallel.datapub',
+    DeprecationWarning
+)
 
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
@@ -56,7 +59,10 @@ def publish_data(data):
     data : dict
         The data to be published. Think of it as a namespace.
     """
-    warnings.warn("ipykernel.datapub is deprecated. It has moved to ipyparallel.datapub", DeprecationWarning)
-    
+    warnings.warn(
+        'ipykernel.datapub is deprecated. It has moved to ipyparallel.datapub',
+        DeprecationWarning
+    )
+
     from ipykernel.zmqshell import ZMQInteractiveShell
     ZMQInteractiveShell.instance().data_pub.publish_data(data)

--- a/ipykernel/displayhook.py
+++ b/ipykernel/displayhook.py
@@ -29,8 +29,10 @@ class ZMQDisplayHook(object):
         builtin_mod._ = obj
         sys.stdout.flush()
         sys.stderr.flush()
-        self.session.send(self.pub_socket, u'execute_result', {u'data':repr(obj)},
-                          parent=self.parent_header, ident=self.topic)
+        self.session.send(
+            self.pub_socket, u'execute_result', {u'data':repr(obj)},
+            parent=self.parent_header, ident=self.topic
+        )
 
     def set_parent(self, parent):
         self.parent_header = extract_header(parent)

--- a/ipykernel/displayhook.py
+++ b/ipykernel/displayhook.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Replacements for sys.displayhook that publish over ZMQ."""
 
 # Copyright (c) IPython Development Team.

--- a/ipykernel/embed.py
+++ b/ipykernel/embed.py
@@ -1,5 +1,9 @@
 """Simple function for embedding an IPython kernel
 """
+
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License.
+
 #-----------------------------------------------------------------------------
 # Imports
 #-----------------------------------------------------------------------------

--- a/ipykernel/embed.py
+++ b/ipykernel/embed.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Simple function for embedding an IPython kernel
 """
 

--- a/ipykernel/eventloops.py
+++ b/ipykernel/eventloops.py
@@ -190,11 +190,11 @@ def loop_cocoa(kernel):
     import matplotlib
     if matplotlib.__version__ < '1.1.0':
         kernel.log.warn(
-        "MacOSX backend in matplotlib %s doesn't have a Timer, "
-        "falling back on Tk for CFRunLoop integration.  Note that "
-        "even this won't work if Tk is linked against X11 instead of "
-        "Cocoa (e.g. EPD).  To use the MacOSX backend in the kernel, "
-        "you must use matplotlib >= 1.1.0, or a native libtk."
+        'MacOSX backend in matplotlib %s doesn\'t have a Timer, '
+        'falling back on Tk for CFRunLoop integration.  Note that '
+        'even this won\'t work if Tk is linked against X11 instead of '
+        'Cocoa (e.g. EPD).  To use the MacOSX backend in the kernel, '
+        'you must use matplotlib >= 1.1.0, or a native libtk.'
         )
         return loop_tk(kernel)
 
@@ -207,7 +207,7 @@ def loop_cocoa(kernel):
     def handle_int(etype, value, tb):
         """don't let KeyboardInterrupts look like crashes"""
         if etype is KeyboardInterrupt:
-            io.raw_print("KeyboardInterrupt caught in CFRunLoop")
+            io.raw_print('KeyboardInterrupt caught in CFRunLoop')
         else:
             real_excepthook(etype, value, tb)
 
@@ -248,26 +248,27 @@ def loop_cocoa(kernel):
                 raise
         except KeyboardInterrupt:
             # Ctrl-C shouldn't crash the kernel
-            io.raw_print("KeyboardInterrupt caught in kernel")
+            io.raw_print('KeyboardInterrupt caught in kernel')
         finally:
             # ensure excepthook is restored
             sys.excepthook = real_excepthook
 
 
-
 def enable_gui(gui, kernel=None):
     """Enable integration with a given GUI"""
     if gui not in loop_map:
-        e = "Invalid GUI request %r, valid ones are:%s" % (gui, loop_map.keys())
+        e = 'Invalid GUI request %r, valid ones are:%s' % (gui, loop_map.keys())
         raise ValueError(e)
     if kernel is None:
         if Application.initialized():
             kernel = getattr(Application.instance(), 'kernel', None)
         if kernel is None:
-            raise RuntimeError("You didn't specify a kernel,"
-                " and no IPython Application with a kernel appears to be running."
+            raise RuntimeError(
+                'You didn\'t specify a kernel,'
+                ' and no IPython Application with a'
+                ' kernel appears to be running.'
             )
     loop = loop_map[gui]
     if loop and kernel.eventloop is not None and kernel.eventloop is not loop:
-        raise RuntimeError("Cannot activate multiple GUI eventloops")
+        raise RuntimeError('Cannot activate multiple GUI eventloops')
     kernel.eventloop = loop

--- a/ipykernel/heartbeat.py
+++ b/ipykernel/heartbeat.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """The client and server for a basic ping-pong style heartbeat.
 """
 

--- a/ipykernel/heartbeat.py
+++ b/ipykernel/heartbeat.py
@@ -1,12 +1,8 @@
 """The client and server for a basic ping-pong style heartbeat.
 """
 
-#-----------------------------------------------------------------------------
-#  Copyright (C) 2008-2011  The IPython Development Team
-#
-#  Distributed under the terms of the BSD License.  The full license is in
-#  the file COPYING, distributed as part of this software.
-#-----------------------------------------------------------------------------
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License.
 
 #-----------------------------------------------------------------------------
 # Imports
@@ -47,7 +43,7 @@ class Heartbeat(Thread):
                 while os.path.exists("%s-%s" % (self.ip, self.port)):
                     self.port = self.port + 1
             else:
-                raise ValueError("Unrecognized zmq transport: %s" % addr[0])
+                raise ValueError('Unrecognized zmq transport: %s' % addr[0])
         self.addr = (self.ip, self.port)
         self.daemon = True
 

--- a/ipykernel/inprocess/__init__.py
+++ b/ipykernel/inprocess/__init__.py
@@ -1,3 +1,6 @@
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License.
+
 from .channels import (
     InProcessChannel,
     InProcessHBChannel,

--- a/ipykernel/inprocess/__init__.py
+++ b/ipykernel/inprocess/__init__.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
 

--- a/ipykernel/inprocess/blocking.py
+++ b/ipykernel/inprocess/blocking.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """ Implements a fully blocking kernel client.
 
 Useful for test suites and blocking terminal interfaces.

--- a/ipykernel/inprocess/channels.py
+++ b/ipykernel/inprocess/channels.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """A kernel client for in-process kernels."""
 
 # Copyright (c) IPython Development Team.

--- a/ipykernel/inprocess/client.py
+++ b/ipykernel/inprocess/client.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """A client for in-process kernels."""
 
 #-----------------------------------------------------------------------------
@@ -50,11 +51,11 @@ class InProcessKernelClient(KernelClient):
     #--------------------------------------------------------------------------
     # Channel management methods
     #--------------------------------------------------------------------------
-    
+
     def _blocking_class_default(self):
         from .blocking import BlockingInProcessKernelClient
         return BlockingInProcessKernelClient
-    
+
     def get_connection_info(self):
         d = super(InProcessKernelClient, self).get_connection_info()
         d['kernel'] = self.kernel

--- a/ipykernel/inprocess/ipkernel.py
+++ b/ipykernel/inprocess/ipkernel.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """An in-process kernel"""
 
 # Copyright (c) IPython Development Team.

--- a/ipykernel/inprocess/ipkernel.py
+++ b/ipykernel/inprocess/ipkernel.py
@@ -56,17 +56,20 @@ class InProcessKernel(IPythonKernel):
         thread = IOPubThread(self._underlying_iopub_socket)
         thread.start()
         return thread
-    
+
     iopub_socket = Instance(BackgroundSocket)
     def _iopub_socket_default(self):
         return self.iopub_thread.background_socket
-    
+
     stdin_socket = Instance(DummySocket, ())
 
     def __init__(self, **traits):
         super(InProcessKernel, self).__init__(**traits)
 
-        self._underlying_iopub_socket.on_trait_change(self._io_dispatch, 'message_sent')
+        self._underlying_iopub_socket.on_trait_change(
+            self._io_dispatch,
+            'message_sent'
+        )
         self.shell.kernel = self
 
     def execute_request(self, stream, ident, parent):

--- a/ipykernel/inprocess/manager.py
+++ b/ipykernel/inprocess/manager.py
@@ -23,7 +23,8 @@ class InProcessKernelManager(KernelManager):
     kernel = Instance('ipykernel.inprocess.ipkernel.InProcessKernel',
                       allow_none=True)
     # the client class for KM.client() shortcut
-    client_class = DottedObjectName('ipykernel.inprocess.BlockingInProcessKernelClient')
+    name = 'ipykernel.inprocess.BlockingInProcessKernelClient'
+    client_class = DottedObjectName(name)
     def _blocking_class_default(self):
         from .blocking import BlockingInProcessKernelClient
         return BlockingInProcessKernelClient
@@ -55,10 +56,10 @@ class InProcessKernelManager(KernelManager):
         self.kernel = None
 
     def interrupt_kernel(self):
-        raise NotImplementedError("Cannot interrupt in-process kernel.")
+        raise NotImplementedError('Cannot interrupt in-process kernel.')
 
     def signal_kernel(self, signum):
-        raise NotImplementedError("Cannot signal in-process kernel.")
+        raise NotImplementedError('Cannot signal in-process kernel.')
 
     def is_alive(self):
         return self.kernel is not None

--- a/ipykernel/inprocess/manager.py
+++ b/ipykernel/inprocess/manager.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """A kernel manager for in-process kernels."""
 
 # Copyright (c) IPython Development Team.

--- a/ipykernel/inprocess/socket.py
+++ b/ipykernel/inprocess/socket.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """ Defines a dummy socket implementing (part of) the zmq.Socket interface. """
 
 # Copyright (c) IPython Development Team.

--- a/ipykernel/inprocess/socket.py
+++ b/ipykernel/inprocess/socket.py
@@ -20,7 +20,7 @@ from ipython_genutils.py3compat import with_metaclass
 #-----------------------------------------------------------------------------
 
 class SocketABC(with_metaclass(abc.ABCMeta, object)):
-    
+
     @abc.abstractmethod
     def recv_multipart(self, flags=0, copy=True, track=False):
         raise NotImplementedError
@@ -28,10 +28,10 @@ class SocketABC(with_metaclass(abc.ABCMeta, object)):
     @abc.abstractmethod
     def send_multipart(self, msg_parts, flags=0, copy=True, track=False):
         raise NotImplementedError
-    
+
     @classmethod
     def register(cls, other_cls):
-        warnings.warn("SocketABC is deprecated.", DeprecationWarning)
+        warnings.warn('SocketABC is deprecated.', DeprecationWarning)
         abc.ABCMeta.register(cls, other_cls)
 
 #-----------------------------------------------------------------------------

--- a/ipykernel/inprocess/tests/test_kernel.py
+++ b/ipykernel/inprocess/tests/test_kernel.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
 

--- a/ipykernel/inprocess/tests/test_kernelmanager.py
+++ b/ipykernel/inprocess/tests/test_kernelmanager.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
 

--- a/ipykernel/iostream.py
+++ b/ipykernel/iostream.py
@@ -72,7 +72,7 @@ class IOPubThread(object):
         try:
             self._pipe_port = pipe_in.bind_to_random_port('tcp://127.0.0.1')
         except zmq.ZMQError as e:
-            warn('Couldn't bind IOPub Pipe to 127.0.0.1: %s' % e +
+            warn('Couldn\'t bind IOPub Pipe to 127.0.0.1: %s' % e +
                 '\nsubprocess output will be unavailable.'
             )
             self._pipe_flag = False

--- a/ipykernel/iostream.py
+++ b/ipykernel/iostream.py
@@ -37,9 +37,9 @@ CHILD = 1
 
 class IOPubThread(object):
     """An object for sending IOPub messages in a background thread
-    
+
     prevents a blocking main thread
-    
+
     IOPubThread(pub_socket).background_socket is a Socket-API-providing object
     whose IO is always run in a thread.
     """
@@ -70,23 +70,23 @@ class IOPubThread(object):
         pipe_in = ctx.socket(zmq.PULL)
         pipe_in.linger = 0
         try:
-            self._pipe_port = pipe_in.bind_to_random_port("tcp://127.0.0.1")
+            self._pipe_port = pipe_in.bind_to_random_port('tcp://127.0.0.1')
         except zmq.ZMQError as e:
-            warn("Couldn't bind IOPub Pipe to 127.0.0.1: %s" % e +
-                "\nsubprocess output will be unavailable."
+            warn('Couldn't bind IOPub Pipe to 127.0.0.1: %s' % e +
+                '\nsubprocess output will be unavailable.'
             )
             self._pipe_flag = False
             pipe_in.close()
             return
         self._pipe_in = ZMQStream(pipe_in, self.io_loop)
         self._pipe_in.on_recv(self._handle_pipe_msg)
-    
+
     def _handle_pipe_msg(self, msg):
         """handle a pipe message from a subprocess"""
         if not self._pipe_flag or not self._is_master_process():
             return
         if msg[0] != self._pipe_uuid:
-            print("Bad pipe message: %s", msg, file=sys.__stderr__)
+            print('Bad pipe message: %s', msg, file=sys.__stderr__)
             return
         self.send_multipart(msg[1:])
 
@@ -95,7 +95,7 @@ class IOPubThread(object):
         ctx = zmq.Context()
         pipe_out = ctx.socket(zmq.PUSH)
         pipe_out.linger = 3000 # 3s timeout for pipe_out sends before discarding the message
-        pipe_out.connect("tcp://127.0.0.1:%i" % self._pipe_port)
+        pipe_out.connect('tcp://127.0.0.1:%i' % self._pipe_port)
         return ctx, pipe_out
 
     def _is_master_process(self):
@@ -107,21 +107,22 @@ class IOPubThread(object):
             return MASTER
         else:
             return CHILD
-    
+
     def start(self):
         """Start the IOPub thread"""
         self.thread.start()
         # make sure we don't prevent process exit
-        # I'm not sure why setting daemon=True above isn't enough, but it doesn't appear to be.
+        # I'm not sure why setting daemon=True above
+        # isn't enough, but it doesn't appear to be.
         atexit.register(self.stop)
-    
+
     def stop(self):
         """Stop the IOPub thread"""
         if not self.thread.is_alive():
             return
         self.io_loop.add_callback(self.io_loop.stop)
         self.thread.join()
-    
+
     def close(self):
         self.socket.close()
         self.socket = None
@@ -129,18 +130,20 @@ class IOPubThread(object):
     @property
     def closed(self):
         return self.socket is None
-    
+
     def send_multipart(self, *args, **kwargs):
         """send_multipart schedules actual zmq send in my thread.
-        
+
         If my thread isn't running (e.g. forked process), send immediately.
         """
 
         if self.thread.is_alive():
-            self.io_loop.add_callback(lambda : self._really_send(*args, **kwargs))
+            self.io_loop.add_callback(
+                lambda : self._really_send(*args, **kwargs)
+            )
         else:
             self._really_send(*args, **kwargs)
-    
+
     def _really_send(self, msg, *args, **kwargs):
         """The callback that actually sends messages"""
         mp_mode = self._check_mp_mode()
@@ -151,7 +154,8 @@ class IOPubThread(object):
         else:
             # we are a child, pipe to master
             # new context/socket for every pipe-out
-            # since forks don't teardown politely, use ctx.term to ensure send has completed
+            # since forks don't teardown politely,
+            # use ctx.term to ensure send has completed
             ctx, pipe_out = self._setup_pipe_out()
             pipe_out.send_multipart([self._pipe_uuid] + msg, *args, **kwargs)
             pipe_out.close()
@@ -161,29 +165,35 @@ class IOPubThread(object):
 class BackgroundSocket(object):
     """Wrapper around IOPub thread that provides zmq send[_multipart]"""
     io_thread = None
-    
+
     def __init__(self, io_thread):
         self.io_thread = io_thread
-    
+
     def __getattr__(self, attr):
         """Wrap socket attr access for backward-compatibility"""
         if attr.startswith('__') and attr.endswith('__'):
             # don't wrap magic methods
             super(BackgroundSocket, self).__getattr__(attr)
         if hasattr(self.io_thread.socket, attr):
-            warnings.warn("Accessing zmq Socket attribute %s on BackgroundSocket" % attr,
-                DeprecationWarning, stacklevel=2)
+            warnings.warn(
+                'Accessing zmq Socket attribute %s on BackgroundSocket' % attr,
+                DeprecationWarning,
+                stacklevel = 2
+            )
             return getattr(self.io_thread.socket, attr)
         super(BackgroundSocket, self).__getattr__(attr)
-    
+
     def __setattr__(self, attr, value):
         if attr == 'io_thread' or (attr.startswith('__' and attr.endswith('__'))):
             super(BackgroundSocket, self).__setattr__(attr, value)
         else:
-            warnings.warn("Setting zmq Socket attribute %s on BackgroundSocket" % attr,
-                DeprecationWarning, stacklevel=2)
+            warnings.warn(
+                'Setting zmq Socket attribute %s on BackgroundSocket' % attr,
+                DeprecationWarning,
+                stacklevel = 2
+            )
             setattr(self.io_thread.socket, attr, value)
-    
+
     def send(self, msg, *args, **kwargs):
         return self.send_multipart([msg], *args, **kwargs)
 
@@ -194,7 +204,7 @@ class BackgroundSocket(object):
 
 class OutStream(object):
     """A file like object that publishes the stream to a 0MQ PUB socket.
-    
+
     Output is handed off to an IO Thread
     """
 
@@ -204,14 +214,16 @@ class OutStream(object):
 
     def __init__(self, session, pub_thread, name, pipe=None):
         if pipe is not None:
-            warnings.warn("pipe argument to OutStream is deprecated and ignored",
-                DeprecationWarning)
+            warnings.warn(
+                'pipe argument to OutStream is deprecated and ignored',
+                DeprecationWarning
+            )
         self.encoding = 'UTF-8'
         self.session = session
         if not isinstance(pub_thread, IOPubThread):
             # Backward-compat: given socket, not thread. Wrap in a thread.
-            warnings.warn("OutStream should be created with IOPubThread, not %r" % pub_thread,
-                DeprecationWarning, stacklevel=2)
+            w = 'OutStream should be created with IOPubThread, not %r'
+            warnings.warn(w % pub_thread, DeprecationWarning, stacklevel = 2)
             pub_thread = IOPubThread(pub_thread)
             pub_thread.start()
         self.pub_thread = pub_thread
@@ -239,7 +251,7 @@ class OutStream(object):
 
     def _schedule_flush(self):
         """schedule a flush in the IO thread
-        
+
         call this on write, to indicate that flush should be called soon.
         """
         with self._flush_lock:
@@ -247,9 +259,10 @@ class OutStream(object):
                 return
             # None indicates there's no flush scheduled.
             # Use a non-None placeholder to indicate that a flush is scheduled
-            # to avoid races while we wait for _schedule_in_thread below to fire in the io thread.
+            # to avoid races while we wait for _schedule_in_thread
+            # below to fire in the io thread.
             self._flush_timeout = 'placeholder'
-        
+
         # add_timeout has to be handed to the io thread with add_callback
         def _schedule_in_thread():
             self._flush_timeout = self._io_loop.call_later(self.flush_interval, self._flush)
@@ -257,7 +270,7 @@ class OutStream(object):
 
     def flush(self):
         """trigger actual zmq send
-        
+
         send will happen in the background thread
         """
         if self.pub_thread.thread.is_alive():
@@ -268,10 +281,10 @@ class OutStream(object):
             evt.wait()
         else:
             self._flush()
-    
+
     def _flush(self):
         """This is where the actual send happens.
-        
+
         _flush should generally be called in the IO thread,
         unless the thread has been destroyed (e.g. forked subprocess).
         """
@@ -283,10 +296,12 @@ class OutStream(object):
             # since pub_thread is itself fork-safe.
             # There should be a better way to do this.
             self.session.pid = os.getpid()
-            content = {u'name':self.name, u'text':data}
-            self.session.send(self.pub_thread, u'stream', content=content,
-                parent=self.parent_header, ident=self.topic)
-    
+            content = {u'name': self.name, u'text': data}
+            self.session.send(
+                self.pub_thread, u'stream', content=content,
+                parent=self.parent_header, ident=self.topic
+            )
+
     def isatty(self):
         return False
 
@@ -303,7 +318,7 @@ class OutStream(object):
         raise IOError('Read not supported on a write only stream.')
 
     def fileno(self):
-        raise UnsupportedOperation("IOStream has no fileno.")
+        raise UnsupportedOperation('IOStream has no fileno.')
 
     def write(self, string):
         if self.pub_thread is None:

--- a/ipykernel/ipkernel.py
+++ b/ipykernel/ipkernel.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """The IPython kernel implementation"""
 
 # Copyright (c) IPython Development Team.

--- a/ipykernel/ipkernel.py
+++ b/ipykernel/ipkernel.py
@@ -1,5 +1,8 @@
 """The IPython kernel implementation"""
 
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License.
+
 import getpass
 import sys
 import traceback
@@ -58,38 +61,38 @@ class IPythonKernel(KernelBase):
                                         kernel=self)
 
         self.shell.configurables.append(self.comm_manager)
-        comm_msg_types = [ 'comm_open', 'comm_msg', 'comm_close' ]
+        comm_msg_types = ['comm_open', 'comm_msg', 'comm_close']
         for msg_type in comm_msg_types:
             self.shell_handlers[msg_type] = getattr(self.comm_manager, msg_type)
 
     help_links = List([
         {
-            'text': "Python",
-            'url': "http://docs.python.org/%i.%i" % sys.version_info[:2],
+            'text': 'Python',
+            'url': 'http://docs.python.org/%i.%i' % sys.version_info[:2],
         },
         {
-            'text': "IPython",
-            'url': "http://ipython.org/documentation.html",
+            'text': 'IPython',
+            'url': 'http://ipython.org/documentation.html',
         },
         {
-            'text': "NumPy",
-            'url': "http://docs.scipy.org/doc/numpy/reference/",
+            'text': 'NumPy',
+            'url': 'http://docs.scipy.org/doc/numpy/reference/',
         },
         {
-            'text': "SciPy",
-            'url': "http://docs.scipy.org/doc/scipy/reference/",
+            'text': 'SciPy',
+            'url': 'http://docs.scipy.org/doc/scipy/reference/',
         },
         {
-            'text': "Matplotlib",
-            'url': "http://matplotlib.org/contents.html",
+            'text': 'Matplotlib',
+            'url': 'http://matplotlib.org/contents.html',
         },
         {
-            'text': "SymPy",
-            'url': "http://docs.sympy.org/latest/index.html",
+            'text': 'SymPy',
+            'url': 'http://docs.sympy.org/latest/index.html',
         },
         {
-            'text': "pandas",
-            'url': "http://pandas.pydata.org/pandas-docs/stable/",
+            'text': 'pandas',
+            'url': 'http://pandas.pydata.org/pandas-docs/stable/',
         },
     ])
 
@@ -123,7 +126,7 @@ class IPythonKernel(KernelBase):
 
     def init_metadata(self, parent):
         """Initialize metadata.
-        
+
         Run at the beginning of each execution request.
         """
         md = super(IPythonKernel, self).init_metadata(parent)
@@ -134,10 +137,10 @@ class IPythonKernel(KernelBase):
             'engine' : self.ident,
         })
         return md
-    
+
     def finish_metadata(self, parent, metadata, reply_content):
         """Finish populating metadata.
-        
+
         Run after completing an execution request.
         """
         # FIXME: remove deprecated ipyparallel-specific code
@@ -229,8 +232,10 @@ class IPythonKernel(KernelBase):
             reply_content['engine_info'] = e_info
 
         if 'traceback' in reply_content:
-            self.log.info("Exception in execute request:\n%s", '\n'.join(reply_content['traceback']))
-
+            self.log.info(
+                'Exception in execute request:\n%s',
+                '\n'.join(reply_content['traceback'])
+            )
 
         # At this point, we can tell whether the main code execution succeeded
         # or not.  If it did, we proceed to evaluate user_expressions
@@ -243,9 +248,9 @@ class IPythonKernel(KernelBase):
 
         # Payloads should be retrieved regardless of outcome, so we can both
         # recover partial output (that could have been generated early in a
-        # block, before an error) and clear the payload system always.
+        # block, before an error) and always clear the payload system.
         reply_content[u'payload'] = shell.payload_manager.read_payload()
-        # Be agressive about clearing the payload because we don't want
+        # Be aggressive about clearing the payload because we don't want
         # it to sit in memory until the next execute_request comes in.
         shell.payload_manager.clear_payload()
 
@@ -286,17 +291,21 @@ class IPythonKernel(KernelBase):
 
     def do_history(self, hist_access_type, output, raw, session=None, start=None,
                    stop=None, n=None, pattern=None, unique=False):
+        hist_man = self.shell.history_manager
         if hist_access_type == 'tail':
-            hist = self.shell.history_manager.get_tail(n, raw=raw, output=output,
-                                                            include_latest=True)
+            hist = hist_man.get_tail(
+                n, raw=raw, output=output, include_latest=True
+            )
 
         elif hist_access_type == 'range':
-            hist = self.shell.history_manager.get_range(session, start, stop,
-                                                        raw=raw, output=output)
+            hist = hist_man.get_range(
+                session, start, stop, raw=raw, output=output
+            )
 
         elif hist_access_type == 'search':
-            hist = self.shell.history_manager.search(
-                pattern, raw=raw, output=output, n=n, unique=unique)
+            hist = hist_man.search(
+                pattern, raw=raw, output=output, n=n, unique=unique
+            )
         else:
             hist = []
 
@@ -319,21 +328,24 @@ class IPythonKernel(KernelBase):
         try:
             working = shell.user_ns
 
-            prefix = "_"+str(msg_id).replace("-","")+"_"
+            prefix = '_' + str(msg_id).replace('-', '') + '_'
 
             f,args,kwargs = unpack_apply_message(bufs, working, copy=False)
 
             fname = getattr(f, '__name__', 'f')
 
-            fname = prefix+"f"
-            argname = prefix+"args"
-            kwargname = prefix+"kwargs"
-            resultname = prefix+"result"
+            fname = prefix + 'f'
+            argname = prefix + 'args'
+            kwargname = prefix + 'kwargs'
+            resultname = prefix + 'result'
 
-            ns = { fname : f, argname : args, kwargname : kwargs , resultname : None }
+            ns = {
+                fname : f, argname : args,
+                kwargname : kwargs, resultname : None
+            }
             # print ns
             working.update(ns)
-            code = "%s = %s(*%s,**%s)" % (resultname, fname, argname, kwargname)
+            code = '%s = %s(*%s,**%s)' % (resultname, fname, argname, kwargname)
             try:
                 exec(code, shell.user_global_ns, shell.user_ns)
                 result = working.get(resultname)
@@ -356,14 +368,21 @@ class IPythonKernel(KernelBase):
                 reply_content.update(shell._reply_content)
                 # reset after use
                 shell._reply_content = None
-                
+
                 # FIXME: deprecate piece for ipyparallel:
-                e_info = dict(engine_uuid=self.ident, engine_id=self.int_id, method='apply')
+                e_info = dict(
+                    engine_uuid=self.ident,
+                    engine_id=self.int_id,
+                    method='apply'
+                )
                 reply_content['engine_info'] = e_info
 
             self.send_response(self.iopub_socket, u'error', reply_content,
                                 ident=self._topic('error'))
-            self.log.info("Exception in apply request:\n%s", '\n'.join(reply_content['traceback']))
+            self.log.info(
+                'Exception in apply request:\n%s',
+                '\n'.join(reply_content['traceback'])
+            )
             result_buf = []
         else:
             reply_content = {'status' : 'ok'}
@@ -380,6 +399,8 @@ class IPythonKernel(KernelBase):
 class Kernel(IPythonKernel):
     def __init__(self, *args, **kwargs):
         import warnings
-        warnings.warn('Kernel is a deprecated alias of ipykernel.ipkernel.IPythonKernel',
-                      DeprecationWarning)
+        warnings.warn(
+            'Kernel is a deprecated alias of ipykernel.ipkernel.IPythonKernel',
+            DeprecationWarning
+        )
         super(Kernel, self).__init__(*args, **kwargs)

--- a/ipykernel/jsonutil.py
+++ b/ipykernel/jsonutil.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Utilities to manipulate JSON objects."""
 
 # Copyright (c) IPython Development Team.

--- a/ipykernel/jsonutil.py
+++ b/ipykernel/jsonutil.py
@@ -26,12 +26,12 @@ next_attr_name = '__next__' if py3compat.PY3 else 'next'
 #-----------------------------------------------------------------------------
 
 # timestamp formats
-ISO8601 = "%Y-%m-%dT%H:%M:%S.%f"
-ISO8601_PAT=re.compile(r"^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})(\.\d{1,6})?Z?([\+\-]\d{2}:?\d{2})?$")
+ISO8601 = '%Y-%m-%dT%H:%M:%S.%f'
+ISO8601_PAT = re.compile(r'^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})(\.\d{1,6})?Z?([\+\-]\d{2}:?\d{2})?$')
 
 # holy crap, strptime is not threadsafe.
 # Calling it once at import seems to help.
-datetime.strptime("1", "%d")
+datetime.strptime('1', '%d')
 
 #-----------------------------------------------------------------------------
 # Classes and functions
@@ -130,7 +130,8 @@ def json_clean(obj):
         return obj
 
     if isinstance(obj, numbers.Integral):
-        # cast int to int, in case subclasses override __str__ (e.g. boost enum, #4598)
+        # cast int to int, in case subclasses
+        # override __str__ (e.g. boost enum, #4598)
         return int(obj)
 
     if isinstance(obj, numbers.Real):
@@ -138,7 +139,7 @@ def json_clean(obj):
         if math.isnan(obj) or math.isinf(obj):
             return repr(obj)
         return float(obj)
-    
+
     if isinstance(obj, atomic_ok):
         return obj
 
@@ -168,6 +169,6 @@ def json_clean(obj):
         return out
     if isinstance(obj, datetime):
         return obj.strftime(ISO8601)
-    
+
     # we don't understand it, it's probably an unserializable object
-    raise ValueError("Can't clean for JSON: %r" % obj)
+    raise ValueError('Can\'t clean for JSON: %r' % obj)

--- a/ipykernel/kernelapp.py
+++ b/ipykernel/kernelapp.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """An Application for launching a kernel"""
 
 # Copyright (c) IPython Development Team.

--- a/ipykernel/kernelapp.py
+++ b/ipykernel/kernelapp.py
@@ -62,14 +62,14 @@ kernel_flags = dict(base_flags)
 kernel_flags.update({
     'no-stdout' : (
             {'IPKernelApp' : {'no_stdout' : True}},
-            "redirect stdout to the null device"),
+            'redirect stdout to the null device'),
     'no-stderr' : (
             {'IPKernelApp' : {'no_stderr' : True}},
-            "redirect stderr to the null device"),
+            'redirect stderr to the null device'),
     'pylab' : (
         {'IPKernelApp' : {'pylab' : 'auto'}},
-        """Pre-load matplotlib and numpy for interactive use with
-        the default matplotlib backend."""),
+        '''Pre-load matplotlib and numpy for interactive use with
+        the default matplotlib backend.'''),
 })
 
 # inherit flags&aliases for any IPython shell apps
@@ -80,7 +80,7 @@ kernel_flags.update(shell_flags)
 kernel_aliases.update(session_aliases)
 kernel_flags.update(session_flags)
 
-_ctrl_c_message = """\
+_ctrl_c_message = '''\
 NOTE: When using the `ipython kernel` entry point, Ctrl-C will not work.
 
 To exit, you will have to explicitly quit this process, by either sending
@@ -88,7 +88,7 @@ To exit, you will have to explicitly quit this process, by either sending
 
 To read more about this, see https://github.com/ipython/ipython/issues/2049
 
-"""
+'''
 
 #-----------------------------------------------------------------------------
 # Application class for starting an IPython Kernel
@@ -103,16 +103,16 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp,
     # the kernel class, as an importstring
     kernel_class = Type('ipykernel.ipkernel.IPythonKernel',
                         klass='ipykernel.kernelbase.Kernel',
-    help="""The Kernel subclass to be used.
+    help='''The Kernel subclass to be used.
 
     This should allow easy re-use of the IPKernelApp entry point
     to configure and launch kernels other than IPython's own.
-    """).tag(config=True)
+    ''').tag(config=True)
     kernel = Any()
     poller = Any() # don't restrict this even though current pollers are all Threads
     heartbeat = Instance(Heartbeat, allow_none=True)
     ports = Dict()
-    
+
     subcommands = {
         'install': (
             'ipykernel.kernelspec.InstallIPythonKernelSpecApp',
@@ -134,26 +134,26 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp,
 
 
     # streams, etc.
-    no_stdout = Bool(False, help="redirect stdout to the null device").tag(config=True)
-    no_stderr = Bool(False, help="redirect stderr to the null device").tag(config=True)
+    no_stdout = Bool(False, help='redirect stdout to the null device').tag(config=True)
+    no_stderr = Bool(False, help='redirect stderr to the null device').tag(config=True)
     outstream_class = DottedObjectName('ipykernel.iostream.OutStream',
-        help="The importstring for the OutStream factory").tag(config=True)
+        help='The importstring for the OutStream factory').tag(config=True)
     displayhook_class = DottedObjectName('ipykernel.displayhook.ZMQDisplayHook',
-        help="The importstring for the DisplayHook factory").tag(config=True)
+        help='The importstring for the DisplayHook factory').tag(config=True)
 
     # polling
     parent_handle = Integer(int(os.environ.get('JPY_PARENT_PID') or 0),
-        help="""kill this process if its parent dies.  On Windows, the argument
+        help='''kill this process if its parent dies.  On Windows, the argument
         specifies the HANDLE of the parent process, otherwise it is simply boolean.
-        """).tag(config=True)
+        ''').tag(config=True)
     interrupt = Integer(int(os.environ.get('JPY_INTERRUPT_EVENT') or 0),
-        help="""ONLY USED ON WINDOWS
+        help='''ONLY USED ON WINDOWS
         Interrupt this process when the parent is signaled.
-        """).tag(config=True)
+        ''').tag(config=True)
 
     def init_crash_handler(self):
         sys.excepthook = self.excepthook
-    
+
     def excepthook(self, etype, evalue, tb):
         # write uncaught traceback to 'real' stderr, not zmq-forwarder
         traceback.print_exception(etype, evalue, tb, file=sys.__stderr__)
@@ -171,30 +171,30 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp,
             if port <= 0:
                 port = s.bind_to_random_port(iface)
             else:
-                s.bind("tcp://%s:%i" % (self.ip, port))
+                s.bind('tcp://%s:%i' % (self.ip, port))
         elif self.transport == 'ipc':
             if port <= 0:
                 port = 1
-                path = "%s-%i" % (self.ip, port)
+                path = '%s-%i' % (self.ip, port)
                 while os.path.exists(path):
                     port = port + 1
-                    path = "%s-%i" % (self.ip, port)
+                    path = '%s-%i' % (self.ip, port)
             else:
-                path = "%s-%i" % (self.ip, port)
-            s.bind("ipc://%s" % path)
+                path = '%s-%i' % (self.ip, port)
+            s.bind('ipc://%s' % path)
         return port
 
     def write_connection_file(self):
         """write connection info to JSON file"""
         cf = self.abs_connection_file
-        self.log.debug("Writing connection file: %s", cf)
+        self.log.debug('Writing connection file: %s', cf)
         write_connection_file(cf, ip=self.ip, key=self.session.key, transport=self.transport,
         shell_port=self.shell_port, stdin_port=self.stdin_port, hb_port=self.hb_port,
         iopub_port=self.iopub_port, control_port=self.control_port)
 
     def cleanup_connection_file(self):
         cf = self.abs_connection_file
-        self.log.debug("Cleaning up connection file: %s", cf)
+        self.log.debug('Cleaning up connection file: %s', cf)
         try:
             os.remove(cf)
         except (IOError, OSError):
@@ -204,11 +204,17 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp,
 
     def init_connection_file(self):
         if not self.connection_file:
-            self.connection_file = "kernel-%s.json"%os.getpid()
+            self.connection_file = 'kernel-%s.json'%os.getpid()
         try:
-            self.connection_file = filefind(self.connection_file, ['.', self.connection_dir])
+            self.connection_file = filefind(
+                self.connection_file,
+                ['.', self.connection_dir]
+            )
         except IOError:
-            self.log.debug("Connection file not found: %s", self.connection_file)
+            self.log.debug(
+                'Connection file not found: %s',
+                self.connection_file
+            )
             # This means I own it, and I'll create it in this directory:
             ensure_dir_exists(os.path.dirname(self.abs_connection_file), 0o700)
             # Also, I will clean it up:
@@ -217,12 +223,16 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp,
         try:
             self.load_connection_file()
         except Exception:
-            self.log.error("Failed to load connection file: %r", self.connection_file, exc_info=True)
+            self.log.error(
+                'Failed to load connection file: %r',
+                self.connection_file,
+                exc_info=True
+            )
             self.exit(1)
 
     def init_sockets(self):
         # Create a context, a session, and the kernel sockets.
-        self.log.info("Starting the kernel at pid: %i", os.getpid())
+        self.log.info('Starting the kernel at pid: %i', os.getpid())
         context = zmq.Context.instance()
         # Uncomment this to try closing the context.
         # atexit.register(context.term)
@@ -230,30 +240,30 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp,
         self.shell_socket = context.socket(zmq.ROUTER)
         self.shell_socket.linger = 1000
         self.shell_port = self._bind_socket(self.shell_socket, self.shell_port)
-        self.log.debug("shell ROUTER Channel on port: %i" % self.shell_port)
+        self.log.debug('shell ROUTER Channel on port: %i' % self.shell_port)
 
         self.stdin_socket = context.socket(zmq.ROUTER)
         self.stdin_socket.linger = 1000
         self.stdin_port = self._bind_socket(self.stdin_socket, self.stdin_port)
-        self.log.debug("stdin ROUTER Channel on port: %i" % self.stdin_port)
+        self.log.debug('stdin ROUTER Channel on port: %i' % self.stdin_port)
 
         self.control_socket = context.socket(zmq.ROUTER)
         self.control_socket.linger = 1000
         self.control_port = self._bind_socket(self.control_socket, self.control_port)
-        self.log.debug("control ROUTER Channel on port: %i" % self.control_port)
-        
+        self.log.debug('control ROUTER Channel on port: %i' % self.control_port)
+
         self.init_iopub(context)
 
     def init_iopub(self, context):
         self.iopub_socket = context.socket(zmq.PUB)
         self.iopub_socket.linger = 1000
         self.iopub_port = self._bind_socket(self.iopub_socket, self.iopub_port)
-        self.log.debug("iopub PUB Channel on port: %i" % self.iopub_port)
+        self.log.debug('iopub PUB Channel on port: %i' % self.iopub_port)
         self.iopub_thread = IOPubThread(self.iopub_socket, pipe=True)
         self.iopub_thread.start()
         # backward-compat: wrap iopub socket API in background thread
         self.iopub_socket = self.iopub_thread.background_socket
-        
+
 
     def init_heartbeat(self):
         """start the heart beating"""
@@ -262,7 +272,7 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp,
         hb_ctx = zmq.Context()
         self.heartbeat = Heartbeat(hb_ctx, (self.transport, self.ip, self.hb_port))
         self.hb_port = self.heartbeat.port
-        self.log.debug("Heartbeat REP Channel on port: %i" % self.hb_port)
+        self.log.debug('Heartbeat REP Channel on port: %i' % self.hb_port)
         self.heartbeat.start()
 
     def log_connection_info(self):
@@ -275,8 +285,8 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp,
         else:
             tail = self.connection_file
         lines = [
-            "To connect another client to this kernel, use:",
-            "    --existing %s" % tail,
+            'To connect another client to this kernel, use:',
+            '    --existing %s' % tail,
         ]
         # log connection info
         # info-level, so often not shown.
@@ -305,16 +315,17 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp,
 
     def init_io(self):
         """Redirect input streams and set a display hook."""
+        session, iopub = self.session, self.iopub_thread
         if self.outstream_class:
             outstream_factory = import_item(str(self.outstream_class))
-            sys.stdout = outstream_factory(self.session, self.iopub_thread, u'stdout')
-            sys.stderr = outstream_factory(self.session, self.iopub_thread, u'stderr')
+            sys.stdout = outstream_factory(session, iopub, u'stdout')
+            sys.stderr = outstream_factory(session, iopub, u'stderr')
         if self.displayhook_class:
             displayhook_factory = import_item(str(self.displayhook_class))
-            sys.displayhook = displayhook_factory(self.session, self.iopub_socket)
-        
+            sys.displayhook = displayhook_factory(session, self.iopub_socket)
+
         self.patch_io()
-    
+
     def patch_io(self):
         """Patch important libraries that can't handle sys.stdout forwarding"""
         try:
@@ -322,22 +333,31 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp,
         except ImportError:
             pass
         else:
-            # Warning: this is a monkeypatch of `faulthandler.enable`, watch for possible
-            # updates to the upstream API and update accordingly (up-to-date as of Python 3.5):
+            # Warning: this is a monkeypatch of `faulthandler.enable`,
+            # watch for possible updates to the upstream API and update
+            # accordingly (up-to-date as of Python 3.5):
             # https://docs.python.org/3/library/faulthandler.html#faulthandler.enable
 
             # change default file to __stderr__ from forwarded stderr
             faulthandler_enable = faulthandler.enable
             def enable(file=sys.__stderr__, all_threads=True, **kwargs):
-                return faulthandler_enable(file=file, all_threads=all_threads, **kwargs)
+                return faulthandler_enable(
+                    file=file,
+                    all_threads=all_threads,
+                    **kwargs
+                )
 
             faulthandler.enable = enable
 
             if hasattr(faulthandler, 'register'):
                 faulthandler_register = faulthandler.register
                 def register(signum, file=sys.__stderr__, all_threads=True, chain=False, **kwargs):
-                    return faulthandler_register(signum, file=file, all_threads=all_threads,
-                                                 chain=chain, **kwargs)
+                    return faulthandler_register(
+                        signum,
+                        file=file,
+                        all_threads=all_threads,
+                        chain=chain, **kwargs
+                    )
                 faulthandler.register = register
 
     def init_signal(self):
@@ -376,7 +396,7 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp,
         try:
             # replace error-sending traceback with stderr
             def print_tb(etype, evalue, stb):
-                print ("GUI event loop or pylab initialization failed",
+                print ('GUI event loop or pylab initialization failed',
                        file=sys.stderr)
                 print (shell.InteractiveTB.stb2text(stb), file=sys.stderr)
             shell._showtraceback = print_tb
@@ -388,7 +408,7 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp,
         self.shell = getattr(self.kernel, 'shell', None)
         if self.shell:
             self.shell.configurables.append(self)
-    
+
     def init_extensions(self):
         super(IPKernelApp, self).init_extensions()
         # BEGIN HARDCODED WIDGETS HACK
@@ -398,7 +418,10 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp,
             try:
                 extension_man.load_extension('ipywidgets')
             except ImportError as e:
-                self.log.debug('ipywidgets package not installed.  Widgets will not be available.')
+                self.log.debug(
+                'ipywidgets package not installed.'
+                ' Widgets will not be available.'
+            )
         # END HARDCODED WIDGETS HACK
 
     @catch_config_error
@@ -411,10 +434,12 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp,
         self.init_poller()
         self.init_sockets()
         self.init_heartbeat()
-        # writing/displaying connection info must be *after* init_sockets/heartbeat
+        # writing/displaying connection info must be
+        # *after* init_sockets/heartbeat
         self.write_connection_file()
-        # Log connection info after writing connection file, so that the connection
-        # file is definitely available at the time someone reads the log.
+        # Log connection info after writing connection file,
+        # so that the connection file is definitely available
+        # at the time someone reads the log.
         self.log_connection_info()
         self.init_io()
         self.init_signal()
@@ -434,7 +459,7 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp,
     def start(self):
         if self.subapp is not None:
             return self.subapp.start()
-        
+
         if self.poller is not None:
             self.poller.start()
         self.kernel.start()

--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -112,7 +112,7 @@ class Kernel(SingletonConfigurable):
     # Track execution count here. For IPython, we override this to use the
     # execution count we store in the shell.
     execution_count = 0
-    
+
     msg_types = [
         'execute_request', 'complete_request',
         'inspect_request', 'history_request',
@@ -144,10 +144,10 @@ class Kernel(SingletonConfigurable):
         try:
             msg = self.session.deserialize(msg, content=True, copy=False)
         except:
-            self.log.error("Invalid Control Message", exc_info=True)
+            self.log.error('Invalid Control Message', exc_info=True)
             return
 
-        self.log.debug("Control received: %s", msg)
+        self.log.debug('Control received: %s', msg)
 
         # Set the parent message for side effects.
         self.set_parent(idents, msg)
@@ -158,12 +158,12 @@ class Kernel(SingletonConfigurable):
 
         handler = self.control_handlers.get(msg_type, None)
         if handler is None:
-            self.log.error("UNKNOWN CONTROL MESSAGE TYPE: %r", msg_type)
+            self.log.error('UNKNOWN CONTROL MESSAGE TYPE: %r', msg_type)
         else:
             try:
                 handler(self.control_stream, idents, msg)
             except Exception:
-                self.log.error("Exception in control handler:", exc_info=True)
+                self.log.error('Exception in control handler:', exc_info=True)
 
         sys.stdout.flush()
         sys.stderr.flush()
@@ -171,7 +171,7 @@ class Kernel(SingletonConfigurable):
 
     def should_handle(self, stream, msg, idents):
         """Check whether a shell-channel message should be handled
-        
+
         Allows subclasses to prevent handling of certain messages (e.g. aborted requests).
         """
         msg_id = msg['header']['msg_id']
@@ -198,7 +198,7 @@ class Kernel(SingletonConfigurable):
         try:
             msg = self.session.deserialize(msg, content=True, copy=False)
         except:
-            self.log.error("Invalid Message", exc_info=True)
+            self.log.error('Invalid Message', exc_info=True)
             return
 
         # Set the parent message for side effects.
@@ -220,14 +220,14 @@ class Kernel(SingletonConfigurable):
 
         handler = self.shell_handlers.get(msg_type, None)
         if handler is None:
-            self.log.error("UNKNOWN MESSAGE TYPE: %r", msg_type)
+            self.log.error('UNKNOWN MESSAGE TYPE: %r', msg_type)
         else:
-            self.log.debug("%s: %s", msg_type, msg)
+            self.log.debug('%s: %s', msg_type, msg)
             self.pre_handler_hook()
             try:
                 handler(stream, idents, msg)
             except Exception:
-                self.log.error("Exception in message handler:", exc_info=True)
+                self.log.error('Exception in message handler:', exc_info=True)
             finally:
                 self.post_handler_hook()
 
@@ -246,7 +246,7 @@ class Kernel(SingletonConfigurable):
 
     def enter_eventloop(self):
         """enter eventloop"""
-        self.log.info("entering eventloop %s", self.eventloop)
+        self.log.info('entering eventloop %s', self.eventloop)
         for stream in self.shell_streams:
             # flush any pending replies,
             # which may be skipped by entering the eventloop
@@ -258,13 +258,13 @@ class Kernel(SingletonConfigurable):
                 self.eventloop(self)
             except KeyboardInterrupt:
                 # Ctrl-C shouldn't crash the kernel
-                self.log.error("KeyboardInterrupt caught in kernel")
+                self.log.error('KeyboardInterrupt caught in kernel')
                 continue
             else:
                 # eventloop exited cleanly, this means we should stop (right?)
                 self.eventloop = None
                 break
-        self.log.info("exiting eventloop")
+        self.log.info('exiting eventloop')
 
     def start(self):
         """register dispatchers for streams"""
@@ -343,21 +343,30 @@ class Kernel(SingletonConfigurable):
         This relies on :meth:`set_parent` having been called for the current
         message.
         """
-        return self.session.send(stream, msg_or_type, content, self._parent_header,
-                                 ident, buffers, track, header, metadata)
-    
+        return self.session.send(
+            stream,
+            msg_or_type,
+            content,
+            self._parent_header,
+            ident,
+            buffers,
+            track,
+            header,
+            metadata
+        )
+
     def init_metadata(self, parent):
         """Initialize metadata.
-        
+
         Run at the beginning of execution requests.
         """
         return {
             'started': datetime.now(),
         }
-    
+
     def finish_metadata(self, parent, metadata, reply_content):
         """Finish populating metadata.
-        
+
         Run after completing an execution request.
         """
         return metadata
@@ -373,8 +382,8 @@ class Kernel(SingletonConfigurable):
             user_expressions = content.get('user_expressions', {})
             allow_stdin = content.get('allow_stdin', False)
         except:
-            self.log.error("Got bad msg: ")
-            self.log.error("%s", parent)
+            self.log.error('Got bad msg: ')
+            self.log.error('%s', parent)
             return
 
         stop_on_error = content.get('stop_on_error', True)
@@ -407,9 +416,10 @@ class Kernel(SingletonConfigurable):
                                       reply_content, parent, metadata=metadata,
                                       ident=ident)
 
-        self.log.debug("%s", reply_msg)
+        self.log.debug('%s', reply_msg)
 
-        if not silent and reply_msg['content']['status'] == u'error' and stop_on_error:
+        reply_is_error = reply_msg['content']['status'] == u'error'
+        if not silent and reply_is_error and stop_on_error:
             self._abort_queues()
 
     def do_execute(self, code, silent, store_history=True,
@@ -545,27 +555,27 @@ class Kernel(SingletonConfigurable):
     def do_is_complete(self, code):
         """Override in subclasses to find completions.
         """
-        return {'status' : 'unknown',
-                }
+        return {'status' : 'unknown'}
 
     #---------------------------------------------------------------------------
     # Engine methods (DEPRECATED)
     #---------------------------------------------------------------------------
 
     def apply_request(self, stream, ident, parent):
-        self.log.warn("""apply_request is deprecated in kernel_base, moving to ipyparallel.""")
+        w = 'apply_request is deprecated in kernel_base, moving to ipyparallel.'
+        self.log.warn(w)
         try:
             content = parent[u'content']
             bufs = parent[u'buffers']
             msg_id = parent['header']['msg_id']
         except:
-            self.log.error("Got bad msg: %s", parent, exc_info=True)
+            self.log.error('Got bad msg: %s', parent, exc_info=True)
             return
 
         md = self.init_metadata(parent)
 
         reply_content, result_buf = self.do_apply(content, bufs, msg_id, md)
-        
+
         # flush i/o
         sys.stdout.flush()
         sys.stderr.flush()
@@ -585,7 +595,10 @@ class Kernel(SingletonConfigurable):
 
     def abort_request(self, stream, ident, parent):
         """abort a specific msg by id"""
-        self.log.warn("abort_request is deprecated in kernel_base. It os only part of IPython parallel")
+        self.log.warn(
+            'abort_request is deprecated in kernel_base.'
+            ' It os only part of IPython parallel'
+        )
         msg_ids = parent['content'].get('msg_ids', None)
         if isinstance(msg_ids, string_types):
             msg_ids = [msg_ids]
@@ -594,17 +607,24 @@ class Kernel(SingletonConfigurable):
         for mid in msg_ids:
             self.aborted.add(str(mid))
 
-        content = dict(status='ok')
-        reply_msg = self.session.send(stream, 'abort_reply', content=content,
-                parent=parent, ident=ident)
-        self.log.debug("%s", reply_msg)
+        content = dict(status = 'ok')
+        reply_msg = self.session.send(
+            stream, 'abort_reply', content=content,
+            parent=parent, ident=ident
+        )
+        self.log.debug('%s', reply_msg)
 
     def clear_request(self, stream, idents, parent):
         """Clear our namespace."""
-        self.log.warn("clear_request is deprecated in kernel_base. It os only part of IPython parallel")
+        self.log.warn(
+            'clear_request is deprecated in kernel_base.'
+            ' It os only part of IPython parallel'
+        )
         content = self.do_clear()
-        self.session.send(stream, 'clear_reply', ident=idents, parent=parent,
-                content = content)
+        self.session.send(
+            stream, 'clear_reply', ident = idents,
+            parent = parent, content = content
+        )
 
     def do_clear(self):
         """DEPRECATED"""
@@ -616,7 +636,7 @@ class Kernel(SingletonConfigurable):
 
     def _topic(self, topic):
         """prefixed topic for IOPub messages"""
-        base = "kernel.%s" % self.ident
+        base = 'kernel.%s' % self.ident
 
         return py3compat.cast_bytes("%s.%s" % (base, topic))
 
@@ -633,8 +653,8 @@ class Kernel(SingletonConfigurable):
             if msg is None:
                 return
 
-            self.log.info("Aborting:")
-            self.log.info("%s", msg)
+            self.log.info('Aborting:')
+            self.log.info('%s', msg)
             msg_type = msg['header']['msg_type']
             reply_type = msg_type.split('_')[0] + '_reply'
 
@@ -643,7 +663,7 @@ class Kernel(SingletonConfigurable):
             md.update(status)
             reply_msg = self.session.send(stream, reply_type, metadata=md,
                         content=status, parent=msg, ident=idents)
-            self.log.debug("%s", reply_msg)
+            self.log.debug('%s', reply_msg)
             # We need to wait a bit for requests to come in. This can probably
             # be set shorter for true asynchronous clients.
             poller.poll(50)
@@ -652,8 +672,8 @@ class Kernel(SingletonConfigurable):
     def _no_raw_input(self):
         """Raise StdinNotImplentedError if active frontend doesn't support
         stdin."""
-        raise StdinNotImplementedError("raw_input was called, but this "
-                                       "frontend does not support stdin.")
+        raise StdinNotImplementedError('raw_input was called, but this '
+                                       'frontend does not support stdin.')
 
     def getpass(self, prompt=''):
         """Forward getpass to frontends
@@ -664,7 +684,8 @@ class Kernel(SingletonConfigurable):
         """
         if not self._allow_stdin:
             raise StdinNotImplementedError(
-                "getpass was called, but this frontend does not support input requests."
+                'getpass was called, but this frontend'
+                ' does not support input requests.'
             )
         return self._input_request(prompt,
             self._parent_ident,
@@ -681,7 +702,8 @@ class Kernel(SingletonConfigurable):
         """
         if not self._allow_stdin:
             raise StdinNotImplementedError(
-                "raw_input was called, but this frontend does not support input requests."
+                'raw_input was called, but this frontend'
+                ' does not support input requests.'
             )
         return self._input_request(prompt,
             self._parent_ident,
@@ -713,7 +735,7 @@ class Kernel(SingletonConfigurable):
             try:
                 ident, reply = self.session.recv(self.stdin_socket, 0)
             except Exception:
-                self.log.warn("Invalid Message:", exc_info=True)
+                self.log.warn('Invalid Message:', exc_info=True)
             except KeyboardInterrupt:
                 # re-raise KeyboardInterrupt, to truncate traceback
                 raise KeyboardInterrupt
@@ -722,7 +744,7 @@ class Kernel(SingletonConfigurable):
         try:
             value = py3compat.unicode_to_str(reply['content']['value'])
         except:
-            self.log.error("Bad input_reply: %s", parent)
+            self.log.error('Bad input_reply: %s', parent)
             value = ''
         if value == '\x04':
             # EOF
@@ -734,6 +756,10 @@ class Kernel(SingletonConfigurable):
         """
         # io.rprint("Kernel at_shutdown") # dbg
         if self._shutdown_message is not None:
-            self.session.send(self.iopub_socket, self._shutdown_message, ident=self._topic('shutdown'))
-            self.log.debug("%s", self._shutdown_message)
+            self.session.send(
+                self.iopub_socket,
+                self._shutdown_message,
+                ident=self._topic('shutdown')
+            )
+            self.log.debug('%s', self._shutdown_message)
         [ s.flush(zmq.POLLOUT) for s in self.shell_streams ]

--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Base class for a kernel that talks to frontends over 0MQ."""
 
 # Copyright (c) IPython Development Team.

--- a/ipykernel/kernelspec.py
+++ b/ipykernel/kernelspec.py
@@ -22,7 +22,7 @@ KERNEL_NAME = 'python%i' % sys.version_info[0]
 RESOURCES = pjoin(os.path.dirname(__file__), 'resources')
 
 
-def make_ipkernel_cmd(mod='ipykernel', executable=None, extra_arguments=[], **kw):
+def make_ipkernel_cmd(mod='ipykernel', executable=None, extra_arguments=None, **kw):
     """Build Popen command list for launching an IPython kernel.
 
     Parameters
@@ -43,6 +43,7 @@ def make_ipkernel_cmd(mod='ipykernel', executable=None, extra_arguments=[], **kw
     """
     if executable is None:
         executable = sys.executable
+    extra_arguments = extra_arguments or []
     arguments = [ executable, '-m', mod, '-f', '{connection_file}' ]
     arguments.extend(extra_arguments)
 
@@ -60,15 +61,15 @@ def get_kernel_dict():
 
 def write_kernel_spec(path=None, overrides=None):
     """Write a kernel spec directory to `path`
-    
+
     If `path` is not specified, a temporary directory is created.
     If `overrides` is given, the kernelspec JSON is updated before writing.
-    
+
     The path to the kernelspec is always returned.
     """
     if path is None:
         path = os.path.join(tempfile.mkdtemp(suffix='_kernels'), KERNEL_NAME)
-    
+
     # stage resources
     shutil.copytree(RESOURCES, path)
     # write kernel.json
@@ -77,16 +78,16 @@ def write_kernel_spec(path=None, overrides=None):
         kernel_dict.update(overrides)
     with open(pjoin(path, 'kernel.json'), 'w') as f:
         json.dump(kernel_dict, f, indent=1)
-    
+
     return path
 
 
 def install(kernel_spec_manager=None, user=False, kernel_name=KERNEL_NAME, display_name=None, prefix=None):
     """Install the IPython kernelspec for Jupyter
-    
+
     Parameters
     ----------
-    
+
     kernel_spec_manager: KernelSpecManager [optional]
         A KernelSpecManager to use for installation.
         If none provided, a default instance will be created.
@@ -94,16 +95,18 @@ def install(kernel_spec_manager=None, user=False, kernel_name=KERNEL_NAME, displ
         Whether to do a user-only install, or system-wide.
     kernel_name: str, optional
         Specify a name for the kernelspec.
-        This is needed for having multiple IPython kernels for different environments.
+        This is needed for having multiple IPython kernels for
+        different environments.
     prefix: str, optional
         Specify an install prefix for the kernelspec.
-        This is needed to install into a non-default location, such as a conda/virtual-env.
+        This is needed to install into a non-default location,
+        such as a conda/virtual-env.
     display_name: str, optional
         Specify the display name for the kernelspec
-    
+
     Returns
     -------
-    
+
     The path where the kernelspec was installed.
     """
     if kernel_spec_manager is None:
@@ -132,40 +135,46 @@ from traitlets.config import Application
 class InstallIPythonKernelSpecApp(Application):
     """Dummy app wrapping argparse"""
     name = 'ipython-kernel-install'
-    
+
     def initialize(self, argv=None):
         if argv is None:
             argv = sys.argv[1:]
         self.argv = argv
-    
+
     def start(self):
         import argparse
         parser = argparse.ArgumentParser(prog=self.name,
-            description="Install the IPython kernel spec.")
+            description='Install the IPython kernel spec.')
         parser.add_argument('--user', action='store_true',
-            help="Install for the current user instead of system-wide")
+            help='Install for the current user instead of system-wide')
         parser.add_argument('--name', type=str, default=KERNEL_NAME,
-            help="Specify a name for the kernelspec."
-            " This is needed to have multiple IPython kernels at the same time.")
+            help='Specify a name for the kernelspec.'
+            ' This is needed to have multiple IPython kernels'
+            ' at the same time.')
         parser.add_argument('--display-name', type=str,
-            help="Specify the display name for the kernelspec."
-            " This is helpful when you have multiple IPython kernels.")
+            help='Specify the display name for the kernelspec.'
+            ' This is helpful when you have multiple IPython kernels.')
         parser.add_argument('--prefix', type=str,
-            help="Specify an install prefix for the kernelspec."
-            " This is needed to install into a non-default location, such as a conda/virtual-env.")
+            help='Specify an install prefix for the kernelspec.'
+            ' This is needed to install into a non-default location,'
+            ' such as a conda/virtual-env.')
         opts = parser.parse_args(self.argv)
         try:
-            dest = install(user=opts.user, kernel_name=opts.name, prefix=opts.prefix,
-                display_name=opts.display_name,
+            dest = install(
+                user=opts.user,
+                kernel_name=opts.name,
+                prefix=opts.prefix,
+                display_name=opts.display_name
             )
         except OSError as e:
             if e.errno == errno.EACCES:
                 print(e, file=sys.stderr)
                 if opts.user:
-                    print("Perhaps you want `sudo` or `--user`?", file=sys.stderr)
+                    print('Perhaps you want `sudo` or `--user`?',
+                          file=sys.stderr)
                 self.exit(1)
             raise
-        print("Installed kernelspec %s in %s" % (opts.name, dest))
+        print('Installed kernelspec %s in %s' % (opts.name, dest))
 
 
 if __name__ == '__main__':

--- a/ipykernel/kernelspec.py
+++ b/ipykernel/kernelspec.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """The IPython kernel spec for Jupyter"""
 
 # Copyright (c) IPython Development Team.

--- a/ipykernel/log.py
+++ b/ipykernel/log.py
@@ -3,14 +3,17 @@ from logging import INFO, DEBUG, WARN, ERROR, FATAL
 from zmq.log.handlers import PUBHandler
 
 import warnings
-warnings.warn("ipykernel.log is deprecated. It has moved to ipyparallel.engine.log", DeprecationWarning)
+warnings.warn(
+    'ipykernel.log is deprecated. It has moved to ipyparallel.engine.log',
+    DeprecationWarning
+)
 
 class EnginePUBHandler(PUBHandler):
     """A simple PUBHandler subclass that sets root_topic"""
-    engine=None
+    engine = None
 
     def __init__(self, engine, *args, **kwargs):
-        PUBHandler.__init__(self,*args, **kwargs)
+        PUBHandler.__init__(self, *args, **kwargs)
         self.engine = engine
 
     @property
@@ -18,6 +21,6 @@ class EnginePUBHandler(PUBHandler):
         """this is a property, in case the handler is created
         before the engine gets registered with an id"""
         if isinstance(getattr(self.engine, 'id', None), int):
-            return "engine.%i"%self.engine.id
+            return 'engine.%i' % self.engine.id
         else:
-            return "engine"
+            return 'engine'

--- a/ipykernel/log.py
+++ b/ipykernel/log.py
@@ -1,3 +1,7 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License.
 from logging import INFO, DEBUG, WARN, ERROR, FATAL
 
 from zmq.log.handlers import PUBHandler

--- a/ipykernel/parentpoller.py
+++ b/ipykernel/parentpoller.py
@@ -64,7 +64,7 @@ class ParentPollerWindows(Thread):
         assert(interrupt_handle or parent_handle)
         super(ParentPollerWindows, self).__init__()
         if ctypes is None:
-            raise ImportError("ParentPollerWindows requires ctypes")
+            raise ImportError('ParentPollerWindows requires ctypes')
         self.daemon = True
         self.interrupt_handle = interrupt_handle
         self.parent_handle = parent_handle

--- a/ipykernel/parentpoller.py
+++ b/ipykernel/parentpoller.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
 

--- a/ipykernel/pylab/backend_inline.py
+++ b/ipykernel/pylab/backend_inline.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """A matplotlib backend for publishing figures via display_data"""
 
 # Copyright (c) IPython Development Team.

--- a/ipykernel/pylab/config.py
+++ b/ipykernel/pylab/config.py
@@ -43,8 +43,9 @@ class InlineBackend(InlineBackendConfig):
 
     def _config_changed(self, name, old, new):
         # warn on change of renamed config section
-        if new.InlineBackendConfig != getattr(old, 'InlineBackendConfig', Config()):
-            warn("InlineBackendConfig has been renamed to InlineBackend")
+        oldInlineBackendConfig = getattr(old, 'InlineBackendConfig', Config())
+        if new.InlineBackendConfig != oldInlineBackendConfig:
+            warn('InlineBackendConfig has been renamed to InlineBackend')
         super(InlineBackend, self)._config_changed(name, old, new)
 
     # The typical default figure size is too large for inline use,
@@ -62,13 +63,13 @@ class InlineBackend(InlineBackendConfig):
         # 10pt still needs a little more room on the xlabel:
         'figure.subplot.bottom' : .125
         },
-        help="""Subset of matplotlib rcParams that should be different for the
-        inline backend."""
+        help='''Subset of matplotlib rcParams that should be different for the
+        inline backend.'''
     ).tag(config=True)
 
     figure_formats = Set({'png'},
-                          help="""A set of figure formats to enable: 'png',
-                          'retina', 'jpeg', 'svg', 'pdf'.""").tag(config=True)
+                          help='''A set of figure formats to enable: "png",
+                          "retina", "jpeg", "svg", "pdf".''').tag(config=True)
 
     def _update_figure_formatters(self):
         if self.shell is not None:
@@ -78,26 +79,26 @@ class InlineBackend(InlineBackendConfig):
     def _figure_formats_changed(self, name, old, new):
         if 'jpg' in new or 'jpeg' in new:
             if not pil_available():
-                raise TraitError("Requires PIL/Pillow for JPG figures")
+                raise TraitError('Requires PIL/Pillow for JPG figures')
         self._update_figure_formatters()
 
-    figure_format = Unicode(help="""The figure format to enable (deprecated
-                                         use `figure_formats` instead)""").tag(config=True)
+    figure_format = Unicode(help='''The figure format to enable (deprecated
+                                         use `figure_formats` instead)''').tag(config=True)
 
     def _figure_format_changed(self, name, old, new):
         if new:
             self.figure_formats = {new}
 
     print_figure_kwargs = Dict({'bbox_inches' : 'tight'},
-        help="""Extra kwargs to be passed to fig.canvas.print_figure.
+        help='''Extra kwargs to be passed to fig.canvas.print_figure.
 
         Logical examples include: bbox_inches, quality (for jpeg figures), etc.
-        """
+        '''
     ).tag(config=True)
     _print_figure_kwargs_changed = _update_figure_formatters
 
     close_figures = Bool(True,
-        help="""Close all figures at the end of each cell.
+        help='''Close all figures at the end of each cell.
 
         When True, ensures that each cell starts with no active figures, but it
         also means that one must keep track of references in order to edit or
@@ -111,8 +112,7 @@ class InlineBackend(InlineBackendConfig):
         iterative editing of figures, and behaves most consistently with
         other matplotlib backends, but figure barriers between cells must
         be explicit.
-        """).tag(config=True)
-    
+        ''').tag(config=True)
+
     shell = Instance('IPython.core.interactiveshell.InteractiveShellABC',
                      allow_none=True)
-

--- a/ipykernel/pylab/config.py
+++ b/ipykernel/pylab/config.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Configurable for configuring the IPython inline backend
 
 This module does not import anything from matplotlib.

--- a/ipykernel/serialize.py
+++ b/ipykernel/serialize.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """serialization utilities for apply messages"""
 
 # Copyright (c) IPython Development Team.

--- a/ipykernel/serialize.py
+++ b/ipykernel/serialize.py
@@ -184,6 +184,6 @@ def unpack_apply_message(bufs, g=None, copy=True):
     for key in info['kw_keys']:
         kwarg, kwarg_bufs = deserialize_object(kwarg_bufs, g)
         kwargs[key] = kwarg
-    assert not kwarg_bufs, 'Shouldn\t be any kwarg bufs left over'
+    assert not kwarg_bufs, 'Shouldn\'t be any kwarg bufs left over'
 
     return f,args,kwargs

--- a/ipykernel/serialize.py
+++ b/ipykernel/serialize.py
@@ -166,7 +166,7 @@ def unpack_apply_message(bufs, g=None, copy=True):
     """unpack f,args,kwargs from buffers packed by pack_apply_message()
     Returns: original f,args,kwargs"""
     bufs = list(bufs) # allow us to pop
-    assert len(bufs) >= 2, 'not enough buffers!''
+    assert len(bufs) >= 2, 'not enough buffers!'
     pf = buffer_to_bytes_py2(bufs.pop(0))
     f = uncan(pickle.loads(pf), g)
     pinfo = buffer_to_bytes_py2(bufs.pop(0))

--- a/ipykernel/serialize.py
+++ b/ipykernel/serialize.py
@@ -4,7 +4,10 @@
 # Distributed under the terms of the Modified BSD License.
 
 import warnings
-warnings.warn("ipykernel.serialize is deprecated. It has moved to ipyparallel.serialize", DeprecationWarning)
+warnings.warn(
+    'ipykernel.serialize is deprecated. It has moved to ipyparallel.serialize',
+    DeprecationWarning
+)
 
 try:
     import cPickle
@@ -49,7 +52,7 @@ def _extract_buffers(obj, threshold=MAX_BYTES):
     return buffers
 
 def _restore_buffers(obj, buffers):
-    """restore buffers extracted by """
+    """ restore buffers extracted by """
     if isinstance(obj, CannedObject) and obj.buffers:
         for i,buf in enumerate(obj.buffers):
             if buf is None:
@@ -163,7 +166,7 @@ def unpack_apply_message(bufs, g=None, copy=True):
     """unpack f,args,kwargs from buffers packed by pack_apply_message()
     Returns: original f,args,kwargs"""
     bufs = list(bufs) # allow us to pop
-    assert len(bufs) >= 2, "not enough buffers!"
+    assert len(bufs) >= 2, 'not enough buffers!''
     pf = buffer_to_bytes_py2(bufs.pop(0))
     f = uncan(pickle.loads(pf), g)
     pinfo = buffer_to_bytes_py2(bufs.pop(0))
@@ -175,12 +178,12 @@ def unpack_apply_message(bufs, g=None, copy=True):
         arg, arg_bufs = deserialize_object(arg_bufs, g)
         args.append(arg)
     args = tuple(args)
-    assert not arg_bufs, "Shouldn't be any arg bufs left over"
+    assert not arg_bufs, 'Shouldn\'t be any arg bufs left over'
 
     kwargs = {}
     for key in info['kw_keys']:
         kwarg, kwarg_bufs = deserialize_object(kwarg_bufs, g)
         kwargs[key] = kwarg
-    assert not kwarg_bufs, "Shouldn't be any kwarg bufs left over"
+    assert not kwarg_bufs, 'Shouldn\t be any kwarg bufs left over'
 
     return f,args,kwargs

--- a/ipykernel/tests/__init__.py
+++ b/ipykernel/tests/__init__.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
 
@@ -28,7 +30,7 @@ def setup():
     ]
     for p in patchers:
         p.start()
-    
+
     # install IPython in the temp home:
     install(user=True)
 

--- a/ipykernel/tests/test_connect.py
+++ b/ipykernel/tests/test_connect.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Tests for kernel connection utilities"""
 
 # Copyright (c) IPython Development Team.

--- a/ipykernel/tests/test_connect.py
+++ b/ipykernel/tests/test_connect.py
@@ -38,7 +38,7 @@ def test_get_connection_file():
         profile_cf = os.path.join(app.connection_dir, cf)
         nt.assert_equal(profile_cf, app.abs_connection_file)
         with open(profile_cf, 'w') as f:
-            f.write("{}")
+            f.write('{}')
         nt.assert_true(os.path.exists(profile_cf))
         nt.assert_equal(connect.get_connection_file(app), profile_cf)
 
@@ -52,7 +52,7 @@ def test_get_connection_info():
         connect.write_connection_file(cf, **sample_info)
         json_info = connect.get_connection_info(cf)
         info = connect.get_connection_info(cf, unpack=True)
-    
+
     nt.assert_equal(type(json_info), type(""))
     sub_info = {k:v for k,v in info.items() if k in sample_info}
     nt.assert_equal(sub_info, sample_info)

--- a/ipykernel/tests/test_embed_kernel.py
+++ b/ipykernel/tests/test_embed_kernel.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """test IPython.embed_kernel()"""
 
 # Copyright (c) IPython Development Team.

--- a/ipykernel/tests/test_embed_kernel.py
+++ b/ipykernel/tests/test_embed_kernel.py
@@ -48,12 +48,12 @@ def setup_kernel(cmd):
     if kernel.poll() is not None:
         o,e = kernel.communicate()
         e = py3compat.cast_unicode(e)
-        raise IOError("Kernel failed to start:\n%s" % e)
+        raise IOError('Kernel failed to start:\n%s' % e)
 
     if not os.path.exists(connection_file):
         if kernel.poll() is None:
             kernel.terminate()
-        raise IOError("Connection file %r never arrived" % connection_file)
+        raise IOError('Connection file %r never arrived' % connection_file)
 
     client = BlockingKernelClient(connection_file=connection_file)
     client.load_connection_file()
@@ -85,7 +85,7 @@ def test_embed_kernel_basic():
         content = msg['content']
         nt.assert_true(content['found'])
 
-        msg_id = client.execute("c=a*2")
+        msg_id = client.execute('c=a*2')
         msg = client.get_shell_msg(block=True, timeout=TIMEOUT)
         content = msg['content']
         nt.assert_equal(content['status'], u'ok')
@@ -158,6 +158,6 @@ def test_embed_kernel_reentrant():
             nt.assert_in(unicode_type(i), text)
 
             # exit from embed_kernel
-            client.execute("get_ipython().exit_now = True")
+            client.execute('get_ipython().exit_now = True')
             msg = client.get_shell_msg(block=True, timeout=TIMEOUT)
             time.sleep(0.2)

--- a/ipykernel/tests/test_jsonutil.py
+++ b/ipykernel/tests/test_jsonutil.py
@@ -44,11 +44,11 @@ def test():
              # More exotic objects
              ((x for x in range(3)), [0, 1, 2]),
              (iter([1, 2]), [1, 2]),
-             (datetime(1991, 7, 3, 12, 00), "1991-07-03T12:00:00.000000"),
+             (datetime(1991, 7, 3, 12, 00), '1991-07-03T12:00:00.000000'),
              (MyFloat(), 3.14),
              (MyInt(), 389)
              ]
-    
+
     for val, jval in pairs:
         if jval is None:
             jval = val
@@ -64,7 +64,7 @@ def test_encode_images():
     pngdata = b'\x89PNG\r\n\x1a\nblahblahnotactuallyvalidIEND\xaeB`\x82'
     jpegdata = b'\xff\xd8\xff\xe0\x00\x10JFIFblahblahjpeg(\xa0\x0f\xff\xd9'
     pdfdata = b'%PDF-1.\ntrailer<</Root<</Pages<</Kids[<</MediaBox[0 0 3 3]>>]>>>>>>'
-    
+
     fmt = {
         'image/png'  : pngdata,
         'image/jpeg' : jpegdata,
@@ -77,7 +77,7 @@ def test_encode_images():
         nt.assert_equal(decoded, value)
     encoded2 = encode_images(encoded)
     nt.assert_equal(encoded, encoded2)
-    
+
     b64_str = {}
     for key, encoded in iteritems(encoded):
         b64_str[key] = unicode_to_str(encoded)

--- a/ipykernel/tests/test_kernel.py
+++ b/ipykernel/tests/test_kernel.py
@@ -50,7 +50,7 @@ def test_sys_path():
             kc=kc, code='import sys; print (repr(sys.path[0]))'
         )
         stdout, stderr = assemble_output(kc.iopub_channel)
-        nt.assert_equal(stdout, '""\n')
+        nt.assert_equal(stdout, "''\n")
 
 def test_sys_path_profile_dir():
     """test that sys.path doesn't get messed up when `--profile-dir` is specified"""
@@ -58,7 +58,7 @@ def test_sys_path_profile_dir():
     with new_kernel(['--profile-dir', locate_profile('default')]) as kc:
         msg_id, content = execute(kc=kc, code='import sys; print (repr(sys.path[0]))')
         stdout, stderr = assemble_output(kc.iopub_channel)
-        nt.assert_equal(stdout, '""\n')
+        nt.assert_equal(stdout, "''\n")
 
 @dec.knownfailureif(sys.platform == 'win32', 'subprocess prints fail on Windows')
 def test_subprocess_print():
@@ -140,7 +140,7 @@ def test_raw_input():
         iopub = kc.iopub_channel
 
         input_f = 'input' if py3compat.PY3 else 'raw_input'
-        theprompt = 'prompt> ''
+        theprompt = 'prompt> '
         code = 'print({input_f}("{theprompt}"))'.format(**locals())
         msg_id = kc.execute(code, allow_stdin=True)
         msg = kc.get_stdin_msg(block=True, timeout=TIMEOUT)

--- a/ipykernel/tests/test_kernel.py
+++ b/ipykernel/tests/test_kernel.py
@@ -20,10 +20,12 @@ from .utils import (new_kernel, kernel, TIMEOUT, assemble_output, execute,
                     flush_channels, wait_for_idle)
 
 
-def _check_master(kc, expected=True, stream="stdout"):
-    execute(kc=kc, code="import sys")
+def _check_master(kc, expected=True, stream='stdout'):
+    execute(kc=kc, code='import sys')
     flush_channels(kc)
-    msg_id, content = execute(kc=kc, code="print (sys.%s._is_master_process())" % stream)
+    msg_id, content = execute(
+        kc=kc, code='print (sys.%s._is_master_process())' % stream
+    )
     stdout, stderr = assemble_output(kc.iopub_channel)
     nt.assert_equal(stdout.strip(), repr(expected))
 
@@ -34,7 +36,7 @@ def test_simple_print():
     """simple print statement in kernel"""
     with kernel() as kc:
         iopub = kc.iopub_channel
-        msg_id, content = execute(kc=kc, code="print ('hi')")
+        msg_id, content = execute(kc=kc, code='print ("hi")')
         stdout, stderr = assemble_output(iopub)
         nt.assert_equal(stdout, 'hi\n')
         nt.assert_equal(stderr, '')
@@ -44,19 +46,21 @@ def test_simple_print():
 def test_sys_path():
     """test that sys.path doesn't get messed up by default"""
     with kernel() as kc:
-        msg_id, content = execute(kc=kc, code="import sys; print (repr(sys.path[0]))")
+        msg_id, content = execute(
+            kc=kc, code='import sys; print (repr(sys.path[0]))'
+        )
         stdout, stderr = assemble_output(kc.iopub_channel)
-        nt.assert_equal(stdout, "''\n")
+        nt.assert_equal(stdout, '""\n')
 
 def test_sys_path_profile_dir():
     """test that sys.path doesn't get messed up when `--profile-dir` is specified"""
 
     with new_kernel(['--profile-dir', locate_profile('default')]) as kc:
-        msg_id, content = execute(kc=kc, code="import sys; print (repr(sys.path[0]))")
+        msg_id, content = execute(kc=kc, code='import sys; print (repr(sys.path[0]))')
         stdout, stderr = assemble_output(kc.iopub_channel)
-        nt.assert_equal(stdout, "''\n")
+        nt.assert_equal(stdout, '""\n')
 
-@dec.knownfailureif(sys.platform == 'win32', "subprocess prints fail on Windows")
+@dec.knownfailureif(sys.platform == 'win32', 'subprocess prints fail on Windows')
 def test_subprocess_print():
     """printing from forked mp.Process"""
     with new_kernel() as kc:
@@ -66,23 +70,23 @@ def test_subprocess_print():
         flush_channels(kc)
         np = 5
         code = '\n'.join([
-            "from __future__ import print_function",
-            "import time",
-            "import multiprocessing as mp",
-            "pool = [mp.Process(target=print, args=('hello', i,)) for i in range(%i)]" % np,
-            "for p in pool: p.start()",
-            "for p in pool: p.join()",
-            "time.sleep(0.5),"
+            'from __future__ import print_function',
+            'import time',
+            'import multiprocessing as mp',
+            'pool = [mp.Process(target=print, args=("hello", i,)) for i in range(%i)]' % np,
+            'for p in pool: p.start()',
+            'for p in pool: p.join()',
+            'time.sleep(0.5)'
         ])
 
         msg_id, content = execute(kc=kc, code=code)
         stdout, stderr = assemble_output(iopub)
-        nt.assert_equal(stdout.count("hello"), np, stdout)
+        nt.assert_equal(stdout.count('hello'), np, stdout)
         for n in range(np):
             nt.assert_equal(stdout.count(str(n)), 1, stdout)
         nt.assert_equal(stderr, '')
         _check_master(kc, expected=True)
-        _check_master(kc, expected=True, stream="stderr")
+        _check_master(kc, expected=True, stream='stderr')
 
 
 def test_subprocess_noprint():
@@ -92,10 +96,10 @@ def test_subprocess_noprint():
 
         np = 5
         code = '\n'.join([
-            "import multiprocessing as mp",
-            "pool = [mp.Process(target=range, args=(i,)) for i in range(%i)]" % np,
-            "for p in pool: p.start()",
-            "for p in pool: p.join()"
+            'import multiprocessing as mp',
+            'pool = [mp.Process(target=range, args=(i,)) for i in range(%i)]' % np,
+            'for p in pool: p.start()',
+            'for p in pool: p.join()'
         ])
 
         msg_id, content = execute(kc=kc, code=code)
@@ -104,29 +108,29 @@ def test_subprocess_noprint():
         nt.assert_equal(stderr, '')
 
         _check_master(kc, expected=True)
-        _check_master(kc, expected=True, stream="stderr")
+        _check_master(kc, expected=True, stream='stderr')
 
 
-@dec.knownfailureif(sys.platform == 'win32', "subprocess prints fail on Windows")
+@dec.knownfailureif(sys.platform == 'win32', 'subprocess prints fail on Windows')
 def test_subprocess_error():
     """error in mp.Process doesn't crash"""
     with new_kernel() as kc:
         iopub = kc.iopub_channel
 
         code = '\n'.join([
-            "import multiprocessing as mp",
-            "p = mp.Process(target=int, args=('hi',))",
-            "p.start()",
-            "p.join()",
+            'import multiprocessing as mp',
+            'p = mp.Process(target=int, args=("hi",))',
+            'p.start()',
+            'p.join()',
         ])
 
         msg_id, content = execute(kc=kc, code=code)
         stdout, stderr = assemble_output(iopub)
         nt.assert_equal(stdout, '')
-        nt.assert_true("ValueError" in stderr, stderr)
+        nt.assert_true('ValueError' in stderr, stderr)
 
         _check_master(kc, expected=True)
-        _check_master(kc, expected=True, stream="stderr")
+        _check_master(kc, expected=True, stream='stderr')
 
 # raw_input tests
 
@@ -135,15 +139,15 @@ def test_raw_input():
     with kernel() as kc:
         iopub = kc.iopub_channel
 
-        input_f = "input" if py3compat.PY3 else "raw_input"
-        theprompt = "prompt> "
+        input_f = 'input' if py3compat.PY3 else 'raw_input'
+        theprompt = 'prompt> ''
         code = 'print({input_f}("{theprompt}"))'.format(**locals())
         msg_id = kc.execute(code, allow_stdin=True)
         msg = kc.get_stdin_msg(block=True, timeout=TIMEOUT)
         nt.assert_equal(msg['header']['msg_type'], u'input_request')
         content = msg['content']
         nt.assert_equal(content['prompt'], theprompt)
-        text = "some text"
+        text = 'some text'
         kc.input(text)
         reply = kc.get_shell_msg(block=True, timeout=TIMEOUT)
         nt.assert_equal(reply['content']['status'], 'ok')
@@ -157,19 +161,19 @@ def test_eval_input():
     with kernel() as kc:
         iopub = kc.iopub_channel
 
-        input_f = "input" if py3compat.PY3 else "raw_input"
-        theprompt = "prompt> "
+        input_f = 'input' if py3compat.PY3 else 'raw_input'
+        theprompt = 'prompt> '
         code = 'print(input("{theprompt}"))'.format(**locals())
         msg_id = kc.execute(code, allow_stdin=True)
         msg = kc.get_stdin_msg(block=True, timeout=TIMEOUT)
         nt.assert_equal(msg['header']['msg_type'], u'input_request')
         content = msg['content']
         nt.assert_equal(content['prompt'], theprompt)
-        kc.input("1+1")
+        kc.input('1+1')
         reply = kc.get_shell_msg(block=True, timeout=TIMEOUT)
         nt.assert_equal(reply['content']['status'], 'ok')
         stdout, stderr = assemble_output(iopub)
-        nt.assert_equal(stdout, "2\n")
+        nt.assert_equal(stdout, '2\n')
 
 
 def test_save_history():
@@ -181,7 +185,7 @@ def test_save_history():
         wait_for_idle(kc)
         execute(u'b=u"abcþ"', kc=kc)
         wait_for_idle(kc)
-        _, reply = execute("%hist -f " + file, kc=kc)
+        _, reply = execute('%hist -f ' + file, kc=kc)
         nt.assert_equal(reply['status'], 'ok')
         with io.open(file, encoding='utf-8') as f:
             content = f.read()

--- a/ipykernel/tests/test_kernelspec.py
+++ b/ipykernel/tests/test_kernelspec.py
@@ -7,7 +7,7 @@ import os
 import shutil
 import sys
 import tempfile
-    
+
 try:
     from unittest import mock
 except ImportError:
@@ -26,8 +26,6 @@ from ipykernel.kernelspec import (
 )
 
 import nose.tools as nt
-
-pjoin = os.path.join
 
 
 def test_make_ipkernel_cmd():
@@ -53,6 +51,7 @@ def test_get_kernel_dict():
 
 
 def assert_is_spec(path):
+    pjoin = os.path.join
     for fname in os.listdir(RESOURCES):
         dst = pjoin(path, fname)
         assert os.path.exists(dst)
@@ -79,7 +78,7 @@ def test_write_kernel_spec_path():
 def test_install_kernelspec():
 
     path = tempfile.mkdtemp()
-    try: 
+    try:
         test = InstallIPythonKernelSpecApp.launch_instance(argv=['--prefix', path])
         assert_is_spec(os.path.join(
             path, 'share', 'jupyter', 'kernels', KERNEL_NAME))
@@ -89,21 +88,19 @@ def test_install_kernelspec():
 
 def test_install_user():
     tmp = tempfile.mkdtemp()
-    
+
     with mock.patch.dict(os.environ, {'HOME': tmp}):
         install(user=True)
         data_dir = jupyter_data_dir()
-    
+
     assert_is_spec(os.path.join(data_dir, 'kernels', KERNEL_NAME))
 
 
 def test_install():
     system_jupyter_dir = tempfile.mkdtemp()
-    
+
     with mock.patch('jupyter_client.kernelspec.SYSTEM_JUPYTER_PATH',
             [system_jupyter_dir]):
         install()
-    
+
     assert_is_spec(os.path.join(system_jupyter_dir, 'kernels', KERNEL_NAME))
-
-

--- a/ipykernel/tests/test_kernelspec.py
+++ b/ipykernel/tests/test_kernelspec.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
 

--- a/ipykernel/tests/test_message_spec.py
+++ b/ipykernel/tests/test_message_spec.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Test suite for our zeromq-based message specification."""
 
 # Copyright (c) IPython Development Team.

--- a/ipykernel/tests/test_message_spec.py
+++ b/ipykernel/tests/test_message_spec.py
@@ -35,7 +35,6 @@ def setup():
 #-----------------------------------------------------------------------------
 
 class Reference(HasTraits):
-
     """
     Base class for message spec specification testing.
 
@@ -43,7 +42,6 @@ class Reference(HasTraits):
     idea is that child classes implement trait attributes for each
     message keys, so that message keys can be tested against these
     traits using :meth:`check` method.
-
     """
 
     def check(self, d):
@@ -68,9 +66,9 @@ class Version(Unicode):
 
     def validate(self, obj, value):
         if self.min and V(value) < V(self.min):
-            raise TraitError("bad version: %s < %s" % (value, self.min))
+            raise TraitError('bad version: %s < %s' % (value, self.min))
         if self.max and (V(value) > V(self.max)):
-            raise TraitError("bad version: %s > %s" % (value, self.max))
+            raise TraitError('bad version: %s > %s' % (value, self.max))
 
 
 class RMessage(Reference):
@@ -140,7 +138,10 @@ class ArgSpec(Reference):
 
 
 class Status(Reference):
-    execution_state = Enum((u'busy', u'idle', u'starting'), default_value=u'busy')
+    execution_state = Enum(
+        (u'busy', u'idle', u'starting'),
+        default_value=u'busy'
+    )
 
 
 class CompleteReply(Reference):
@@ -168,7 +169,10 @@ class CommInfoReply(Reference):
     comms = Dict()
 
 class IsCompleteReply(Reference):
-    status = Enum((u'complete', u'incomplete', u'invalid', u'unknown'), default_value=u'complete')
+    status = Enum(
+        (u'complete', u'incomplete', u'invalid', u'unknown'),
+        default_value=u'complete'
+    )
 
     def check(self, d):
         Reference.check(self, d)
@@ -406,7 +410,7 @@ def test_oinfo_not_found():
 def test_complete():
     flush_channels()
 
-    msg_id, reply = execute(code="alpha = albert = 5")
+    msg_id, reply = execute(code='alpha = albert = 5')
 
     msg_id = KC.complete('al', 2)
     reply = KC.get_shell_msg(timeout=TIMEOUT)
@@ -435,16 +439,16 @@ def test_comm_info_request():
 
 def test_single_payload():
     flush_channels()
-    msg_id, reply = execute(code="for i in range(3):\n"+
-                                 "   x=range?\n")
+    msg_id, reply = execute(code='for i in range(3):\n'+
+                                 '   x=range?\n')
     payload = reply['payload']
-    next_input_pls = [pl for pl in payload if pl["source"] == "set_next_input"]
+    next_input_pls = [pl for pl in payload if pl['source'] == 'set_next_input']
     nt.assert_equal(len(next_input_pls), 1)
 
 def test_is_complete():
     flush_channels()
 
-    msg_id = KC.is_complete("a = 1")
+    msg_id = KC.is_complete('a = 1')
     reply = KC.get_shell_msg(timeout=TIMEOUT)
     validate_message(reply, 'is_complete_reply', msg_id)
 
@@ -454,7 +458,10 @@ def test_history_range():
     msg_id_exec = KC.execute(code='x=1', store_history = True)
     reply_exec = KC.get_shell_msg(timeout=TIMEOUT)
 
-    msg_id = KC.history(hist_access_type = 'range', raw = True, output = True, start = 1, stop = 2, session = 0)
+    msg_id = KC.history(
+        hist_access_type = 'range', raw = True, output = True,
+        start = 1, stop = 2, session = 0
+    )
     reply = KC.get_shell_msg(timeout=TIMEOUT)
     validate_message(reply, 'history_reply', msg_id)
     content = reply['content']
@@ -466,7 +473,10 @@ def test_history_tail():
     msg_id_exec = KC.execute(code='x=1', store_history = True)
     reply_exec = KC.get_shell_msg(timeout=TIMEOUT)
 
-    msg_id = KC.history(hist_access_type = 'tail', raw = True, output = True, n = 1, session = 0)
+    msg_id = KC.history(
+        hist_access_type = 'tail', raw = True,
+        output = True, n = 1, session = 0
+    )
     reply = KC.get_shell_msg(timeout=TIMEOUT)
     validate_message(reply, 'history_reply', msg_id)
     content = reply['content']
@@ -478,7 +488,10 @@ def test_history_search():
     msg_id_exec = KC.execute(code='x=1', store_history = True)
     reply_exec = KC.get_shell_msg(timeout=TIMEOUT)
 
-    msg_id = KC.history(hist_access_type = 'search', raw = True, output = True, n = 1, pattern = '*', session = 0)
+    msg_id = KC.history(
+        hist_access_type = 'search', raw = True,
+        output = True, n = 1, pattern = '*', session = 0
+    )
     reply = KC.get_shell_msg(timeout=TIMEOUT)
     validate_message(reply, 'history_reply', msg_id)
     content = reply['content']
@@ -490,7 +503,7 @@ def test_history_search():
 def test_stream():
     flush_channels()
 
-    msg_id, reply = execute("print('hi')")
+    msg_id, reply = execute('print("hi")')
 
     stdout = KC.iopub_channel.get_msg(timeout=TIMEOUT)
     validate_message(stdout, 'stream', msg_id)
@@ -501,7 +514,7 @@ def test_stream():
 def test_display_data():
     flush_channels()
 
-    msg_id, reply = execute("from IPython.core.display import display; display(1)")
+    msg_id, reply = execute('from IPython.core.display import display; display(1)')
 
     display = KC.iopub_channel.get_msg(timeout=TIMEOUT)
     validate_message(display, 'display_data', parent=msg_id)

--- a/ipykernel/tests/test_pickleutil.py
+++ b/ipykernel/tests/test_pickleutil.py
@@ -1,4 +1,4 @@
-
+# -*- coding: utf-8 -*-
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
 

--- a/ipykernel/tests/test_pickleutil.py
+++ b/ipykernel/tests/test_pickleutil.py
@@ -1,4 +1,7 @@
 
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License.
+
 import os
 import pickle
 
@@ -21,7 +24,7 @@ def test_no_closure():
     def foo():
         a = 5
         return a
-    
+
     pfoo = dumps(foo)
     bar = loads(pfoo)
     nt.assert_equal(foo(), bar())
@@ -33,7 +36,7 @@ def test_generator_closure():
         i = 'i'
         r = [ i for j in (1,2) ]
         return r
-    
+
     pfoo = dumps(foo)
     bar = loads(pfoo)
     nt.assert_equal(foo(), bar())
@@ -45,7 +48,7 @@ def test_nested_closure():
         def g():
             return i
         return g()
-    
+
     pfoo = dumps(foo)
     bar = loads(pfoo)
     nt.assert_equal(foo(), bar())
@@ -55,7 +58,7 @@ def test_closure():
     @interactive
     def foo():
         return i
-    
+
     pfoo = dumps(foo)
     bar = loads(pfoo)
     nt.assert_equal(foo(), bar())

--- a/ipykernel/tests/test_serialize.py
+++ b/ipykernel/tests/test_serialize.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """test serialization tools"""
 
 # Copyright (c) IPython Development Team.

--- a/ipykernel/tests/test_serialize.py
+++ b/ipykernel/tests/test_serialize.py
@@ -56,9 +56,9 @@ def test_roundtrip_nested():
 
 def test_roundtrip_buffered():
     for obj in [
-        dict(a=b"x"*1025),
-        b"hello"*500,
-        [b"hello"*501, 1,2,3]
+        dict(a=b'x'*1025),
+        b'hello'*500,
+        [b'hello'*501, 1,2,3]
     ]:
         bufs = serialize_object(obj)
         nt.assert_equal(len(bufs), 2)

--- a/ipykernel/tests/test_start_kernel.py
+++ b/ipykernel/tests/test_start_kernel.py
@@ -1,4 +1,4 @@
-
+# -*- coding: utf-8 -*-
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
 

--- a/ipykernel/tests/test_start_kernel.py
+++ b/ipykernel/tests/test_start_kernel.py
@@ -1,3 +1,7 @@
+
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License.
+
 import nose.tools as nt
 
 from .test_embed_kernel import setup_kernel
@@ -18,7 +22,7 @@ def test_ipython_start_kernel_userns():
         nt.assert_in(u'123', text)
 
         # user_module should be an instance of DummyMod
-        msg_id = client.execute("usermod = get_ipython().user_module")
+        msg_id = client.execute('usermod = get_ipython().user_module')
         msg = client.get_shell_msg(block=True, timeout=TIMEOUT)
         content = msg['content']
         nt.assert_equal(content['status'], u'ok')
@@ -36,7 +40,7 @@ def test_ipython_start_kernel_no_userns():
 
     with setup_kernel(cmd) as client:
         # user_module should not be an instance of DummyMod
-        msg_id = client.execute("usermod = get_ipython().user_module")
+        msg_id = client.execute('usermod = get_ipython().user_module')
         msg = client.get_shell_msg(block=True, timeout=TIMEOUT)
         content = msg['content']
         nt.assert_equal(content['status'], u'ok')

--- a/ipykernel/tests/utils.py
+++ b/ipykernel/tests/utils.py
@@ -151,7 +151,7 @@ def assemble_output(iopub):
             elif content['name'] == 'stderr':
                 stderr += content['text']
             else:
-                raise KeyError("bad stream: %r" % content['name'])
+                raise KeyError('bad stream: %r' % content['name'])
         else:
             # other output, ignored
             pass

--- a/ipykernel/tests/utils.py
+++ b/ipykernel/tests/utils.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """utilities for testing IPython kernels"""
 
 # Copyright (c) IPython Development Team.

--- a/ipykernel/zmqshell.py
+++ b/ipykernel/zmqshell.py
@@ -262,7 +262,7 @@ class KernelMagics(Magics):
             filename, lineno, _ = CodeMagics._find_edit_target(self.shell, args, opts, last_call)
         except MacroToEdit as e:
             # TODO: Implement macro editing over 2 processes.
-            print("Macro editing not yet implemented in 2-process model.")
+            print('Macro editing not yet implemented in 2-process model.')
             return
 
         # Make sure we send to the client an absolute path, in case the working
@@ -283,9 +283,9 @@ class KernelMagics(Magics):
     def clear(self, arg_s):
         """Clear the terminal."""
         if os.name == 'posix':
-            self.shell.system("clear")
+            self.shell.system('clear')
         else:
-            self.shell.system("cls")
+            self.shell.system('cls')
 
     if os.name == 'nt':
         # This is the usual name in windows
@@ -345,11 +345,11 @@ class KernelMagics(Magics):
             connection_file = get_connection_file()
             info = get_connection_info(unpack=False)
         except Exception as e:
-            error("Could not get connection info: %r" % e)
+            error('Could not get connection info: %r' % e)
             return
 
         # add profile flag for non-default profile
-        profile_flag = "--profile %s" % profile if profile != 'default' else ""
+        profile_flag = '--profile %s' % profile if profile != 'default' else ''
 
         # if it's in the security dir, truncate to basename
         if security_dir == os.path.dirname(connection_file):
@@ -357,13 +357,13 @@ class KernelMagics(Magics):
 
 
         print (info + '\n')
-        print ("Paste the above JSON into a file, and connect with:\n"
-            "    $> ipython <app> --existing <file>\n"
-            "or, if you are local, you can connect with just:\n"
-            "    $> ipython <app> --existing {0} {1}\n"
-            "or even just:\n"
-            "    $> ipython <app> --existing {1}\n"
-            "if this is the most recent IPython session you have started.".format(
+        print ('Paste the above JSON into a file, and connect with:\n'
+            '    $> ipython <app> --existing <file>\n'
+            'or, if you are local, you can connect with just:\n'
+            '    $> ipython <app> --existing {0} {1}\n'
+            'or even just:\n'
+            '    $> ipython <app> --existing {1}\n'
+            'if this is the most recent IPython session you have started.'.format(
             connection_file, profile_flag
             )
         )
@@ -385,7 +385,7 @@ class KernelMagics(Magics):
         try:
             p = connect_qtconsole(argv=arg_split(arg_s, os.name=='posix'))
         except Exception as e:
-            error("Could not start qtconsole: %r" % e)
+            error('Could not start qtconsole: %r' % e)
             return
 
     @line_magic
@@ -402,17 +402,17 @@ class KernelMagics(Magics):
         try:
             interval = int(arg_s)
         except ValueError:
-            raise UsageError("%%autosave requires an integer, got %r" % arg_s)
+            raise UsageError('%%autosave requires an integer, got %r' % arg_s)
 
         # javascript wants milliseconds
         milliseconds = 1000 * interval
-        display(Javascript("IPython.notebook.set_autosave_interval(%i)" % milliseconds),
+        display(Javascript('IPython.notebook.set_autosave_interval(%i)' % milliseconds),
             include=['application/javascript']
         )
         if interval:
-            print("Autosaving every %i seconds" % interval)
+            print('Autosaving every %i seconds' % interval)
         else:
-            print("Autosave disabled")
+            print('Autosave disabled')
 
 
 class ZMQInteractiveShell(InteractiveShell):
@@ -481,8 +481,8 @@ class ZMQInteractiveShell(InteractiveShell):
     @property
     def data_pub(self):
         if not hasattr(self, '_data_pub'):
-            warnings.warn("InteractiveShell.data_pub is deprecated outside IPython parallel.",
-                DeprecationWarning, stacklevel=2)
+            w = 'InteractiveShell.data_pub is deprecated outside IPython parallel.'
+            warnings.warn(w, DeprecationWarning, stacklevel=2)
 
             self._data_pub = self.data_pub_class(parent=self)
             self._data_pub.session = self.display_pub.session
@@ -520,7 +520,13 @@ class ZMQInteractiveShell(InteractiveShell):
         if dh.topic:
             topic = dh.topic.replace(b'execute_result', b'error')
 
-        exc_msg = dh.session.send(dh.pub_socket, u'error', json_clean(exc_content), dh.parent_header, ident=topic)
+        exc_msg = dh.session.send(
+            dh.pub_socket,
+            u'error',
+            json_clean(exc_content),
+            dh.parent_header,
+            ident=topic
+        )
 
         # FIXME - Hack: store exception info in shell object.  Right now, the
         # caller is reading this info after the fact, we need to fix this logic

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ import sys
 
 v = sys.version_info
 if v[:2] < (2,7) or (v[0] >= 3 and v[:2] < (3,3)):
-    error = "ERROR: %s requires Python version 2.7 or 3.3 or above." % name
+    error = 'ERROR: %s requires Python version 2.7 or 3.3 or above.' % name
     print(error, file=sys.stderr)
     sys.exit(1)
 
@@ -56,12 +56,12 @@ setup_args = dict(
     scripts         = glob(pjoin('scripts', '*')),
     packages        = packages,
     package_data    = package_data,
-    description     = "IPython Kernel for Jupyter",
+    description     = 'IPython Kernel for Jupyter',
     author          = 'IPython Development Team',
     author_email    = 'ipython-dev@scipy.org',
     url             = 'http://ipython.org',
     license         = 'BSD',
-    platforms       = "Linux, Mac OS X, Windows",
+    platforms       = 'Linux, Mac OS X, Windows',
     keywords        = ['Interactive', 'Interpreter', 'Shell', 'Web'],
     classifiers     = [
         'Intended Audience :: Developers',


### PR DESCRIPTION
- [X] Consistent use of single/double quotes. Standalone strings were mostly single-quoted, so i stuck with that, whereas docstrings were all double-quoted, so I left them alone.
- [X] Consistent use of ipython copyright header.
- [X] Re-jig any code over 79 chars, except regex lines.
- [X] Remove triple-quoted strings where the string fits on one line.
- [X] Assign repeated code fragments to local variables, where it makes sense.
- [X] Fix typos.
- [X] Consistent spacing around binary operators.
- [X] Remove mutable default arguments.
- [X] Remove whitespace at end-of-line.
- [X] Factor out complex (and long) if-criteria in pickleutil.
- [X] Move global var in test module to function local.
- [X] Consistent UTF-8 encoding notice in each file (required to keep py2.7 tests passing)