### PR TITLE
Add a launcher module to ignore the CWD for imports while ipykernel starts

### DIFF
--- a/ipykernel/kernelspec.py
+++ b/ipykernel/kernelspec.py
@@ -22,7 +22,7 @@ KERNEL_NAME = 'python%i' % sys.version_info[0]
 RESOURCES = pjoin(os.path.dirname(__file__), 'resources')
 
 
-def make_ipkernel_cmd(mod='ipykernel', executable=None, extra_arguments=None, **kw):
+def make_ipkernel_cmd(mod='ipykernel_launcher', executable=None, extra_arguments=None, **kw):
     """Build Popen command list for launching an IPython kernel.
 
     Parameters

--- a/ipykernel/tests/test_kernelspec.py
+++ b/ipykernel/tests/test_kernelspec.py
@@ -35,7 +35,7 @@ def test_make_ipkernel_cmd():
     nt.assert_equal(cmd, [
         sys.executable,
         '-m',
-        'ipykernel',
+        'ipykernel_launcher',
         '-f',
         '{connection_file}'
     ])

--- a/ipykernel_launcher.py
+++ b/ipykernel_launcher.py
@@ -1,0 +1,16 @@
+"""Entry point for launching an IPython kernel.
+
+This is separate from the ipykernel package so we can avoid doing imports until
+after removing the cwd from sys.path.
+"""
+
+import sys
+
+if __name__ == '__main__':
+    # Remove the CWD from sys.path while we load stuff.
+    # This is added back by InteractiveShellApp.init_path()
+    if sys.path[0] == '':
+        del sys.path[0]
+
+    from ipykernel import kernelapp as app
+    app.launch_new_instance()

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ setup_args = dict(
     version         = version_ns['__version__'],
     scripts         = glob(pjoin('scripts', '*')),
     packages        = packages,
+    py_modules      = ['ipykernel_launcher'],
     package_data    = package_data,
     description     = "IPython Kernel for Jupyter",
     author          = 'IPython Development Team',


### PR DESCRIPTION
After helping someone who'd shadowed a stdlib module with a file in the cwd (jupyter/help#97), I realised that we could fairly easily make the kernel able to start in such situations.

This PR adds an ipykernel_launcher module which removes the CWD from sys.path and then launches the kernel. There is already code in IPython which adds the CWD back to sys.path before user code runs.

This doesn't get rid of issues with name clashes: modules that we import will shadow modules of the same name in the cwd. So if you wrote math.py, you wouldn't be able to import it. But I think this is easier
for users to understand than the kernel completely failing to start, especially if it's not easy for them to see the logs showing the error.