### PR TITLE
General Fixes for Comms

### DIFF
--- a/ipykernel/comm/comm.py
+++ b/ipykernel/comm/comm.py
@@ -30,6 +30,8 @@ class Comm(LoggingConfigurable):
     def _default_comm_id(self):
         return uuid.uuid4().hex
 
+    primary = Bool(True, help="Am I the primary or secondary Comm?")
+
     target_name = Unicode('comm')
     target_module = Unicode(None, allow_none=True, help="""requirejs module from
         which to load comm target.""")
@@ -47,8 +49,6 @@ class Comm(LoggingConfigurable):
     _close_callback = Any()
 
     _closed = Bool(True)
-
-    primary = Bool(True, help="Am I the primary or secondary Comm?")
 
     def __init__(self, target_name='', data=None, metadata=None, buffers=None, **kwargs):
         if target_name:
@@ -154,8 +154,8 @@ class Comm(LoggingConfigurable):
     def handle_msg(self, msg):
         """Handle a comm_msg message"""
         self.log.debug("handle_msg[%s](%s)", self.comm_id, msg)
-        shell = self.kernel.shell
         if self._msg_callback:
+            shell = self.kernel.shell
             if shell:
                 shell.events.trigger('pre_execute')
             self._msg_callback(msg)

--- a/ipykernel/comm/manager.py
+++ b/ipykernel/comm/manager.py
@@ -67,7 +67,7 @@ class CommManager(LoggingConfigurable):
         except KeyError:
             self.log.warn("No such comm: %s", comm_id)
             if self.log.isEnabledFor(self.log.DEBUG):
-                self.log.debug("Current comms: %s", self.comms.keys())
+                self.log.debug("Current comms: %s", list(self.comms.keys()))
 
     # Message handlers
     def comm_open(self, stream, ident, msg):
@@ -103,7 +103,7 @@ class CommManager(LoggingConfigurable):
         if self._comm_is_not_valid(comm, comm_id):
             return
 
-        self._safe_handle(msg, comm.handle_msg)
+        self._safe_handle(msg, comm.handle_msg, name='comm_msg')
 
     def comm_close(self, stream, ident, msg):
         """Handler for comm_close messages"""
@@ -112,7 +112,7 @@ class CommManager(LoggingConfigurable):
             return
 
         del self.comms[comm_id]
-        self._safe_handle(msg, comm.handle_close)
+        self._safe_handle(msg, comm.handle_close, name='comm_close')
 
     def _comm_is_not_valid(self, comm, comm_id):
         invalid = comm is None
@@ -125,11 +125,11 @@ class CommManager(LoggingConfigurable):
         comm_id = content['comm_id']
         return (comm_id, self.get_comm(comm_id))
 
-    def _safe_handle(self, msg, callback):
+    def _safe_handle(self, msg, callback, name = ''):
         try:
             callback(msg)
         except Exception:
-            self.log.error('Exception handling ' + callback.__name__ + ' for %s', msg['content']['comm_id'], exc_info=True)
+            self.log.error('Exception handling ' + name + ' for %s', msg['content']['comm_id'], exc_info=True)
 
 
 __all__ = ['CommManager']

--- a/ipykernel/comm/manager.py
+++ b/ipykernel/comm/manager.py
@@ -6,8 +6,6 @@
 import sys
 
 from traitlets.config import LoggingConfigurable
-from IPython.core.prompts import LazyEvaluate
-from IPython.core.getipython import get_ipython
 
 from ipython_genutils.importstring import import_item
 from ipython_genutils.py3compat import string_types
@@ -16,35 +14,10 @@ from traitlets import Instance, Unicode, Dict, Any, default
 from .comm import Comm
 
 
-def lazy_keys(dikt):
-    """Return lazy-evaluated string representation of a dictionary's keys
-
-    Key list is only constructed if it will actually be used.
-    Used for debug-logging.
-    """
-    return LazyEvaluate(lambda d: list(d.keys()))
-
-
 class CommManager(LoggingConfigurable):
     """Manager for Comms in the Kernel"""
 
-    # If this is instantiated by a non-IPython kernel, shell will be None
-    shell = Instance('IPython.core.interactiveshell.InteractiveShellABC',
-                     allow_none=True)
     kernel = Instance('ipykernel.kernelbase.Kernel')
-
-    iopub_socket = Any()
-
-    @default('iopub_socket')
-    def _default_iopub_socket(self):
-        return self.kernel.iopub_socket
-
-    session = Instance('jupyter_client.session.Session')
-
-    @default('session')
-    def _default_session(self):
-        return self.kernel.session
-
     comms = Dict()
     targets = Dict()
 
@@ -67,14 +40,12 @@ class CommManager(LoggingConfigurable):
 
     def unregister_target(self, target_name, f):
         """Unregister a callable registered with register_target"""
-        return self.targets.pop(target_name);
+        return self.targets.pop(target_name)
 
     def register_comm(self, comm):
         """Register a new comm"""
         comm_id = comm.comm_id
-        comm.shell = self.shell
         comm.kernel = self.kernel
-        comm.iopub_socket = self.iopub_socket
         self.comms[comm_id] = comm
         return comm_id
 
@@ -91,13 +62,12 @@ class CommManager(LoggingConfigurable):
         This will not raise an error,
         it will log messages if the comm cannot be found.
         """
-        if comm_id not in self.comms:
+        try:
+            return self.comms[comm_id]
+        except KeyError:
             self.log.warn("No such comm: %s", comm_id)
-            self.log.debug("Current comms: %s", lazy_keys(self.comms))
-            return
-        # call, because we store weakrefs
-        comm = self.comms[comm_id]
-        return comm
+            if self.log.isEnabledFor(self.log.DEBUG):
+                self.log.debug("Current comms: %s", self.comms.keys())
 
     # Message handlers
     def comm_open(self, stream, ident, msg):
@@ -107,9 +77,6 @@ class CommManager(LoggingConfigurable):
         target_name = content['target_name']
         f = self.targets.get(target_name, None)
         comm = Comm(comm_id=comm_id,
-                    shell=self.shell,
-                    kernel=self.kernel,
-                    iopub_socket=self.iopub_socket,
                     primary=False,
                     target_name=target_name,
         )
@@ -132,32 +99,37 @@ class CommManager(LoggingConfigurable):
 
     def comm_msg(self, stream, ident, msg):
         """Handler for comm_msg messages"""
-        content = msg['content']
-        comm_id = content['comm_id']
-        comm = self.get_comm(comm_id)
-        if comm is None:
-            # no such comm
+        comm_id, comm = self._get_id_and_comm(msg)
+        if self._comm_is_not_valid(comm, comm_id):
             return
-        try:
-            comm.handle_msg(msg)
-        except Exception:
-            self.log.error("Exception in comm_msg for %s", comm_id, exc_info=True)
+
+        self._safe_handle(msg, comm.handle_msg)
 
     def comm_close(self, stream, ident, msg):
         """Handler for comm_close messages"""
+        comm_id, comm = self._get_id_and_comm(msg)
+        if self._comm_is_not_valid(comm, comm_id):
+            return
+
+        del self.comms[comm_id]
+        self._safe_handle(msg, comm.handle_close)
+
+    def _comm_is_not_valid(self, comm, comm_id):
+        invalid = comm is None
+        if invalid:
+            self.log.debug('No such comm: ', str(comm_id))
+        return not invalid
+
+    def _get_id_and_comm(self, msg):
         content = msg['content']
         comm_id = content['comm_id']
-        comm = self.get_comm(comm_id)
-        if comm is None:
-            # no such comm
-            self.log.debug("No such comm to close: %s", comm_id)
-            return
-        del self.comms[comm_id]
+        return (comm_id, self.get_comm(comm_id))
 
+    def _safe_handle(self, msg, callback):
         try:
-            comm.handle_close(msg)
+            callback(msg)
         except Exception:
-            self.log.error("Exception handling comm_close for %s", comm_id, exc_info=True)
+            self.log.error('Exception handling ' + callback.__name__ + ' for %s', msg['content']['comm_id'], exc_info=True)
 
 
 __all__ = ['CommManager']

--- a/ipykernel/ipkernel.py
+++ b/ipykernel/ipkernel.py
@@ -54,8 +54,7 @@ class IPythonKernel(KernelBase):
         # TMP - hack while developing
         self.shell._reply_content = None
 
-        self.comm_manager = CommManager(shell=self.shell, parent=self,
-                                        kernel=self)
+        self.comm_manager = CommManager(kernel=self)
 
         self.shell.configurables.append(self.comm_manager)
         comm_msg_types = [ 'comm_open', 'comm_msg', 'comm_close' ]
@@ -126,7 +125,7 @@ class IPythonKernel(KernelBase):
 
     def init_metadata(self, parent):
         """Initialize metadata.
-        
+
         Run at the beginning of each execution request.
         """
         md = super(IPythonKernel, self).init_metadata(parent)
@@ -137,10 +136,10 @@ class IPythonKernel(KernelBase):
             'engine' : self.ident,
         })
         return md
-    
+
     def finish_metadata(self, parent, metadata, reply_content):
         """Finish populating metadata.
-        
+
         Run after completing an execution request.
         """
         # FIXME: remove deprecated ipyparallel-specific code
@@ -359,7 +358,7 @@ class IPythonKernel(KernelBase):
                 reply_content.update(shell._reply_content)
                 # reset after use
                 shell._reply_content = None
-                
+
                 # FIXME: deprecate piece for ipyparallel:
                 e_info = dict(engine_uuid=self.ident, engine_id=self.int_id, method='apply')
                 reply_content['engine_info'] = e_info

--- a/ipykernel/ipkernel.py
+++ b/ipykernel/ipkernel.py
@@ -54,7 +54,7 @@ class IPythonKernel(KernelBase):
         # TMP - hack while developing
         self.shell._reply_content = None
 
-        self.comm_manager = CommManager(kernel=self)
+        self.comm_manager = CommManager(parent=self, kernel=self)
 
         self.shell.configurables.append(self.comm_manager)
         comm_msg_types = [ 'comm_open', 'comm_msg', 'comm_close' ]


### PR DESCRIPTION
Howdy,

This is a general fix-up across the Comm and CommManager classes - there was quite a lot of redundant/duplicate code which has been cleaned up. There’s also a few performance items here - eg.  multiple identical dict lookups in the same function.

I deliberately haven’t made whitespace changes, but the editor has auto-cleaned up some trailing whitespace.

The biggest changes (which need input from @minrk @takluyver) are the removal of `session` and `iopub_socket` from Comm and CommManager. The tests pass and i can't find any places where these items are used directly, but it could do with some thought from you.

Their use on CommManager was only to be passed into the Comm objects (which happened in 2 places), and their use on Comm objects is restricted to a single method, so it's simpler to just take them from the kernel object that needs passing down the hierarchy anyway. 

ipykernel/comm/manager.py

- [x] Removed lazy_keys function as it’s completely broken. There was only one use which was in a logging statement, and there was an error in the function definition because the single `dikt` argument wasn’t used. This would have caused a runtime exception had the code ever been hit. Have replaced the single use with a direct check of the logging level, which is more obviously correct to readers.
- [x] Removed incorrect comment - `# call, because we store weak refs`. The item wasn’t called, and it’s not storing weak refs.
- [x] Fixed get_comm to not perform the dict lookup twice.
- [x] Removed session from CommManager. It’s not used internally, and the only instantiation of a comm manager i can find is on the kernel, in which case kernel.session is the correct, direct lookup.
- [x] Reduced duplication of code between comm_msg and comm_close.
- [x] Removed duplication of code between register_comm and comm_open. comm_open calls register_comm anyway, so theres no need to set the shell, kernel and iopub_socket twice.
- [x] Removed iopub_socket, because with the previous change it’s only used internally in a single place, and there’s no need for the CommManager to know about it (can be taken directly from `kernel`. 
- [x] Removed shell, because with the previous changes it’s only used when being set on the comm objects, and they can just take it from the kernel object.
- [x] Removed unused imports.
- [x] Removed an EOL semi-colon.

Overall these changes reduce the line count by about  20%, whilst also making the code more efficient, and easier to understand (i.e., smaller methods).


ipykernel/comm/comm.py

- [x] Remove `shell` trait, because it’s only used in one method (and only then if a message callback is set), and there’s no need for the comm objects to know about it when that method can pull it off of `kernel`.
- [x] Remove `iopub` for the same reason as `shell` above.
- [x] Remove `session` for the same reason.


ipykernel/ipykernel.py

- [x] Removed the redundant `shell` and `parent` args from being passed into CommManager.