### PR TITLE
update use of tornado IOLoop.current

### DIFF
--- a/ipykernel/iostream.py
+++ b/ipykernel/iostream.py
@@ -63,7 +63,7 @@ class IOPubThread(object):
         self.background_socket = BackgroundSocket(self)
         self._master_pid = os.getpid()
         self._pipe_flag = pipe
-        self.io_loop = IOLoop()
+        self.io_loop = IOLoop(make_current=False)
         if pipe:
             self._setup_pipe_in()
         self._local = threading.local()
@@ -74,6 +74,7 @@ class IOPubThread(object):
 
     def _thread_main(self):
         """The inner loop that's actually run in a thread"""
+        self.io_loop.make_current()
         self.io_loop.start()
         self.io_loop.close(all_fds=True)
 

--- a/ipykernel/kernelapp.py
+++ b/ipykernel/kernelapp.py
@@ -473,8 +473,9 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp,
         if self.poller is not None:
             self.poller.start()
         self.kernel.start()
+        self.io_loop = ioloop.IOLoop.current()
         try:
-            ioloop.IOLoop.instance().start()
+            self.io_loop.start()
         except KeyboardInterrupt:
             pass
 

--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -49,7 +49,7 @@ class Kernel(SingletonConfigurable):
     @observe('eventloop')
     def _update_eventloop(self, change):
         """schedule call to eventloop from IOLoop"""
-        loop = ioloop.IOLoop.instance()
+        loop = ioloop.IOLoop.current()
         loop.add_callback(self.enter_eventloop)
 
     session = Instance(Session, allow_none=True)
@@ -272,6 +272,7 @@ class Kernel(SingletonConfigurable):
 
     def start(self):
         """register dispatchers for streams"""
+        self.io_loop = ioloop.IOLoop.current()
         if self.control_stream:
             self.control_stream.on_recv(self.dispatch_control, copy=False)
 
@@ -530,7 +531,7 @@ class Kernel(SingletonConfigurable):
 
         self._at_shutdown()
         # call sys.exit after a short delay
-        loop = ioloop.IOLoop.instance()
+        loop = ioloop.IOLoop.current()
         loop.add_timeout(time.time()+0.1, loop.stop)
 
     def do_shutdown(self, restart):

--- a/ipykernel/zmqshell.py
+++ b/ipykernel/zmqshell.py
@@ -469,8 +469,8 @@ class ZMQInteractiveShell(InteractiveShell):
     def _update_exit_now(self, change):
         """stop eventloop when exit_now fires"""
         if change['new']:
-            loop = ioloop.IOLoop.instance()
-            loop.add_timeout(time.time() + 0.1, loop.stop)
+            loop = self.kernel.io_loop
+            loop.call_later(0.1, loop.stop)
 
     keepkernel_on_exit = None
 


### PR DESCRIPTION
prepare for tornado 5:

- use thread-local .current over deprecated global .instance
- avoid making IOPubThread loops main thread's instance for a brief period during initialization