### PR TITLE
Set the dpi with figure.dpi instead of savefig.dpi

### DIFF
--- a/ipykernel/pylab/config.py
+++ b/ipykernel/pylab/config.py
@@ -50,7 +50,7 @@ class InlineBackend(InlineBackendConfig):
         'font.size': 10,
         # 72 dpi matches SVG/qtconsole
         # this only affects PNG export, as SVG has no dpi setting
-        'savefig.dpi': 72,
+        'figure.dpi': 72,
         # 10pt still needs a little more room on the xlabel:
         'figure.subplot.bottom' : .125
         },


### PR DESCRIPTION
This makes changing the dpi more straight forward and
controllable within a context.

For example, the code below now works as expected.

```python
with mpl.rc_context():
    mpl.rcParams['figure.dpi'] = 200
    mpl.rcParams['figure.figsize'] = (6, 4)
    ax = plt.subplot(111)
    ax.scatter([1, 2], [1, 2])
```

Without this commit and the accompanying commit in `ipython`,
the `dpi` would be queried directly from the `rcParams` and
this would happen outside the context. With this commit,
Matplotlib creates a figure with the correct `dpi` as a property
and `ipython` will always use that or modify it accordingly.

Also by using `savefig.dpi`, the internal workings of the backend
were slipping into userspace. `InlineBackend` uses the same method
as used for saving but as far as the user is concerned, what is
happening is an image-display not an image-save.

See also: ipython/ipython/pull/9868