### PR TITLE
The python logging module no longer seems to work properly inside a notebook

### DIFF
--- a/ipykernel/iostream.py
+++ b/ipykernel/iostream.py
@@ -12,7 +12,6 @@ import sys
 import threading
 import uuid
 import warnings
-import logging
 from io import StringIO, UnsupportedOperation
 
 import zmq
@@ -51,7 +50,6 @@ class IOPubThread(object):
         self.background_socket = BackgroundSocket(self)
         self._master_pid = os.getpid()
         self._pipe_flag = pipe
-        self._setup_tornado_logger()
         self.io_loop = IOLoop()
         if pipe:
             self._setup_pipe_in()
@@ -159,19 +157,6 @@ class IOPubThread(object):
             pipe_out.send_multipart([self._pipe_uuid] + msg, *args, **kwargs)
             pipe_out.close()
             ctx.term()
-
-    def _setup_tornado_logger(self):
-        """ Must set up the tornado logger or else tornado will call
-            basicConfig for the root logger which makes the root logger
-            go to the real sys.stderr instead of the capture streams.
-            This function mimics the setup of logging.basicConfig.
-        """
-        logger = logging.getLogger('tornado')
-        handler = logging.StreamHandler()
-        formatter = logging.Formatter(logging.BASIC_FORMAT)
-        handler.setFormatter(formatter)
-        logger.addHandler(handler)
-
 
 
 class BackgroundSocket(object):

--- a/ipykernel/iostream.py
+++ b/ipykernel/iostream.py
@@ -12,6 +12,7 @@ import sys
 import threading
 import uuid
 import warnings
+import logging
 from io import StringIO, UnsupportedOperation
 
 import zmq
@@ -50,6 +51,7 @@ class IOPubThread(object):
         self.background_socket = BackgroundSocket(self)
         self._master_pid = os.getpid()
         self._pipe_flag = pipe
+        self._setup_tornado_logger()
         self.io_loop = IOLoop()
         if pipe:
             self._setup_pipe_in()
@@ -157,6 +159,15 @@ class IOPubThread(object):
             pipe_out.send_multipart([self._pipe_uuid] + msg, *args, **kwargs)
             pipe_out.close()
             ctx.term()
+
+    def _setup_tornado_logger(self):
+        """ Must set up the tornado logger or else tornado will call
+            basicConfig for the root logger which makes the root logger
+            go to the real sys.stderr instead of the capture streams.
+        """
+        logger = logging.getLogger('tornado')
+        logger.addHandler(logging.StreamHandler())
+
 
 
 class BackgroundSocket(object):

--- a/ipykernel/iostream.py
+++ b/ipykernel/iostream.py
@@ -164,9 +164,13 @@ class IOPubThread(object):
         """ Must set up the tornado logger or else tornado will call
             basicConfig for the root logger which makes the root logger
             go to the real sys.stderr instead of the capture streams.
+            This function mimics the setup of logging.basicConfig.
         """
         logger = logging.getLogger('tornado')
-        logger.addHandler(logging.StreamHandler())
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(logging.BASIC_FORMAT)
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
 
 
 

--- a/ipykernel/kernelapp.py
+++ b/ipykernel/kernelapp.py
@@ -404,7 +404,9 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp,
         # END HARDCODED WIDGETS HACK
 
     def configure_tornado_logger(self):
-        """ Must set up the tornado logger or else tornado will call
+        """ Configure the tornado logging.Logger.
+
+            Must set up the tornado logger or else tornado will call
             basicConfig for the root logger which makes the root logger
             go to the real sys.stderr instead of the capture streams.
             This function mimics the setup of logging.basicConfig.

--- a/ipykernel/kernelapp.py
+++ b/ipykernel/kernelapp.py
@@ -10,6 +10,7 @@ import os
 import sys
 import signal
 import traceback
+import logging
 
 import zmq
 from zmq.eventloop import ioloop
@@ -250,6 +251,7 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp,
         self.iopub_socket.linger = 1000
         self.iopub_port = self._bind_socket(self.iopub_socket, self.iopub_port)
         self.log.debug("iopub PUB Channel on port: %i" % self.iopub_port)
+        self.init_tornado_logger()
         self.iopub_thread = IOPubThread(self.iopub_socket, pipe=True)
         self.iopub_thread.start()
         # backward-compat: wrap iopub socket API in background thread
@@ -400,6 +402,18 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp,
             except ImportError as e:
                 self.log.debug('ipywidgets package not installed.  Widgets will not be available.')
         # END HARDCODED WIDGETS HACK
+
+    def init_tornado_logger(self):
+        """ Must set up the tornado logger or else tornado will call
+            basicConfig for the root logger which makes the root logger
+            go to the real sys.stderr instead of the capture streams.
+            This function mimics the setup of logging.basicConfig.
+        """
+        logger = logging.getLogger('tornado')
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(logging.BASIC_FORMAT)
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
 
     @catch_config_error
     def initialize(self, argv=None):

--- a/ipykernel/kernelapp.py
+++ b/ipykernel/kernelapp.py
@@ -251,7 +251,7 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp,
         self.iopub_socket.linger = 1000
         self.iopub_port = self._bind_socket(self.iopub_socket, self.iopub_port)
         self.log.debug("iopub PUB Channel on port: %i" % self.iopub_port)
-        self.init_tornado_logger()
+        self.configure_tornado_logger()
         self.iopub_thread = IOPubThread(self.iopub_socket, pipe=True)
         self.iopub_thread.start()
         # backward-compat: wrap iopub socket API in background thread
@@ -403,7 +403,7 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp,
                 self.log.debug('ipywidgets package not installed.  Widgets will not be available.')
         # END HARDCODED WIDGETS HACK
 
-    def init_tornado_logger(self):
+    def configure_tornado_logger(self):
         """ Must set up the tornado logger or else tornado will call
             basicConfig for the root logger which makes the root logger
             go to the real sys.stderr instead of the capture streams.


### PR DESCRIPTION
This pull request fixes this issue: https://github.com/jupyter/notebook/issues/1397

For the sake of completeness, I'll repeat the issue here (edited according to the discussion on https://github.com/jupyter/notebook/issues/1397).

When running the example from the python logging documentation page in a jupyter notebook, the messages go to the notebook console as opposed to the notebook's webpage output via the capture mechanism. Just create an empty notebook, run the example below, you'll see what I mean.

```python
import logging
logging.basicConfig(format='%(levelname)s:%(message)s', level=logging.DEBUG)
logging.debug('This message should appear in the notebook')
logging.info('So should this')
logging.warning('And this, too')
```

What should happen: The messages appear in the notebook.
What actually happens: The messages don't appear in the notebook.

The issue is caused by:
- When jupyter runs a notebook, it spawns a subprocess for the notebook.
- The subprocess spawns an ZMQ IOLoop thread.
- The IOLoop thread creates a tornado IO loop.
- The tornad IO loop checks to see if there's any logger configured, and if not calls `logging.basicConfig()`.
- `logging.basicConfig()` will then set up the root logger (`logging.root`) to use a default `StreamHandler`.
- `StreamHandler` when not given a stream defaults to `sys.stderr`.
- at that point `sys.stderr` is not the ipykernel captured output yet, it will be set later.

Just to be clear, this is the IOLoop on the side of the subprocess, not on the side of the jupyter server.

The tornado code that calls `basicConfig` is:
https://github.com/tornadoweb/tornado/blob/stable/tornado/ioloop.py#L360
```python
   def _setup_logging(self):
       if not any([logging.getLogger().handlers,
                   logging.getLogger('tornado').handlers,
                   logging.getLogger('tornado.application').handlers]):
            logging.basicConfig()

```

I've added the `IOPubThread._setup_tornado_logger()` method which will just add a default `StreamHandler` to the `tornado` logger. This will stop tornado from calling basicConfig, so the actual user can configure the root logger.

With this patch, the code at the beginning of this comment works as expected in a notebook.
