### PR TITLE
Add stream parameter to getpass

### DIFF
--- a/ipykernel/inprocess/tests/test_kernel.py
+++ b/ipykernel/inprocess/tests/test_kernel.py
@@ -66,3 +66,11 @@ class InProcessKernelTestCase(unittest.TestCase):
         kc.execute('print("bar")')
         out, err = assemble_output(kc.iopub_channel)
         self.assertEqual(out, 'bar\n')
+
+    def test_getpass_stream(self):
+        "Tests that kernel getpass accept the stream parameter"
+        kernel = InProcessKernel()
+        kernel._allow_stdin = True
+        kernel._input_request = lambda *args, **kwargs : None
+
+        kernel.getpass(stream='non empty')

--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -656,7 +656,7 @@ class Kernel(SingletonConfigurable):
         raise StdinNotImplementedError("raw_input was called, but this "
                                        "frontend does not support stdin.")
 
-    def getpass(self, prompt=''):
+    def getpass(self, prompt='', stream=None):
         """Forward getpass to frontends
 
         Raises
@@ -667,6 +667,10 @@ class Kernel(SingletonConfigurable):
             raise StdinNotImplementedError(
                 "getpass was called, but this frontend does not support input requests."
             )
+        if stream is not None:
+            import warnings
+            warnings.warn("The `stream` parameter of `getpass.getpass` will have no effect when using ipykernel",
+                    UserWarning, stacklevel=2)
         return self._input_request(prompt,
             self._parent_ident,
             self._parent_header,


### PR DESCRIPTION

'cause getpass.getpass takes stream as an argument. 