### PR TITLE
activate_matplotlib() is not called in _enable_matplotlib_integration()

### DIFF
--- a/ipykernel/pylab/backend_inline.py
+++ b/ipykernel/pylab/backend_inline.py
@@ -150,12 +150,14 @@ def _enable_matplotlib_integration():
     ip = get_ipython()
     backend = get_backend()
     if ip and backend == 'module://%s' % __name__:
-        from IPython.core.pylabtools import configure_inline_support
+        from IPython.core.pylabtools import configure_inline_support, activate_matplotlib
         try:
+            activate_matplotlib(backend)
             configure_inline_support(ip, backend)
-        except ImportError:
+        except (ImportError, AttributeError):
             # bugs may cause a circular import on Python 2
             def configure_once(*args):
+                activate_matplotlib(backend)
                 configure_inline_support(ip, backend)
                 ip.events.unregister('post_run_cell', configure_once)
             ip.events.register('post_run_cell', configure_once)


### PR DESCRIPTION
This PR was sent to fix the behavior of Matplotlib inline mode on Jupyter Notebook.

- before:

<img width="457" alt="before" src="https://user-images.githubusercontent.com/1491856/30510300-997424a2-9afc-11e7-862d-b2c1b34ffcfb.png">

- after

<img width="497" alt="after" src="https://user-images.githubusercontent.com/1491856/30510302-a00ab20e-9afc-11e7-9af1-593a335c635d.png">

Please refer the issue #247 