### PR TITLE
fixed #9974 enable  IPython.lib.guisupport.is_event_loop_running_XXX()

### DIFF
--- a/ipykernel/inprocess/ipkernel.py
+++ b/ipykernel/inprocess/ipkernel.py
@@ -172,7 +172,9 @@ class InProcessInteractiveShell(ZMQInteractiveShell):
         from ipykernel.eventloops import enable_gui
         if not gui:
             gui = self.kernel.gui
-        return enable_gui(gui, kernel=self.kernel)
+        enable_gui(gui, kernel=self.kernel)
+        self.active_eventloop = gui
+
 
     def enable_matplotlib(self, gui=None):
         """Enable matplotlib integration for the kernel."""

--- a/ipykernel/zmqshell.py
+++ b/ipykernel/zmqshell.py
@@ -476,11 +476,11 @@ class ZMQInteractiveShell(InteractiveShell):
 
     # Over ZeroMQ, GUI control isn't done with PyOS_InputHook as there is no
     # interactive input being read; we provide event loop support in ipkernel
-    @staticmethod
-    def enable_gui(gui):
+    def enable_gui(self, gui):
         from .eventloops import enable_gui as real_enable_gui
         try:
             real_enable_gui(gui)
+            self.active_eventloop = gui
         except ValueError as e:
             raise UsageError("%s" % e)
 


### PR DESCRIPTION
for ipython kernels

