### PR TITLE
import IOLoop from tornado

### DIFF
--- a/ipykernel/comm/comm.py
+++ b/ipykernel/comm/comm.py
@@ -6,7 +6,7 @@
 import threading
 import uuid
 
-from zmq.eventloop.ioloop import IOLoop
+from tornado.ioloop import IOLoop
 
 from traitlets.config import LoggingConfigurable
 from ipykernel.kernelbase import Kernel

--- a/ipykernel/kernelapp.py
+++ b/ipykernel/kernelapp.py
@@ -12,8 +12,9 @@ import signal
 import traceback
 import logging
 
+from tornado import ioloop
 import zmq
-from zmq.eventloop import ioloop
+from zmq.eventloop import ioloop as zmq_ioloop
 from zmq.eventloop.zmqstream import ZMQStream
 
 from IPython.core.application import (
@@ -422,6 +423,8 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp,
         super(IPKernelApp, self).initialize(argv)
         if self.subapp is not None:
             return
+        # register zmq IOLoop with tornado
+        zmq_ioloop.install()
         self.init_blackhole()
         self.init_connection_file()
         self.init_poller()

--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -14,7 +14,7 @@ from datetime import datetime
 from signal import signal, default_int_handler, SIGINT
 
 import zmq
-from zmq.eventloop import ioloop
+from tornado import ioloop
 from zmq.eventloop.zmqstream import ZMQStream
 
 from traitlets.config.configurable import SingletonConfigurable

--- a/ipykernel/zmqshell.py
+++ b/ipykernel/zmqshell.py
@@ -23,7 +23,7 @@ import time
 import warnings
 from threading import local
 
-from zmq.eventloop import ioloop
+from tornado import ioloop
 
 from IPython.core.interactiveshell import (
     InteractiveShell, InteractiveShellABC


### PR DESCRIPTION
rather than from zmq

rely on zmq_ioloop.install() to register zmq implementation as default.