### PR TITLE
Cast `dict_values` To A `list`

### DIFF
--- a/ipykernel/jsonutil.py
+++ b/ipykernel/jsonutil.py
@@ -21,6 +21,9 @@ from ipython_genutils.py3compat import unicode_type, iteritems
 from ipython_genutils.encoding import DEFAULT_ENCODING
 next_attr_name = '__next__' if py3compat.PY3 else 'next'
 
+if py3compat.PY3:
+    from collections.abc import MappingView
+
 #-----------------------------------------------------------------------------
 # Globals and constants
 #-----------------------------------------------------------------------------
@@ -123,6 +126,9 @@ def json_clean(obj):
     # containers that we need to convert into lists
     container_to_list = (tuple, set, types.GeneratorType)
 
+    if py3compat.PY3 and isinstance(obj, MappingView):
+        obj = list(obj)
+
     # Since bools are a subtype of Integrals, which are a subtype of Reals,
     # we have to check them in that order.
 
@@ -138,7 +144,7 @@ def json_clean(obj):
         if math.isnan(obj) or math.isinf(obj):
             return repr(obj)
         return float(obj)
-    
+
     if isinstance(obj, atomic_ok):
         return obj
 
@@ -168,6 +174,6 @@ def json_clean(obj):
         return out
     if isinstance(obj, datetime):
         return obj.strftime(ISO8601)
-    
+
     # we don't understand it, it's probably an unserializable object
     raise ValueError("Can't clean for JSON: %r" % obj)


### PR DESCRIPTION
This resolves the following issue that I observed on Python 3:

```
[IPKernelApp] ERROR | Exception opening comm with target: geonotebook
Traceback (most recent call last):
  File "/usr/lib/python3.4/site-packages/ipykernel/comm/manager.py", line 90, in comm_open
    f(comm, msg)
  File "/home/hadoop/.local/lib/python3.4/site-packages/geonotebook/kernel.py", line 534, in handle_comm_open
    "data": self.geonotebook.get_protocol()
  File "/usr/lib/python3.4/site-packages/ipykernel/comm/comm.py", line 121, in send
    data=data, metadata=metadata, buffers=buffers,
  File "/usr/lib/python3.4/site-packages/ipykernel/comm/comm.py", line 65, in _publish_msg
    content = json_clean(dict(data=data, comm_id=self.comm_id, **keys))
  File "/usr/lib/python3.4/site-packages/ipykernel/jsonutil.py", line 167, in json_clean
    out[unicode_type(k)] = json_clean(v)
  File "/usr/lib/python3.4/site-packages/ipykernel/jsonutil.py", line 167, in json_clean
    out[unicode_type(k)] = json_clean(v)
  File "/usr/lib/python3.4/site-packages/ipykernel/jsonutil.py", line 173, in json_clean
    raise ValueError("Can't clean for JSON: %r" % obj)
ValueError: Can't clean for JSON: dict_values([{'optional': [], 'required': [{'default': False, 'key': 'ann_type'}, {'default': False, 'key': 'coords'}, {'default': False, 'key': 'meta'}], 'procedure': 'add_annotation_from_client'}, {'optional': [], 'required': [{'default': False, 'key': 'x'}, {'default': False, 'key': 'y'}, {'default': False, 'key': 'z'}], 'procedure': 'set_center'}, {'optional': [], 'required': [], 'procedure': 'get_protocol'}, {'optional': [], 'required': [], 'procedure': 'get_map_state'}])
```

I am willing to make any changes that might be requested/required.