### PR TITLE
remove locks from stdout

### DIFF
--- a/ipykernel/inprocess/socket.py
+++ b/ipykernel/inprocess/socket.py
@@ -31,7 +31,8 @@ class SocketABC(with_metaclass(abc.ABCMeta, object)):
     
     @classmethod
     def register(cls, other_cls):
-        warnings.warn("SocketABC is deprecated.", DeprecationWarning)
+        if other_cls is not DummySocket:
+            warnings.warn("SocketABC is deprecated.", DeprecationWarning)
         abc.ABCMeta.register(cls, other_cls)
 
 #-----------------------------------------------------------------------------
@@ -43,6 +44,9 @@ class DummySocket(HasTraits):
 
     queue = Instance(Queue, ())
     message_sent = Int(0) # Should be an Event
+    context = Instance(zmq.Context)
+    def _context_default(self):
+        return zmq.Context.instance()
 
     #-------------------------------------------------------------------------
     # Socket interface


### PR DESCRIPTION
use inproc push/pull to send events to the IOPub thread

- moves all read/write on the buffer to the IOPub thread
- event callbacks are stored in a dict by ID, the ID is sent on the socket to signal event procesing on the thread.
- removes all Locks
- adds IOPubThread.schedule method for the call-this-in-the-thread action,
  since events should process immediately in cases (e.g. subprocesses) where
  the thread is no longer alive.

closes #198