### PR TITLE
Bugfix for AttributeError: 'Logger' object has no attribute 'DEBUG'

### DIFF
--- a/ipykernel/comm/manager.py
+++ b/ipykernel/comm/manager.py
@@ -4,6 +4,7 @@
 # Distributed under the terms of the Modified BSD License.
 
 import sys
+import logging
 
 from traitlets.config import LoggingConfigurable
 
@@ -66,7 +67,7 @@ class CommManager(LoggingConfigurable):
             return self.comms[comm_id]
         except KeyError:
             self.log.warn("No such comm: %s", comm_id)
-            if self.log.isEnabledFor(self.log.DEBUG):
+            if self.log.isEnabledFor(logging.DEBUG):
                 # don't create the list of keys if debug messages aren't enabled
                 self.log.debug("Current comms: %s", list(self.comms.keys()))
 


### PR DESCRIPTION
in comm manager

I'm not sure whether every configuration was affected, but I encountered this bug with a python 2.7 setup.