### PR TITLE
KeyboardInterrupt is not abort

### DIFF
--- a/ipykernel/ipkernel.py
+++ b/ipykernel/ipkernel.py
@@ -204,8 +204,6 @@ class IPythonKernel(KernelBase):
 
         if res.success:
             reply_content[u'status'] = u'ok'
-        elif isinstance(err, KeyboardInterrupt):
-            reply_content[u'status'] = u'aborted'
         else:
             reply_content[u'status'] = u'error'
 


### PR DESCRIPTION
abort is a separate action, indicating that the request was not processed, not that a particular error was raised.

Regression in 4.4.

cf https://github.com/jupyter/qtconsole/pull/141