### PR TITLE
handle KeyboardInterrupt with %gui asyncio

### DIFF
--- a/ipykernel/eventloops.py
+++ b/ipykernel/eventloops.py
@@ -302,12 +302,22 @@ def loop_asyncio(kernel):
         loop.call_later(kernel._poll_interval, kernel_handler)
 
     loop.call_soon(kernel_handler)
-    try:
-        if not loop.is_running():
+    # loop is already running (e.g. tornado 5), nothing left to do
+    if loop.is_running():
+        return
+    while True:
+        error = None
+        try:
             loop.run_forever()
-    finally:
+        except KeyboardInterrupt:
+            continue
+        except Exception as e:
+            error = e
         loop.run_until_complete(loop.shutdown_asyncgens())
         loop.close()
+        if error is not None:
+            raise error
+        break
 
 def enable_gui(gui, kernel=None):
     """Enable integration with a given GUI"""

--- a/ipykernel/eventloops.py
+++ b/ipykernel/eventloops.py
@@ -313,7 +313,8 @@ def loop_asyncio(kernel):
             continue
         except Exception as e:
             error = e
-        loop.run_until_complete(loop.shutdown_asyncgens())
+        if hasattr(loop, 'shutdown_asyncgens'):
+            loop.run_until_complete(loop.shutdown_asyncgens())
         loop.close()
         if error is not None:
             raise error

--- a/ipykernel/tests/_asyncio.py
+++ b/ipykernel/tests/_asyncio.py
@@ -1,0 +1,17 @@
+"""test utilities that use async/await syntax
+
+a separate file to avoid syntax errors on Python 2
+"""
+
+import asyncio
+
+
+def async_func():
+    """Simple async function to schedule a task on the current eventloop"""
+    loop = asyncio.get_event_loop()
+    assert loop.is_running()
+
+    async def task():
+        await asyncio.sleep(1)
+
+    loop.create_task(task())

--- a/ipykernel/tests/test_eventloop.py
+++ b/ipykernel/tests/test_eventloop.py
@@ -1,0 +1,44 @@
+"""Test eventloop integration"""
+
+import sys
+import time
+
+import IPython.testing.decorators as dec
+from .utils import flush_channels, start_new_kernel, execute
+
+KC = KM = None
+
+
+def setup():
+    """start the global kernel (if it isn't running) and return its client"""
+    global KM, KC
+    KM, KC = start_new_kernel()
+    flush_channels(KC)
+
+
+def teardown():
+    KC.stop_channels()
+    KM.shutdown_kernel(now=True)
+
+
+async_code = """
+from ipykernel.tests._asyncio import async_func
+async_func()
+"""
+
+
+@dec.skipif(sys.version_info < (3, 5), "async/await syntax required")
+def test_asyncio_interrupt():
+    flush_channels(KC)
+    msg_id, content = execute('%gui asyncio', KC)
+    assert content['status'] == 'ok', content
+
+    flush_channels(KC)
+    msg_id, content = execute(async_code, KC)
+    assert content['status'] == 'ok', content
+
+    KM.interrupt_kernel()
+
+    flush_channels(KC)
+    msg_id, content = execute(async_code, KC)
+    assert content['status'] == 'ok'

--- a/ipykernel/tests/utils.py
+++ b/ipykernel/tests/utils.py
@@ -3,8 +3,11 @@
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
 
+from __future__ import print_function
+
 import atexit
 import os
+import sys
 
 from contextlib import contextmanager
 from subprocess import PIPE, STDOUT
@@ -18,9 +21,6 @@ import nose.tools as nt
 
 from jupyter_client import manager
 
-#-------------------------------------------------------------------------------
-# Globals
-#-------------------------------------------------------------------------------
 
 STARTUP_TIMEOUT = 60
 TIMEOUT = 15
@@ -28,9 +28,7 @@ TIMEOUT = 15
 KM = None
 KC = None
 
-#-------------------------------------------------------------------------------
-# code
-#-------------------------------------------------------------------------------
+
 def start_new_kernel(**kwargs):
     """start a new kernel, and return its Manager and Client
 
@@ -42,6 +40,7 @@ def start_new_kernel(**kwargs):
         stdout = open(os.devnull)
     kwargs.update(dict(stdout=stdout, stderr=STDOUT))
     return manager.start_new_kernel(startup_timeout=STARTUP_TIMEOUT, **kwargs)
+
 
 def flush_channels(kc=None):
     """flush any messages waiting on the queue"""
@@ -75,6 +74,11 @@ def execute(code='', kc=None, **kwargs):
         execute_input = kc.get_iopub_msg(timeout=TIMEOUT)
         validate_message(execute_input, 'execute_input', msg_id)
         nt.assert_equal(execute_input['content']['code'], code)
+
+    # show tracebacks if present for debugging
+    if reply['content'].get('traceback'):
+        print('\n'.join(reply['content']['traceback']), file=sys.stderr)
+
 
     return msg_id, reply['content']
 


### PR DESCRIPTION
when interrupted, re-enter eventloop and don't close it (same as all the other eventloops)

Only close the eventloop when we are done for good AND we are responsible for running it.

Also avoid any cleanup when someone else is already running the eventloop (e.g. tornado 5).

closes #263

I'll try add a test for this before it's ready to merge.