### PR TITLE
Add a --profile flag to kernel install

### DIFF
--- a/ipykernel/kernelspec.py
+++ b/ipykernel/kernelspec.py
@@ -50,7 +50,7 @@ def make_ipkernel_cmd(mod='ipykernel', executable=None, extra_arguments=None, **
     return arguments
 
 
-def get_kernel_dict(extra_arguments):
+def get_kernel_dict(extra_arguments=None):
     """Construct dict for kernel.json"""
     return {
         'argv': make_ipkernel_cmd(extra_arguments=extra_arguments),

--- a/ipykernel/kernelspec.py
+++ b/ipykernel/kernelspec.py
@@ -118,12 +118,14 @@ def install(kernel_spec_manager=None, user=False, kernel_name=KERNEL_NAME, displ
         # kernel_name is specified and display_name is not
         # default display_name to kernel_name
         display_name = kernel_name
+    overrides = {}
     if display_name:
-        overrides = dict(display_name=display_name)
-    else:
-        overrides = None
+        overrides["display_name"] = display_name
     if profile:
         extra_arguments = ["--profile", profile]
+        if not display_name:
+            # add the profile to the default display name
+            overrides["display_name"] = 'Python %i [profile=%s]' % (sys.version_info[0], profile)
     else:
         extra_arguments = None
     path = write_kernel_spec(overrides=overrides, extra_arguments=extra_arguments)

--- a/ipykernel/kernelspec.py
+++ b/ipykernel/kernelspec.py
@@ -84,7 +84,7 @@ def write_kernel_spec(path=None, overrides=None, extra_arguments=None):
 
 
 def install(kernel_spec_manager=None, user=False, kernel_name=KERNEL_NAME, display_name=None,
-            profile=None, prefix=None):
+            prefix=None, profile=None):
     """Install the IPython kernelspec for Jupyter
     
     Parameters

--- a/ipykernel/tests/test_kernelspec.py
+++ b/ipykernel/tests/test_kernelspec.py
@@ -52,6 +52,18 @@ def test_get_kernel_dict():
     assert_kernel_dict(d)
 
 
+def assert_kernel_dict_with_profile(d):
+    nt.assert_equal(d['argv'], make_ipkernel_cmd(
+        extra_arguments=["--profile", "test"]))
+    nt.assert_equal(d['display_name'], 'Python %i' % sys.version_info[0])
+    nt.assert_equal(d['language'], 'python')
+
+
+def test_get_kernel_dict_with_profile():
+    d = get_kernel_dict(["--profile", "test"])
+    assert_kernel_dict_with_profile(d)
+
+
 def assert_is_spec(path):
     for fname in os.listdir(RESOURCES):
         dst = pjoin(path, fname)

--- a/ipykernel/tests/test_kernelspec.py
+++ b/ipykernel/tests/test_kernelspec.py
@@ -119,3 +119,28 @@ def test_install():
     assert_is_spec(os.path.join(system_jupyter_dir, 'kernels', KERNEL_NAME))
 
 
+def test_install_profile():
+    system_jupyter_dir = tempfile.mkdtemp()
+
+    with mock.patch('jupyter_client.kernelspec.SYSTEM_JUPYTER_PATH',
+            [system_jupyter_dir]):
+        install(profile="Test")
+
+    spec = os.path.join(system_jupyter_dir, 'kernels', KERNEL_NAME, "kernel.json")
+    with open(spec) as f:
+        spec = json.load(f)
+    nt.assert_true(spec["display_name"].endswith(" [profile=Test]"))
+    nt.assert_equal(spec["argv"][-2:], ["--profile", "Test"])
+
+
+def test_install_display_name_overrides_profile():
+    system_jupyter_dir = tempfile.mkdtemp()
+
+    with mock.patch('jupyter_client.kernelspec.SYSTEM_JUPYTER_PATH',
+            [system_jupyter_dir]):
+        install(display_name="Display", profile="Test")
+
+    spec = os.path.join(system_jupyter_dir, 'kernels', KERNEL_NAME, "kernel.json")
+    with open(spec) as f:
+        spec = json.load(f)
+    nt.assert_equal(spec["display_name"], "Display")


### PR DESCRIPTION
E.g.
```
$ ipython kernel install --name=mypython --profile=myprofile --user
```
The idea is to be able to configure the kernel to always use a given IPython profile. This could be pretty useful for creating custom versions of the ipykernel.

I realised that there was already almost support for this in the code, I just added a new argument and hooked it up to the internals. 