### PR TITLE
comm.shell is an IPython specific; wrapper kernels use this too

### DIFF
--- a/ipykernel/comm/comm.py
+++ b/ipykernel/comm/comm.py
@@ -148,7 +148,10 @@ class Comm(LoggingConfigurable):
         """Handle a comm_msg message"""
         self.log.debug("handle_msg[%s](%s)", self.comm_id, msg)
         if self._msg_callback:
-            shell = self.kernel.shell
+            if hasattr(self.kernel, "shell"):
+                shell = self.kernel.shell
+            else:
+                shell = None
             if shell:
                 shell.events.trigger('pre_execute')
             self._msg_callback(msg)


### PR DESCRIPTION
I'm not sure how long this has been broken for wrapper-kernels, but this causes problems now that we have some more complex displays working (like matplotlib plots).

Here in Comm, shell is a detail from IPython kernels, but not wrapper kernels. I tried to define wrapper-kernel.shell = None, but that causes other issues. 