### PR TITLE
publish busy/idle for aborted requests

### DIFF
--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -643,8 +643,10 @@ class Kernel(SingletonConfigurable):
             status = {'status' : 'aborted'}
             md = {'engine' : self.ident}
             md.update(status)
+            self._publish_status('busy', parent=msg)
             reply_msg = self.session.send(stream, reply_type, metadata=md,
                         content=status, parent=msg, ident=idents)
+            self._publish_status('idle', parent=msg)
             self.log.debug("%s", reply_msg)
             # We need to wait a bit for requests to come in. This can probably
             # be set shorter for true asynchronous clients.


### PR DESCRIPTION
follow spec: kernels should send busy/idle messages on IOPub during processing of every request

It's ambiguous whether aborted requests are 'processed', but any code that assumes requests get busy/idle could get tripped up by the absence of these messages.  Since the abort is rare, making this case as ordinary as possible is probably best.