### PR TITLE
Allow Comm.kernel to be None

### DIFF
--- a/ipykernel/comm/comm.py
+++ b/ipykernel/comm/comm.py
@@ -14,7 +14,7 @@ from traitlets import Instance, Unicode, Bytes, Bool, Dict, Any, default
 
 class Comm(LoggingConfigurable):
     """Class for communicating between a Frontend and a Kernel"""
-    kernel = Instance('ipykernel.kernelbase.Kernel')
+    kernel = Instance('ipykernel.kernelbase.Kernel', allow_none=True)
 
     @default('kernel')
     def _default_kernel(self):


### PR DESCRIPTION
We already handle this case and raise a more informative exception in `Comm.open()`

This is another thing causing failures from the recent traitlets change.