### PR TITLE
install kernelspec in wheels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ __pycache__
 \#*#
 .#*
 .coverage
+
+data_kernelspec

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,7 @@ sudo: false
 install:
     - |
       pip install --upgrade setuptools pip
-      python setup.py bdist_wheel
-      pip install --pre dist/*.whl ipykernel[test]
+      pip install --pre . ipykernel[test]
     - |
       if [[ "$TRAVIS_PYTHON_VERSION" == "3.6" ||  "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
         pip install matplotlib

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,13 @@ python:
     - 3.3
     - 2.7
 sudo: false
-before_install:
-    - git clone --quiet --depth 1 https://github.com/minrk/travis-wheels travis-wheels
 install:
-    - pip install -f travis-wheels/wheelhouse --pre .
-    - pip install -f travis-wheels/wheelhouse ipykernel[test] nose-timer
     - |
-      if [[ "$TRAVIS_PYTHON_VERSION" != "3.3" ]]; then
+      pip install --upgrade setuptools pip
+      python setup.py bdist_wheel && pip install --pre dist/*.whl
+      pip install ipykernel[test] nose-timer
+    - |
+      if [[ "$TRAVIS_PYTHON_VERSION" == "3.6" ||  "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
         pip install matplotlib
       fi
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,15 +10,15 @@ sudo: false
 before_install:
     - git clone --quiet --depth 1 https://github.com/minrk/travis-wheels travis-wheels
 install:
-    - pip install -f travis-wheels/wheelhouse --pre -e . codecov nose_warnings_filters
+    - pip install -f travis-wheels/wheelhouse --pre .
     - pip install -f travis-wheels/wheelhouse ipykernel[test] nose-timer
     - |
       if [[ "$TRAVIS_PYTHON_VERSION" != "3.3" ]]; then
         pip install matplotlib
       fi
-    - python -c 'import ipykernel.kernelspec; ipykernel.kernelspec.install(user=True)'
 script:
-    - nosetests --with-coverage --with-timer --cover-package  ipykernel ipykernel
+    - jupyter kernelspec list
+    - nosetests --with-coverage --with-timer --cover-package ipykernel ipykernel
 after_success:
     - codecov
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ sudo: false
 install:
     - |
       pip install --upgrade setuptools pip
-      python setup.py bdist_wheel && pip install --pre dist/*.whl
-      pip install ipykernel[test] nose-timer
+      python setup.py bdist_wheel
+      pip install --pre dist/*.whl ipykernel[test]
     - |
       if [[ "$TRAVIS_PYTHON_VERSION" == "3.6" ||  "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
         pip install matplotlib

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ install:
     - |
       pip install --upgrade setuptools pip
       pip install --pre .
-      pip install ipykernel[test]
+      pip install ipykernel[test] codecov
     - |
       if [[ "$TRAVIS_PYTHON_VERSION" == "3.6" ||  "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
         pip install matplotlib

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,8 @@ sudo: false
 install:
     - |
       pip install --upgrade setuptools pip
-      pip install --pre . ipykernel[test]
+      pip install --pre .
+      pip install ipykernel[test]
     - |
       if [[ "$TRAVIS_PYTHON_VERSION" == "3.6" ||  "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
         pip install matplotlib

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -20,3 +20,5 @@ global-exclude *.pyc
 global-exclude *.pyo
 global-exclude .git
 global-exclude .ipynb_checkpoints
+
+prune data_kernelspec

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bdist_wheel]
-universal=1
+universal=0
 
 [nosetests]
 warningfilters= default         |.*                 |DeprecationWarning |ipykernel.*

--- a/setup.py
+++ b/setup.py
@@ -27,8 +27,9 @@ PY3 = (sys.version_info[0] >= 3)
 # get on with it
 #-----------------------------------------------------------------------------
 
-import os
 from glob import glob
+import os
+import shutil
 
 from distutils.core import setup
 
@@ -85,6 +86,20 @@ install_requires = setuptools_args['install_requires'] = [
     'jupyter_client',
     'tornado>=4.0',
 ]
+# setup requres same packages
+setuptools_args['setup_requires'] = setuptools_args['install_requires']
+if any(a.startswith(('bdist', 'build')) for a in sys.argv):
+    from ipykernel.kernelspec import write_kernel_spec, make_ipkernel_cmd, KERNEL_NAME
+
+    argv = make_ipkernel_cmd(executable='python')
+    dest = os.path.join(here, 'data_kernelspec')
+    if os.path.exists(dest):
+        shutil.rmtree(dest)
+    write_kernel_spec(dest, overrides={'argv': argv})
+
+    setup_args['data_files'] = [
+        (pjoin('share', 'jupyter', 'kernels', KERNEL_NAME), glob(pjoin(dest, '*'))),
+    ]
 
 extras_require = setuptools_args['extras_require'] = {
     'test:python_version=="2.7"': ['mock', 'nose_warnings_filters'],

--- a/setup.py
+++ b/setup.py
@@ -101,7 +101,8 @@ if any(a.startswith(('bdist', 'build')) for a in sys.argv):
     ]
 
 extras_require = setuptools_args['extras_require'] = {
-    'test:python_version=="2.7"': ['mock', 'nose_warnings_filters'],
+    'test:python_version=="2.7"': ['mock'],
+    'test': ['nose_warnings_filters', 'nose-timer'],
 }
 
 if 'setuptools' in sys.modules:

--- a/setup.py
+++ b/setup.py
@@ -86,8 +86,7 @@ install_requires = setuptools_args['install_requires'] = [
     'jupyter_client',
     'tornado>=4.0',
 ]
-# setup requres same packages
-setuptools_args['setup_requires'] = setuptools_args['install_requires']
+
 if any(a.startswith(('bdist', 'build')) for a in sys.argv):
     from ipykernel.kernelspec import write_kernel_spec, make_ipkernel_cmd, KERNEL_NAME
 

--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,7 @@ install_requires = setuptools_args['install_requires'] = [
     'tornado>=4.0',
 ]
 
-if any(a.startswith(('bdist', 'build')) for a in sys.argv):
+if any(a.startswith(('bdist', 'build', 'install')) for a in sys.argv):
     from ipykernel.kernelspec import write_kernel_spec, make_ipkernel_cmd, KERNEL_NAME
 
     argv = make_ipkernel_cmd(executable='python')


### PR DESCRIPTION
- wheel kernelspec relies on PATH env to find python, which should be okay when installed to sys.prefix, as opposed to system-wide.
- can't use universal wheels anymore, since Python version is in kernelspec name and display name

It would be ideal to get a hardcoded path at install time (https://github.com/pypa/pip/issues/4032), but for envs this should do until that becomes possible.

After this, it should be a lot harder for the native kernelspec to not be installed, which would be ideal. Plus, uninstalling ipykernel will also uninstall the kernelspec.