### PR TITLE
ipykernel currently implements protocol 5.1

### DIFF
--- a/ipykernel/_version.py
+++ b/ipykernel/_version.py
@@ -1,5 +1,5 @@
 version_info = (4, 6, 0, 'dev')
 __version__ = '.'.join(map(str, version_info))
 
-kernel_protocol_version_info = (5, 0)
+kernel_protocol_version_info = (5, 1)
 kernel_protocol_version = '%s.%s' % kernel_protocol_version_info


### PR DESCRIPTION
should be able to release 4.6 after this.