### PR TITLE
Make inline the default matplotlib backend

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,21 @@
 Changes in IPython kernel
 =========================
 
+4.4
+---
+
+4.4.0
+*****
+
+`4.4.0 on GitHub <https://github.com/ipython/ipykernel/milestones/4.4>`__
+
+- Use `MPLBACKEND`_ environment variable to tell matplotlib >= 1.5 use use the inline backend by default.
+  This is only done if MPLBACKEND is not already set and no backend has been explicitly loaded,
+  so setting ``MPLBACKEND=Qt4Agg`` or calling ``%matplotlib notebook`` or ``matplotlib.use('Agg')``
+  will take precedence.
+
+.. _MPLBACKEND: http://matplotlib.org/devel/coding_guide.html?highlight=mplbackend#developing-a-new-backend
+
 4.3
 ---
 

--- a/ipykernel/kernelapp.py
+++ b/ipykernel/kernelapp.py
@@ -368,6 +368,13 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp,
     def init_gui_pylab(self):
         """Enable GUI event loop integration, taking pylab into account."""
 
+        # Register inline backend as default
+        # this is higher priority than matplotlibrc,
+        # but lower priority than anything else (mpl.use() for instance).
+        # This only affects matplotlib >= 1.5
+        if not os.environ.get('MPLBACKEND'):
+            os.environ['MPLBACKEND'] = 'module://ipykernel.pylab.backend_inline'
+
         # Provide a wrapper for :meth:`InteractiveShellApp.init_gui_pylab`
         # to ensure that any exception is printed straight to stderr.
         # Normally _showtraceback associates the reply with an execution,

--- a/ipykernel/pylab/backend_inline.py
+++ b/ipykernel/pylab/backend_inline.py
@@ -143,3 +143,14 @@ def flush_figures():
 # figurecanvas. This is set here to a Agg canvas
 # See https://github.com/matplotlib/matplotlib/pull/1125
 FigureCanvas = FigureCanvasAgg
+
+def _enable_matplotlib_integration():
+    """Enable extra IPython matplotlib integration when we are loaded as the matplotlib backend."""
+    from matplotlib import get_backend
+    from IPython.core.pylabtools import configure_inline_support
+    ip = get_ipython()
+    backend = get_backend()
+    if ip and backend == 'module://%s' % __name__:
+        configure_inline_support(ip, backend)
+
+_enable_matplotlib_integration()


### PR DESCRIPTION
uses recently discovered (c/o @weathergod) MPLBACKEND env (matplotlib > 1.5) to make inline the 'default' backend, for users who don't call `matplotlib.use()` or `%matplotlib` prior to plotting.

Trigger extra IPython inline setup when inline backend is loaded. We can't call the simpler `ip.enable_matplotlib()` here because this will be triggered during pyplot import, and enable_matplotlib() imports pyplot which isn't ready yet.

This PR is a sibling of https://github.com/matplotlib/matplotlib/pull/6734

With both PRs, users importing matplotlib and using it without calling `%matplotlib <anything>` should get reasonable behavior in all of:

- terminal IPython (including 5, where GUI eventloops won't hang anymore)
- qtconsole (inline backend default, gui backends won't hang)
- notebook (same)

Either PR independently solves the hang in notebooks, but together they should do what we have been wanting for a long time.
This should remove the need for us to do anything with an import hook (#82).

SciPy hallway discussions FTW!

cc @tacaswell @mdboom @takluyver @fperez