### PR TITLE
Dummy inprocess Session key

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,12 @@ Changes in IPython kernel
 4.3
 ---
 
+4.3.2
+*****
+
+- Use a nonempty dummy session key for inprocess kernels to avoid security
+  warnings.
+
 4.3.1
 *****
 

--- a/ipykernel/inprocess/constants.py
+++ b/ipykernel/inprocess/constants.py
@@ -1,0 +1,8 @@
+"""Shared constants.
+"""
+
+# Because inprocess communication is not networked, we can use a common Session
+# key everywhere. This is not just the empty bytestring to avoid tripping
+# certain security checks in the rest of Jupyter that assumes that empty keys
+# are insecure.
+INPROCESS_KEY = b'inprocess'

--- a/ipykernel/inprocess/ipkernel.py
+++ b/ipykernel/inprocess/ipkernel.py
@@ -13,6 +13,7 @@ from traitlets import Any, Enum, Instance, List, Type, default
 from ipykernel.ipkernel import IPythonKernel
 from ipykernel.zmqshell import ZMQInteractiveShell
 
+from .constants import INPROCESS_KEY
 from .socket import DummySocket
 from ..iostream import OutStream, BackgroundSocket, IOPubThread
 
@@ -139,7 +140,7 @@ class InProcessKernel(IPythonKernel):
     @default('session')
     def _default_session(self):
         from jupyter_client.session import Session
-        return Session(parent=self, key=b'')
+        return Session(parent=self, key=INPROCESS_KEY)
 
     @default('shell_class')
     def _default_shell_class(self):

--- a/ipykernel/inprocess/manager.py
+++ b/ipykernel/inprocess/manager.py
@@ -8,6 +8,8 @@ from jupyter_client.managerabc import KernelManagerABC
 from jupyter_client.manager import KernelManager
 from jupyter_client.session import Session
 
+from .constants import INPROCESS_KEY
+
 
 class InProcessKernelManager(KernelManager):
     """A manager for an in-process kernel.
@@ -33,7 +35,7 @@ class InProcessKernelManager(KernelManager):
     @default('session')
     def _default_session(self):
         # don't sign in-process messages
-        return Session(key=b'', parent=self)
+        return Session(key=INPROCESS_KEY, parent=self)
 
     #--------------------------------------------------------------------------
     # Kernel management methods


### PR DESCRIPTION
Use a nonempty dummy `Session` key for inprocess kernels. At present, instantiating a `Session` object with an empty key triggers a security warning that is not relevant to inprocess kernels.

Fixes #130
Fixes jupyter/qtconsole#119