### PR TITLE
Workaround circular imports in pylabtools on Python 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,10 @@ before_install:
 install:
     - pip install -f travis-wheels/wheelhouse --pre -e . codecov nose_warnings_filters
     - pip install -f travis-wheels/wheelhouse ipykernel[test] nose-timer
+    - |
+      if [[ "$TRAVIS_PYTHON_VERSION" != "3.3" ]]; then
+        pip install matplotlib
+      fi
     - python -c 'import ipykernel.kernelspec; ipykernel.kernelspec.install(user=True)'
 script:
     - nosetests --with-coverage --with-timer --cover-package  ipykernel ipykernel

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,14 @@ Changes in IPython kernel
 4.4
 ---
 
+4.4.1
+*****
+
+`4.4.1 on GitHub <https://github.com/ipython/ipykernel/milestones/4.4.1>`__
+
+- Fix circular import of matplotlib on Python 2 caused by the inline backend changes in 4.4.0.
+
+
 4.4.0
 *****
 

--- a/ipykernel/pylab/backend_inline.py
+++ b/ipykernel/pylab/backend_inline.py
@@ -147,10 +147,17 @@ FigureCanvas = FigureCanvasAgg
 def _enable_matplotlib_integration():
     """Enable extra IPython matplotlib integration when we are loaded as the matplotlib backend."""
     from matplotlib import get_backend
-    from IPython.core.pylabtools import configure_inline_support
     ip = get_ipython()
     backend = get_backend()
     if ip and backend == 'module://%s' % __name__:
-        configure_inline_support(ip, backend)
+        from IPython.core.pylabtools import configure_inline_support
+        try:
+            configure_inline_support(ip, backend)
+        except ImportError:
+            # bugs may cause a circular import on Python 2
+            def configure_once(*args):
+                configure_inline_support(ip, backend)
+                ip.events.unregister('post_run_cell', configure_once)
+            ip.events.register('post_run_cell', configure_once)
 
 _enable_matplotlib_integration()


### PR DESCRIPTION
Calling `pylabtools.configure_inline_support` on import of the inline backend causes circular imports on Python 2 due to an unnecessary import of pyplot in that function (fixed by ipython/ipython#9850).

This works around that problem by scheduling the configure call to happen at the end of the IPython cell if it fails. The downside of this is that inline figure display formatters will not be registered in the cell containing the import. I'm not *too* bothered by this, because it only affects explicit `display(fig)` calls, not anything triggered by matplotlib's own `show` or implicit draw_if_interactive that provide most figure display. Plus, IPython 5.1 will fix it.

I can come up with a more resilient fix that *moves* much of the inline setup to this repo in the long run, but I think this is sufficient for 4.4.1.

closes #173

cc @takluyver @xflr6