### PR TITLE
gtk3: Avoid warnings from newer GObject-introspection imports.

### DIFF
--- a/ipykernel/gui/gtk3embed.py
+++ b/ipykernel/gui/gtk3embed.py
@@ -14,6 +14,9 @@
 import sys
 
 # Third-party
+import gi
+gi.require_version ('Gdk', '3.0')
+gi.require_version ('Gtk', '3.0')
 from gi.repository import GObject, Gtk
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
Without this patch, newer versions of pygobject3 lead to the following warnings:

```
In [3]: %gui gtk3
In [4]: 
/a/lib/python2.7/site-packages/ipykernel/gui/gtk3embed.py:17: PyGIWarning: Gtk was imported without specifying a version first. Use gi.require_version('Gtk', '3.0') before import to ensure that the right version gets loaded.
  from gi.repository import GObject, Gtk
In [4]: 
```