### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -298,6 +298,6 @@ texinfo_documents = [
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
     'https://docs.python.org/': None,
-    'ipython': ('https://ipython.readthedocs.org/en/latest', None),
-    'jupyter': ('https://jupyter.readthedocs.org/en/latest', None),
+    'ipython': ('https://ipython.readthedocs.io/en/latest', None),
+    'jupyter': ('https://jupyter.readthedocs.io/en/latest', None),
 }

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,7 +4,7 @@ IPython Kernel Docs
 ===================
 
 This contains minimal version-sensitive documentation for the IPython kernel package.
-Most IPython kernel documentation is in the `IPython documentation <http://ipython.readthedocs.org/en/latest/>`_.
+Most IPython kernel documentation is in the `IPython documentation <https://ipython.readthedocs.io/en/latest/>`_.
 
 Contents:
 

--- a/ipykernel/zmqshell.py
+++ b/ipykernel/zmqshell.py
@@ -563,7 +563,7 @@ class ZMQInteractiveShell(InteractiveShell):
         # Overridden not to do virtualenv detection, because it's probably
         # not appropriate in a kernel. To use a kernel in a virtualenv, install
         # it inside the virtualenv.
-        # http://ipython.readthedocs.org/en/latest/install/kernel_install.html
+        # https://ipython.readthedocs.io/en/latest/install/kernel_install.html
         pass
 
 


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.