### PR TITLE
Disable parent-poller if PID is 1

### DIFF
--- a/ipykernel/kernelapp.py
+++ b/ipykernel/kernelapp.py
@@ -166,7 +166,9 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp,
             if self.interrupt or self.parent_handle:
                 self.poller = ParentPollerWindows(self.interrupt, self.parent_handle)
         elif self.parent_handle and self.parent_handle != 1:
-            # PID 1 is special. Parent polling doesn't work if ppid == 1 to start with.
+            # PID 1 (init) is special and will never go away,
+            # only be reassigned.
+            # Parent polling doesn't work if ppid == 1 to start with.
             self.poller = ParentPollerUnix()
 
     def _bind_socket(self, s, port):

--- a/ipykernel/kernelapp.py
+++ b/ipykernel/kernelapp.py
@@ -165,7 +165,8 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp,
         if sys.platform == 'win32':
             if self.interrupt or self.parent_handle:
                 self.poller = ParentPollerWindows(self.interrupt, self.parent_handle)
-        elif self.parent_handle:
+        elif self.parent_handle and self.parent_handle != 1:
+            # PID 1 is special. Parent polling doesn't work if ppid == 1 to start with.
             self.poller = ParentPollerUnix()
 
     def _bind_socket(self, s, port):

--- a/ipykernel/parentpoller.py
+++ b/ipykernel/parentpoller.py
@@ -15,6 +15,8 @@ except ImportError:
     from thread import interrupt_main  # Py 2
 from threading import Thread
 
+from traitlets.log import get_logger
+
 import warnings
 
 class ParentPollerUnix(Thread):
@@ -32,6 +34,7 @@ class ParentPollerUnix(Thread):
         while True:
             try:
                 if os.getppid() == 1:
+                    get_logger().warning("Parent appears to have exited, shutting down.")
                     os._exit(1)
                 time.sleep(1.0)
             except OSError as e:
@@ -103,6 +106,7 @@ class ParentPollerWindows(Thread):
                         interrupt_main()
 
                 elif handle == self.parent_handle:
+                    get_logger().warning("Parent appears to have exited, shutting down.")
                     os._exit(1)
             elif result < 0:
                 # wait failed, just give up and stop polling.


### PR DESCRIPTION
PID 1 is special, and we can't treat it the same as we do in other cases. When run in Docker, the parent (notebook server) can be PID 1, which results in IPython kernels exiting immediately on start, which manifests as "Kernel Restarting..." and "Kernel appears to have died". This is caused by the parent poller incorrectly detecting that the parent has exited, and shutting down.

Also adds logging for parent-exit-triggered shutdown, which would have helped figure this out much quicker.

closes https://github.com/jupyterhub/kubespawner/issues/31
related: https://github.com/cassinyio/SwarmSpawner/issues/6

cc @yuvipanda