### PR TITLE
Make 'Unknown message' log less scary

### DIFF
--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -220,7 +220,7 @@ class Kernel(SingletonConfigurable):
 
         handler = self.shell_handlers.get(msg_type, None)
         if handler is None:
-            self.log.error("UNKNOWN MESSAGE TYPE: %r", msg_type)
+            self.log.warn("Unknown message type: %r", msg_type)
         else:
             self.log.debug("%s: %s", msg_type, msg)
             self.pre_handler_hook()


### PR DESCRIPTION
See gh-64

With optional parts of the spec, and future additions of message types, the kernel will sometimes get a message that it doesn't know how to handle. This is not generally an error, so we don't need the log message to be so shouty about it.