### PR TITLE
Add widget event loop function

### DIFF
--- a/ipykernel/eventloops.py
+++ b/ipykernel/eventloops.py
@@ -48,6 +48,7 @@ loop_map = {
     'nbagg': None,
     'notebook': None,
     'ipympl': None,
+    'widget': None,
     None : None,
 }
 


### PR DESCRIPTION
Corresponds to https://github.com/ipython/ipython/pull/10756.  Without this addition, a call to `ip.get_backend('widget')` looked up by ` IPython.core.pylabtools.backend2gui.get` would fail randomly depending on whether it chose `ipympl` or `widget`.

cf https://github.com/matplotlib/jupyter-matplotlib/pull/21#issuecomment-340191921

Temporarily worked around by forcing `backend2gui` to use `ipympl` in https://github.com/matplotlib/jupyter-matplotlib/pull/21/commits/676ea162fdee42f4d6513207c332f81e5e5d7592