### PR TITLE
cast prompt to str in raw_input

### DIFF
--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -684,7 +684,7 @@ class Kernel(SingletonConfigurable):
             raise StdinNotImplementedError(
                 "raw_input was called, but this frontend does not support input requests."
             )
-        return self._input_request(prompt,
+        return self._input_request(str(prompt),
             self._parent_ident,
             self._parent_header,
             password=False,


### PR DESCRIPTION
builtin raw_input does this, so we should, too.

closes https://github.com/jupyter/qtconsole/issues/135