### PR TITLE
set timezone on `started` metadata when using jupyter_client 5.0

### DIFF
--- a/ipykernel/ipkernel.py
+++ b/ipykernel/ipkernel.py
@@ -213,7 +213,7 @@ class IPythonKernel(KernelBase):
                 u'evalue': safe_unicode(err),
             })
 
-            # FIXME: deprecate piece for ipyparallel:
+            # FIXME: deprecated piece for ipyparallel (remove in 5.0):
             e_info = dict(engine_uuid=self.ident, engine_id=self.int_id,
                           method='execute')
             reply_content['engine_info'] = e_info
@@ -351,7 +351,7 @@ class IPythonKernel(KernelBase):
                 u'ename': unicode_type(type(e).__name__),
                 u'evalue': safe_unicode(e),
             }
-            # FIXME: deprecate piece for ipyparallel:
+            # FIXME: deprecated piece for ipyparallel (remove in 5.0):
             e_info = dict(engine_uuid=self.ident, engine_id=self.int_id, method='apply')
             reply_content['engine_info'] = e_info
 

--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -11,6 +11,13 @@ import logging
 import uuid
 
 from datetime import datetime
+try:
+    # jupyter_client >= 5, use tz-aware now
+    from jupyter_client.session import utcnow as now
+except ImportError:
+    # jupyter_client < 5, use local now()
+    now = datetime.now
+
 from signal import signal, default_int_handler, SIGINT
 
 import zmq
@@ -350,8 +357,10 @@ class Kernel(SingletonConfigurable):
 
         Run at the beginning of execution requests.
         """
+        # FIXME: `started` is part of ipyparallel
+        # Remove for ipykernel 5.0
         return {
-            'started': datetime.now(),
+            'started': now(),
         }
 
     def finish_metadata(self, parent, metadata, reply_content):


### PR DESCRIPTION
causes deprecation warnings with jupyter_client 5.0 due to the use of naïve datetimes

This metadata is part of ipyparallel and deprecated in ipykernel.

It should be removed in 5.0.

closes jupyter/notebook#2239