### PR TITLE
Added missing `errors` attribute to OutStream (fixes #177)

### DIFF
--- a/ipykernel/iostream.py
+++ b/ipykernel/iostream.py
@@ -205,6 +205,8 @@ class OutStream(object):
             warnings.warn("pipe argument to OutStream is deprecated and ignored",
                 DeprecationWarning)
         self.encoding = 'UTF-8'
+        # This is necessary for compatibility with Python built-in streams
+        self.errors = None
         self.session = session
         if not isinstance(pub_thread, IOPubThread):
             # Backward-compat: given socket, not thread. Wrap in a thread.


### PR DESCRIPTION
Ref #177