### PR TITLE
Ensure basic displayhook sends valid execute_result messages

### DIFF
--- a/ipykernel/displayhook.py
+++ b/ipykernel/displayhook.py
@@ -22,6 +22,10 @@ class ZMQDisplayHook(object):
         self.pub_socket = pub_socket
         self.parent_header = {}
 
+    def get_execution_count(self):
+        """This method is replaced in kernelapp"""
+        return 0
+
     def __call__(self, obj):
         if obj is None:
             return
@@ -29,7 +33,10 @@ class ZMQDisplayHook(object):
         builtin_mod._ = obj
         sys.stdout.flush()
         sys.stderr.flush()
-        self.session.send(self.pub_socket, u'execute_result', {u'data':repr(obj)},
+        contents = {u'execution_count': self.get_execution_count(),
+                    u'data': {'text/plain': repr(obj)},
+                    u'metadata': {}}
+        self.session.send(self.pub_socket, u'execute_result', contents,
                           parent=self.parent_header, ident=self.topic)
 
     def set_parent(self, parent):

--- a/ipykernel/kernelapp.py
+++ b/ipykernel/kernelapp.py
@@ -314,7 +314,8 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp,
             sys.stderr = outstream_factory(self.session, self.iopub_thread, u'stderr')
         if self.displayhook_class:
             displayhook_factory = import_item(str(self.displayhook_class))
-            sys.displayhook = displayhook_factory(self.session, self.iopub_socket)
+            self.displayhook = displayhook_factory(self.session, self.iopub_socket)
+            sys.displayhook = self.displayhook
 
         self.patch_io()
 
@@ -364,6 +365,9 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp,
         )
         kernel.record_ports(self.ports)
         self.kernel = kernel
+
+        # Allow the displayhook to get the execution count
+        self.displayhook.get_execution_count = lambda: kernel.execution_count
 
     def init_gui_pylab(self):
         """Enable GUI event loop integration, taking pylab into account."""


### PR DESCRIPTION
This fixes a crash I was seeing with the xonsh kernel.

Closes gh-161