### PR TITLE
Enable deprecation warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ sudo: false
 before_install:
     - git clone --quiet --depth 1 https://github.com/minrk/travis-wheels travis-wheels
 install:
-    - pip install -f travis-wheels/wheelhouse --pre -e . codecov
+    - pip install -f travis-wheels/wheelhouse --pre -e . codecov nose_warnings_filters
     - pip install -f travis-wheels/wheelhouse ipykernel[test]
     - python -c 'import ipykernel.kernelspec; ipykernel.kernelspec.install(user=True)'
 script:

--- a/ipykernel/pylab/config.py
+++ b/ipykernel/pylab/config.py
@@ -16,7 +16,7 @@ This module does not import anything from matplotlib.
 from traitlets.config import Config
 from traitlets.config.configurable import SingletonConfigurable
 from traitlets import (
-    Dict, Instance, CaselessStrEnum, Set, Bool, Int, TraitError, Unicode
+    Dict, Instance, Set, Bool, TraitError, Unicode
 )
 from IPython.utils.warn import warn
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,13 @@
 [bdist_wheel]
 universal=1
+
+[nosetests]
+warningfilters= default         |.*                 |DeprecationWarning |ipykernel.*
+                default         |.*                 |DeprecationWarning |IPython.*
+                ignore          |.*assert.*         |DeprecationWarning |.* 
+                ignore          |.*observe.*        |DeprecationWarning |IPython.*
+                ignore          |.*default.*        |DeprecationWarning |IPython.*
+                ignore          |.*default.*        |DeprecationWarning |jupyter_client.*
+                ignore          |.*Metada.*         |DeprecationWarning |IPython.*
+                
+                


### PR DESCRIPTION
it seem to show the IPython deprecation warnings for me locally, though even if these are in 4.2 they don't seem to appear on travis...