### PR TITLE
Use the new IPython completer API

### DIFF
--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -128,7 +128,6 @@ class Kernel(SingletonConfigurable):
 
     def __init__(self, **kwargs):
         super(Kernel, self).__init__(**kwargs)
-
         # Build dict of handlers for message types
         self.shell_handlers = {}
         for msg_type in self.msg_types:
@@ -205,8 +204,6 @@ class Kernel(SingletonConfigurable):
         self.set_parent(idents, msg)
         self._publish_status(u'busy')
 
-        header = msg['header']
-        msg_id = header['msg_id']
         msg_type = msg['header']['msg_type']
 
         # Print some info about this message and leave a '--->' marker, so it's
@@ -421,12 +418,11 @@ class Kernel(SingletonConfigurable):
         content = parent['content']
         code = content['code']
         cursor_pos = content['cursor_pos']
-
+        
         matches = self.do_complete(code, cursor_pos)
         matches = json_clean(matches)
         completion_msg = self.session.send(stream, 'complete_reply',
                                            matches, parent, ident)
-        self.log.debug("%s", completion_msg)
 
     def do_complete(self, code, cursor_pos):
         """Override in subclasses to find completions.

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,12 +2,7 @@
 universal=1
 
 [nosetests]
-warningfilters= default         |.*                 |DeprecationWarning |ipykernel.*
-                default         |.*                 |DeprecationWarning |IPython.*
-                ignore          |.*assert.*         |DeprecationWarning |.* 
-                ignore          |.*observe.*        |DeprecationWarning |IPython.*
-                ignore          |.*default.*        |DeprecationWarning |IPython.*
-                ignore          |.*default.*        |DeprecationWarning |jupyter_client.*
-                ignore          |.*Metada.*         |DeprecationWarning |IPython.*
+warningfilters= default   |.*             |DeprecationWarning |ipykernel.*
+                error     |.*invalid.*    |DeprecationWarning |matplotlib.*
                 
                 


### PR DESCRIPTION
Work in progress, I want to see if I can use the metadata fields for frontends to opt-in to some extra informations.

Also how backward compatible would it be to have a metadata field on the `complete_request` ? My idea is for testing would have been to have an "Accept:" like field for the kernel to know whether to compute the new completions.