### PR TITLE
run tests with pytest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 python:
     - "nightly"
-    - 3.6 
+    - 3.6
     - 3.5
     - 3.4
     - 3.3
@@ -18,7 +18,7 @@ install:
       fi
 script:
     - jupyter kernelspec list
-    - nosetests --with-coverage --with-timer --cover-package ipykernel ipykernel
+    - pytest --cov ipykernel -v ipykernel
 after_success:
     - codecov
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ install:
       fi
 script:
     - jupyter kernelspec list
-    - pytest --cov ipykernel -v ipykernel
+    - pytest --cov ipykernel --durations 10 -v ipykernel
 after_success:
     - codecov
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ install:
       if [[ "$TRAVIS_PYTHON_VERSION" == "3.6" ||  "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
         pip install matplotlib
       fi
+    - pip freeze
 script:
     - jupyter kernelspec list
     - pytest --cov ipykernel --durations 10 -v ipykernel

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,14 +21,14 @@ install:
         pip install --upgrade pip wheel
         pip --version
   - cmd: |
-        pip install --pre -e . coverage nose_warnings_filters
-        pip install ipykernel[test] nose-timer
+        pip install --pre -e .
+        pip install ipykernel[test]
   - cmd: |
         pip install matplotlib numpy
         pip freeze
   - cmd: python -c "import ipykernel.kernelspec; ipykernel.kernelspec.install(user=True)"
 test_script:
-  - cmd: nosetests --with-coverage --with-timer --cover-package=ipykernel ipykernel
+  - cmd: pytest -v --cov ipykernel ipykernel
 
 on_success:
   - cmd: pip install codecov

--- a/ipykernel/inprocess/tests/test_kernel.py
+++ b/ipykernel/inprocess/tests/test_kernel.py
@@ -50,7 +50,7 @@ class InProcessKernelTestCase(unittest.TestCase):
                 self.kc.execute('x = raw_input()')
         finally:
             sys.stdin = sys_stdin
-        self.assertEqual(self.km.kernel.shell.user_ns.get('x'), 'foobar')
+        assert self.km.kernel.shell.user_ns.get('x') == 'foobar'
 
     def test_stdout(self):
         """ Does the in-process kernel correctly capture IO?
@@ -59,13 +59,13 @@ class InProcessKernelTestCase(unittest.TestCase):
 
         with capture_output() as io:
             kernel.shell.run_cell('print("foo")')
-        self.assertEqual(io.stdout, 'foo\n')
+        assert io.stdout == 'foo\n'
 
         kc = BlockingInProcessKernelClient(kernel=kernel, session=kernel.session)
         kernel.frontends.append(kc)
         kc.execute('print("bar")')
         out, err = assemble_output(kc.iopub_channel)
-        self.assertEqual(out, 'bar\n')
+        assert out == 'bar\n'
 
     def test_getpass_stream(self):
         "Tests that kernel getpass accept the stream parameter"

--- a/ipykernel/inprocess/tests/test_kernelmanager.py
+++ b/ipykernel/inprocess/tests/test_kernelmanager.py
@@ -25,31 +25,31 @@ class InProcessKernelManagerTestCase(unittest.TestCase):
         """ Does the in-process kernel manager implement the basic KM interface?
         """
         km = self.km
-        self.assert_(not km.has_kernel)
+        assert not km.has_kernel
 
         km.start_kernel()
-        self.assert_(km.has_kernel)
-        self.assert_(km.kernel is not None)
+        assert km.has_kernel
+        assert km.kernel is not None
 
         kc = km.client()
-        self.assert_(not kc.channels_running)
+        assert not kc.channels_running
 
         kc.start_channels()
-        self.assert_(kc.channels_running)
+        assert kc.channels_running
 
         old_kernel = km.kernel
         km.restart_kernel()
         self.assertIsNotNone(km.kernel)
-        self.assertNotEquals(km.kernel, old_kernel)
+        assert km.kernel != old_kernel
 
         km.shutdown_kernel()
-        self.assert_(not km.has_kernel)
+        assert not km.has_kernel
 
         self.assertRaises(NotImplementedError, km.interrupt_kernel)
         self.assertRaises(NotImplementedError, km.signal_kernel, 9)
 
         kc.stop_channels()
-        self.assert_(not kc.channels_running)
+        assert not kc.channels_running
 
     def test_execute(self):
         """ Does executing code in an in-process kernel work?
@@ -60,7 +60,7 @@ class InProcessKernelManagerTestCase(unittest.TestCase):
         kc.start_channels()
         kc.wait_for_ready()
         kc.execute('foo = 1')
-        self.assertEquals(km.kernel.shell.user_ns['foo'], 1)
+        assert km.kernel.shell.user_ns['foo'] == 1
 
     def test_complete(self):
         """ Does requesting completion from an in-process kernel work?
@@ -73,7 +73,7 @@ class InProcessKernelManagerTestCase(unittest.TestCase):
         km.kernel.shell.push({'my_bar': 0, 'my_baz': 1})
         kc.complete('my_ba', 5)
         msg = kc.get_shell_msg()
-        self.assertEqual(msg['header']['msg_type'], 'complete_reply')
+        assert msg['header']['msg_type'] == 'complete_reply'
         self.assertEqual(sorted(msg['content']['matches']),
                           ['my_bar', 'my_baz'])
 
@@ -88,7 +88,7 @@ class InProcessKernelManagerTestCase(unittest.TestCase):
         km.kernel.shell.user_ns['foo'] = 1
         kc.inspect('foo')
         msg = kc.get_shell_msg()
-        self.assertEqual(msg['header']['msg_type'], 'inspect_reply')
+        assert msg['header']['msg_type'] == 'inspect_reply'
         content = msg['content']
         assert content['found']
         text = content['data']['text/plain']
@@ -105,10 +105,10 @@ class InProcessKernelManagerTestCase(unittest.TestCase):
         kc.execute('1')
         kc.history(hist_access_type='tail', n=1)
         msg = kc.shell_channel.get_msgs()[-1]
-        self.assertEquals(msg['header']['msg_type'], 'history_reply')
+        assert msg['header']['msg_type'] == 'history_reply'
         history = msg['content']['history']
-        self.assertEquals(len(history), 1)
-        self.assertEquals(history[0][2], '1')
+        assert len(history) == 1
+        assert history[0][2] == '1'
 
 
 if __name__ == '__main__':

--- a/ipykernel/tests/test_connect.py
+++ b/ipykernel/tests/test_connect.py
@@ -6,8 +6,6 @@
 import json
 import os
 
-import nose.tools as nt
-
 from traitlets.config import Config
 from ipython_genutils.tempdir import TemporaryDirectory, TemporaryWorkingDirectory
 from ipython_genutils.py3compat import str_to_bytes
@@ -36,14 +34,14 @@ def test_get_connection_file():
         app.initialize()
 
         profile_cf = os.path.join(app.connection_dir, cf)
-        nt.assert_equal(profile_cf, app.abs_connection_file)
+        assert profile_cf == app.abs_connection_file
         with open(profile_cf, 'w') as f:
             f.write("{}")
-        nt.assert_true(os.path.exists(profile_cf))
-        nt.assert_equal(connect.get_connection_file(app), profile_cf)
+        assert os.path.exists(profile_cf)
+        assert connect.get_connection_file(app) == profile_cf
 
         app.connection_file = cf
-        nt.assert_equal(connect.get_connection_file(app), profile_cf)
+        assert connect.get_connection_file(app) == profile_cf
 
 
 def test_get_connection_info():
@@ -52,12 +50,12 @@ def test_get_connection_info():
         connect.write_connection_file(cf, **sample_info)
         json_info = connect.get_connection_info(cf)
         info = connect.get_connection_info(cf, unpack=True)
-    
-    nt.assert_equal(type(json_info), type(""))
+    assert isinstance(json_info, str)
+
     sub_info = {k:v for k,v in info.items() if k in sample_info}
-    nt.assert_equal(sub_info, sample_info)
+    assert sub_info == sample_info
 
     info2 = json.loads(json_info)
     info2['key'] = str_to_bytes(info2['key'])
     sub_info2 = {k:v for k,v in info.items() if k in sample_info}
-    nt.assert_equal(sub_info2, sample_info)
+    assert sub_info2 == sample_info

--- a/ipykernel/tests/test_embed_kernel.py
+++ b/ipykernel/tests/test_embed_kernel.py
@@ -4,19 +4,14 @@
 # Distributed under the terms of the Modified BSD License.
 
 import os
-import shutil
 import sys
-import tempfile
 import time
 
 from contextlib import contextmanager
 from subprocess import Popen, PIPE
 
-import nose.tools as nt
-
 from jupyter_client import BlockingKernelClient
 from jupyter_core import paths
-from IPython.paths import get_ipython_dir
 from ipython_genutils import py3compat
 from ipython_genutils.py3compat import unicode_type
 
@@ -83,20 +78,20 @@ def test_embed_kernel_basic():
         msg_id = client.inspect('a')
         msg = client.get_shell_msg(block=True, timeout=TIMEOUT)
         content = msg['content']
-        nt.assert_true(content['found'])
+        assert content['found']
 
         msg_id = client.execute("c=a*2")
         msg = client.get_shell_msg(block=True, timeout=TIMEOUT)
         content = msg['content']
-        nt.assert_equal(content['status'], u'ok')
+        assert content['status'] == u'ok'
 
         # oinfo c (should be 10)
         msg_id = client.inspect('c')
         msg = client.get_shell_msg(block=True, timeout=TIMEOUT)
         content = msg['content']
-        nt.assert_true(content['found'])
+        assert content['found']
         text = content['data']['text/plain']
-        nt.assert_in('10', text)
+        assert '10' in text
 
 def test_embed_kernel_namespace():
     """IPython.embed_kernel() inherits calling namespace"""
@@ -115,23 +110,23 @@ def test_embed_kernel_namespace():
         msg_id = client.inspect('a')
         msg = client.get_shell_msg(block=True, timeout=TIMEOUT)
         content = msg['content']
-        nt.assert_true(content['found'])
+        assert content['found']
         text = content['data']['text/plain']
-        nt.assert_in(u'5', text)
+        assert u'5' in text
 
         # oinfo b (str)
         msg_id = client.inspect('b')
         msg = client.get_shell_msg(block=True, timeout=TIMEOUT)
         content = msg['content']
-        nt.assert_true(content['found'])
+        assert content['found']
         text = content['data']['text/plain']
-        nt.assert_in(u'hi there', text)
+        assert u'hi there' in text
 
         # oinfo c (undefined)
         msg_id = client.inspect('c')
         msg = client.get_shell_msg(block=True, timeout=TIMEOUT)
         content = msg['content']
-        nt.assert_false(content['found'])
+        assert not content['found']
 
 def test_embed_kernel_reentrant():
     """IPython.embed_kernel() can be called multiple times"""
@@ -153,9 +148,9 @@ def test_embed_kernel_reentrant():
             msg_id = client.inspect('count')
             msg = client.get_shell_msg(block=True, timeout=TIMEOUT)
             content = msg['content']
-            nt.assert_true(content['found'])
+            assert content['found']
             text = content['data']['text/plain']
-            nt.assert_in(unicode_type(i), text)
+            assert unicode_type(i) in text
 
             # exit from embed_kernel
             client.execute("get_ipython().exit_now = True")

--- a/ipykernel/tests/test_jsonutil.py
+++ b/ipykernel/tests/test_jsonutil.py
@@ -55,7 +55,7 @@ def test():
             jval = val
         out = json_clean(val)
         # validate our cleanup
-        nt.assert_equal(out, jval)
+        assert out == jval
         # and ensure that what we return, indeed encodes cleanly
         json.loads(json.dumps(out))
 
@@ -77,19 +77,19 @@ def test_encode_images():
     for key, value in fmt.items():
         # encoded has unicode, want bytes
         decoded = a2b_base64(encoded[key])
-        nt.assert_equal(decoded, value)
+        assert decoded == value
     encoded2 = json_clean(encode_images(encoded))
-    nt.assert_equal(encoded, encoded2)
+    assert encoded == encoded2
     
     # test that we don't double-encode base64 str
     b64_str = {}
     for key, encoded in encoded.items():
         b64_str[key] = unicode_to_str(encoded)
     encoded3 = json_clean(encode_images(b64_str))
-    nt.assert_equal(encoded3, b64_str)
+    assert encoded3 == b64_str
     for key, value in fmt.items():
         decoded = a2b_base64(encoded3[key])
-        nt.assert_equal(decoded, value)
+        assert decoded == value
 
 def test_lambda():
     with nt.assert_raises(ValueError):
@@ -107,4 +107,4 @@ def test_exception():
 def test_unicode_dict():
     data = {u'üniço∂e': u'üniço∂e'}
     clean = jsonutil.json_clean(data)
-    nt.assert_equal(data, clean)
+    assert data == clean

--- a/ipykernel/tests/test_kernel.py
+++ b/ipykernel/tests/test_kernel.py
@@ -26,13 +26,13 @@ def _check_master(kc, expected=True, stream="stdout"):
     flush_channels(kc)
     msg_id, content = execute(kc=kc, code="print (sys.%s._is_master_process())" % stream)
     stdout, stderr = assemble_output(kc.iopub_channel)
-    nt.assert_equal(stdout.strip(), repr(expected))
+    assert stdout.strip() == repr(expected)
 
 
 def _check_status(content):
     """If status=error, show the traceback"""
     if content['status'] == 'error':
-        nt.assert_true(False, ''.join(['\n'] + content['traceback']))
+        assert False, ''.join(['\n'] + content['traceback'])
 
 
 # printing tests
@@ -43,8 +43,8 @@ def test_simple_print():
         iopub = kc.iopub_channel
         msg_id, content = execute(kc=kc, code="print ('hi')")
         stdout, stderr = assemble_output(iopub)
-        nt.assert_equal(stdout, 'hi\n')
-        nt.assert_equal(stderr, '')
+        assert stdout == 'hi\n'
+        assert stderr == ''
         _check_master(kc, expected=True)
 
 
@@ -53,7 +53,7 @@ def test_sys_path():
     with kernel() as kc:
         msg_id, content = execute(kc=kc, code="import sys; print (repr(sys.path[0]))")
         stdout, stderr = assemble_output(kc.iopub_channel)
-        nt.assert_equal(stdout, "''\n")
+        assert stdout == "''\n"
 
 def test_sys_path_profile_dir():
     """test that sys.path doesn't get messed up when `--profile-dir` is specified"""
@@ -61,7 +61,7 @@ def test_sys_path_profile_dir():
     with new_kernel(['--profile-dir', locate_profile('default')]) as kc:
         msg_id, content = execute(kc=kc, code="import sys; print (repr(sys.path[0]))")
         stdout, stderr = assemble_output(kc.iopub_channel)
-        nt.assert_equal(stdout, "''\n")
+        assert stdout == "''\n"
 
 @dec.skipif(sys.platform == 'win32', "subprocess prints fail on Windows")
 def test_subprocess_print():
@@ -87,7 +87,7 @@ def test_subprocess_print():
         nt.assert_equal(stdout.count("hello"), np, stdout)
         for n in range(np):
             nt.assert_equal(stdout.count(str(n)), 1, stdout)
-        nt.assert_equal(stderr, '')
+        assert stderr == ''
         _check_master(kc, expected=True)
         _check_master(kc, expected=True, stream="stderr")
 
@@ -107,8 +107,8 @@ def test_subprocess_noprint():
 
         msg_id, content = execute(kc=kc, code=code)
         stdout, stderr = assemble_output(iopub)
-        nt.assert_equal(stdout, '')
-        nt.assert_equal(stderr, '')
+        assert stdout == ''
+        assert stderr == ''
 
         _check_master(kc, expected=True)
         _check_master(kc, expected=True, stream="stderr")
@@ -129,8 +129,8 @@ def test_subprocess_error():
 
         msg_id, content = execute(kc=kc, code=code)
         stdout, stderr = assemble_output(iopub)
-        nt.assert_equal(stdout, '')
-        nt.assert_true("ValueError" in stderr, stderr)
+        assert stdout == ''
+        assert "ValueError" in stderr
 
         _check_master(kc, expected=True)
         _check_master(kc, expected=True, stream="stderr")
@@ -147,15 +147,15 @@ def test_raw_input():
         code = 'print({input_f}("{theprompt}"))'.format(**locals())
         msg_id = kc.execute(code, allow_stdin=True)
         msg = kc.get_stdin_msg(block=True, timeout=TIMEOUT)
-        nt.assert_equal(msg['header']['msg_type'], u'input_request')
+        assert msg['header']['msg_type'] == u'input_request'
         content = msg['content']
-        nt.assert_equal(content['prompt'], theprompt)
+        assert content['prompt'] == theprompt
         text = "some text"
         kc.input(text)
         reply = kc.get_shell_msg(block=True, timeout=TIMEOUT)
-        nt.assert_equal(reply['content']['status'], 'ok')
+        assert reply['content']['status'] == 'ok'
         stdout, stderr = assemble_output(iopub)
-        nt.assert_equal(stdout, text + "\n")
+        assert stdout == text + "\n"
 
 
 @dec.skipif(py3compat.PY3)
@@ -169,14 +169,14 @@ def test_eval_input():
         code = 'print(input("{theprompt}"))'.format(**locals())
         msg_id = kc.execute(code, allow_stdin=True)
         msg = kc.get_stdin_msg(block=True, timeout=TIMEOUT)
-        nt.assert_equal(msg['header']['msg_type'], u'input_request')
+        assert msg['header']['msg_type'] == u'input_request'
         content = msg['content']
-        nt.assert_equal(content['prompt'], theprompt)
+        assert content['prompt'] == theprompt
         kc.input("1+1")
         reply = kc.get_shell_msg(block=True, timeout=TIMEOUT)
-        nt.assert_equal(reply['content']['status'], 'ok')
+        assert reply['content']['status'] == 'ok'
         stdout, stderr = assemble_output(iopub)
-        nt.assert_equal(stdout, "2\n")
+        assert stdout == "2\n"
 
 
 def test_save_history():
@@ -189,11 +189,11 @@ def test_save_history():
         execute(u'b=u"abcþ"', kc=kc)
         wait_for_idle(kc)
         _, reply = execute("%hist -f " + file, kc=kc)
-        nt.assert_equal(reply['status'], 'ok')
+        assert reply['status'] == 'ok'
         with io.open(file, encoding='utf-8') as f:
             content = f.read()
-        nt.assert_in(u'a=1', content)
-        nt.assert_in(u'b=u"abcþ"', content)
+        assert u'a=1' in content
+        assert u'b=u"abcþ"' in content
 
 
 @dec.skip_without('faulthandler')
@@ -248,13 +248,13 @@ def test_complete():
         kc.complete(cell)
         reply = kc.get_shell_msg(block=True, timeout=TIMEOUT)
         c = reply['content']
-        nt.assert_equal(c['status'], 'ok')
-        nt.assert_equal(c['cursor_start'], cell.find('a.'))
-        nt.assert_equal(c['cursor_end'], cell.find('a.') + 2)
+        assert c['status'] == 'ok'
+        assert c['cursor_start'] == cell.find('a.')
+        assert c['cursor_end'] == cell.find('a.') + 2
         matches = c['matches']
         nt.assert_greater(len(matches), 0)
         for match in matches:
-            nt.assert_equal(match[:2], 'a.')
+            assert match[:2] == 'a.'
 
 
 @dec.skip_without('matplotlib')
@@ -270,7 +270,7 @@ def test_matplotlib_inline_on_import():
         _check_status(reply)
         backend_bundle = reply['user_expressions']['backend']
         _check_status(backend_bundle)
-        nt.assert_in('backend_inline', backend_bundle['data']['text/plain'])
+        assert 'backend_inline' in backend_bundle['data']['text/plain']
 
 
 def test_shutdown():
@@ -285,4 +285,4 @@ def test_shutdown():
                 time.sleep(.1)
             else:
                 break
-        nt.assert_false(km.is_alive())
+        assert not km.is_alive()

--- a/ipykernel/tests/test_kernelspec.py
+++ b/ipykernel/tests/test_kernelspec.py
@@ -7,7 +7,7 @@ import os
 import shutil
 import sys
 import tempfile
-    
+
 try:
     from unittest import mock
 except ImportError:
@@ -42,9 +42,9 @@ def test_make_ipkernel_cmd():
 
 
 def assert_kernel_dict(d):
-    nt.assert_equal(d['argv'], make_ipkernel_cmd())
-    nt.assert_equal(d['display_name'], 'Python %i' % sys.version_info[0])
-    nt.assert_equal(d['language'], 'python')
+    assert d['argv'] == make_ipkernel_cmd()
+    assert d['display_name'] == 'Python %i' % sys.version_info[0]
+    assert d['language'] == 'python'
 
 
 def test_get_kernel_dict():
@@ -55,8 +55,8 @@ def test_get_kernel_dict():
 def assert_kernel_dict_with_profile(d):
     nt.assert_equal(d['argv'], make_ipkernel_cmd(
         extra_arguments=["--profile", "test"]))
-    nt.assert_equal(d['display_name'], 'Python %i' % sys.version_info[0])
-    nt.assert_equal(d['language'], 'python')
+    assert d['display_name'] == 'Python %i' % sys.version_info[0]
+    assert d['language'] == 'python'
 
 
 def test_get_kernel_dict_with_profile():
@@ -83,7 +83,7 @@ def test_write_kernel_spec():
 def test_write_kernel_spec_path():
     path = os.path.join(tempfile.mkdtemp(), KERNEL_NAME)
     path2 = write_kernel_spec(path)
-    nt.assert_equal(path, path2)
+    assert path == path2
     assert_is_spec(path)
     shutil.rmtree(path)
 
@@ -129,7 +129,7 @@ def test_install_profile():
     spec = os.path.join(system_jupyter_dir, 'kernels', KERNEL_NAME, "kernel.json")
     with open(spec) as f:
         spec = json.load(f)
-    nt.assert_true(spec["display_name"].endswith(" [profile=Test]"))
+    assert spec["display_name"].endswith(" [profile=Test]")
     nt.assert_equal(spec["argv"][-2:], ["--profile", "Test"])
 
 
@@ -143,4 +143,4 @@ def test_install_display_name_overrides_profile():
     spec = os.path.join(system_jupyter_dir, 'kernels', KERNEL_NAME, "kernel.json")
     with open(spec) as f:
         spec = json.load(f)
-    nt.assert_equal(spec["display_name"], "Display")
+    assert spec["display_name"] == "Display"

--- a/ipykernel/tests/test_message_spec.py
+++ b/ipykernel/tests/test_message_spec.py
@@ -49,7 +49,7 @@ class Reference(HasTraits):
     def check(self, d):
         """validate a dict against our traits"""
         for key in self.trait_names():
-            nt.assert_in(key, d)
+            assert key in d
             # FIXME: always allow None, probably not a good idea
             if d[key] is None:
                 continue
@@ -101,7 +101,7 @@ class MimeBundle(Reference):
     def _data_changed(self, name, old, new):
         for k,v in iteritems(new):
             assert mime_pat.match(k)
-            nt.assert_is_instance(v, string_types)
+            assert isinstance(v, string_types)
 
 
 # shell replies
@@ -257,9 +257,9 @@ def validate_message(msg, msg_type=None, parent=None):
     """
     RMessage().check(msg)
     if msg_type:
-        nt.assert_equal(msg['msg_type'], msg_type)
+        assert msg['msg_type'] == msg_type
     if parent:
-        nt.assert_equal(msg['parent_header']['msg_id'], parent)
+        assert msg['parent_header']['msg_id'] == parent
     content = msg['content']
     ref = references[msg['msg_type']]
     ref.check(content)
@@ -286,7 +286,7 @@ def test_execute_silent():
     # flush status=idle
     status = KC.iopub_channel.get_msg(timeout=TIMEOUT)
     validate_message(status, 'status', msg_id)
-    nt.assert_equal(status['content']['execution_state'], 'idle')
+    assert status['content']['execution_state'] == 'idle'
 
     nt.assert_raises(Empty, KC.iopub_channel.get_msg, timeout=0.1)
     count = reply['execution_count']
@@ -296,19 +296,19 @@ def test_execute_silent():
     # flush status=idle
     status = KC.iopub_channel.get_msg(timeout=TIMEOUT)
     validate_message(status, 'status', msg_id)
-    nt.assert_equal(status['content']['execution_state'], 'idle')
+    assert status['content']['execution_state'] == 'idle'
 
     nt.assert_raises(Empty, KC.iopub_channel.get_msg, timeout=0.1)
     count_2 = reply['execution_count']
-    nt.assert_equal(count_2, count)
+    assert count_2 == count
 
 
 def test_execute_error():
     flush_channels()
 
     msg_id, reply = execute(code='1/0')
-    nt.assert_equal(reply['status'], 'error')
-    nt.assert_equal(reply['ename'], 'ZeroDivisionError')
+    assert reply['status'] == 'error'
+    assert reply['ename'] == 'ZeroDivisionError'
 
     error = KC.iopub_channel.get_msg(timeout=TIMEOUT)
     validate_message(error, 'error', msg_id)
@@ -325,7 +325,7 @@ def test_execute_inc():
 
     msg_id, reply = execute(code='x=2')
     count_2 = reply['execution_count']
-    nt.assert_equal(count_2, count+1)
+    assert count_2 == count+1
 
 def test_execute_stop_on_error():
     """execute request should not abort execution queue with stop_on_error False"""
@@ -341,7 +341,7 @@ def test_execute_stop_on_error():
     msg_id = KC.execute(code='print("Hello")')
     KC.get_shell_msg(timeout=TIMEOUT)
     reply = KC.get_shell_msg(timeout=TIMEOUT)
-    nt.assert_equal(reply['content']['status'], 'aborted')
+    assert reply['content']['status'] == 'aborted'
 
     flush_channels()
 
@@ -349,7 +349,7 @@ def test_execute_stop_on_error():
     msg_id = KC.execute(code='print("Hello")')
     KC.get_shell_msg(timeout=TIMEOUT)
     reply = KC.get_shell_msg(timeout=TIMEOUT)
-    nt.assert_equal(reply['content']['status'], 'ok')
+    assert reply['content']['status'] == 'ok'
 
 
 def test_user_expressions():
@@ -370,8 +370,8 @@ def test_user_expressions_fail():
     msg_id, reply = execute(code='x=0', user_expressions=dict(foo='nosuchname'))
     user_expressions = reply['user_expressions']
     foo = user_expressions['foo']
-    nt.assert_equal(foo['status'], 'error')
-    nt.assert_equal(foo['ename'], 'NameError')
+    assert foo['status'] == 'error'
+    assert foo['ename'] == 'NameError'
 
 
 def test_oinfo():
@@ -393,8 +393,8 @@ def test_oinfo_found():
     content = reply['content']
     assert content['found']
     text = content['data']['text/plain']
-    nt.assert_in('Type:', text)
-    nt.assert_in('Docstring:', text)
+    assert 'Type:' in text
+    assert 'Docstring:' in text
 
 
 def test_oinfo_detail():
@@ -408,8 +408,8 @@ def test_oinfo_detail():
     content = reply['content']
     assert content['found']
     text = content['data']['text/plain']
-    nt.assert_in('Signature:', text)
-    nt.assert_in('Source:', text)
+    assert 'Signature:' in text
+    assert 'Source:' in text
 
 
 def test_oinfo_not_found():
@@ -419,7 +419,7 @@ def test_oinfo_not_found():
     reply = KC.get_shell_msg(timeout=TIMEOUT)
     validate_message(reply, 'inspect_reply', msg_id)
     content = reply['content']
-    nt.assert_false(content['found'])
+    assert not content['found']
 
 
 def test_complete():
@@ -432,7 +432,7 @@ def test_complete():
     validate_message(reply, 'complete_reply', msg_id)
     matches = reply['content']['matches']
     for name in ('alpha', 'albert'):
-        nt.assert_in(name, matches)
+        assert name in matches
 
 
 def test_kernel_info_request():
@@ -469,7 +469,7 @@ def test_single_payload():
                                  "   x=range?\n")
     payload = reply['payload']
     next_input_pls = [pl for pl in payload if pl["source"] == "set_next_input"]
-    nt.assert_equal(len(next_input_pls), 1)
+    assert len(next_input_pls) == 1
 
 def test_is_complete():
     flush_channels()
@@ -488,7 +488,7 @@ def test_history_range():
     reply = KC.get_shell_msg(timeout=TIMEOUT)
     validate_message(reply, 'history_reply', msg_id)
     content = reply['content']
-    nt.assert_equal(len(content['history']), 1)
+    assert len(content['history']) == 1
 
 def test_history_tail():
     flush_channels()
@@ -500,7 +500,7 @@ def test_history_tail():
     reply = KC.get_shell_msg(timeout=TIMEOUT)
     validate_message(reply, 'history_reply', msg_id)
     content = reply['content']
-    nt.assert_equal(len(content['history']), 1)
+    assert len(content['history']) == 1
 
 def test_history_search():
     flush_channels()
@@ -512,7 +512,7 @@ def test_history_search():
     reply = KC.get_shell_msg(timeout=TIMEOUT)
     validate_message(reply, 'history_reply', msg_id)
     content = reply['content']
-    nt.assert_equal(len(content['history']), 1)
+    assert len(content['history']) == 1
 
 # IOPub channel
 
@@ -525,7 +525,7 @@ def test_stream():
     stdout = KC.iopub_channel.get_msg(timeout=TIMEOUT)
     validate_message(stdout, 'stream', msg_id)
     content = stdout['content']
-    nt.assert_equal(content['text'], u'hi\n')
+    assert content['text'] == u'hi\n'
 
 
 def test_display_data():
@@ -536,4 +536,4 @@ def test_display_data():
     display = KC.iopub_channel.get_msg(timeout=TIMEOUT)
     validate_message(display, 'display_data', parent=msg_id)
     data = display['content']['data']
-    nt.assert_equal(data['text/plain'], u'1')
+    assert data['text/plain'] == u'1'

--- a/ipykernel/tests/test_pickleutil.py
+++ b/ipykernel/tests/test_pickleutil.py
@@ -1,8 +1,5 @@
 
-import os
 import pickle
-
-import nose.tools as nt
 
 from ipykernel.pickleutil import can, uncan, codeutil
 
@@ -24,7 +21,7 @@ def test_no_closure():
     
     pfoo = dumps(foo)
     bar = loads(pfoo)
-    nt.assert_equal(foo(), bar())
+    assert foo() == bar()
 
 def test_generator_closure():
     # this only creates a closure on Python 3
@@ -36,7 +33,7 @@ def test_generator_closure():
     
     pfoo = dumps(foo)
     bar = loads(pfoo)
-    nt.assert_equal(foo(), bar())
+    assert foo() == bar()
 
 def test_nested_closure():
     @interactive
@@ -48,7 +45,7 @@ def test_nested_closure():
     
     pfoo = dumps(foo)
     bar = loads(pfoo)
-    nt.assert_equal(foo(), bar())
+    assert foo() == bar()
 
 def test_closure():
     i = 'i'
@@ -58,11 +55,11 @@ def test_closure():
     
     pfoo = dumps(foo)
     bar = loads(pfoo)
-    nt.assert_equal(foo(), bar())
+    assert foo() == bar()
 
 def test_uncan_bytes_buffer():
     data = b'data'
     canned = can(data)
     canned.buffers = [memoryview(buf) for buf in canned.buffers]
     out = uncan(canned)
-    nt.assert_equal(out, data)
+    assert out == data

--- a/ipykernel/tests/test_serialize.py
+++ b/ipykernel/tests/test_serialize.py
@@ -6,31 +6,22 @@
 import pickle
 from collections import namedtuple
 
-import nose.tools as nt
-
 from ipykernel.serialize import serialize_object, deserialize_object
 from IPython.testing import decorators as dec
 from ipykernel.pickleutil import CannedArray, CannedClass, interactive
-from ipython_genutils.py3compat import iteritems
 
-#-------------------------------------------------------------------------------
-# Globals and Utilities
-#-------------------------------------------------------------------------------
 
 def roundtrip(obj):
     """roundtrip an object through serialization"""
     bufs = serialize_object(obj)
     obj2, remainder = deserialize_object(bufs)
-    nt.assert_equals(remainder, [])
+    assert remainder == []
     return obj2
 
 
 SHAPES = ((100,), (1024,10), (10,8,6,5), (), (0,))
 DTYPES = ('uint8', 'float64', 'int32', [('g', 'float32')], '|S10')
 
-#-------------------------------------------------------------------------------
-# Tests
-#-------------------------------------------------------------------------------
 
 def new_array(shape, dtype):
     import numpy
@@ -44,7 +35,7 @@ def test_roundtrip_simple():
         (b'123', 'hello'),
     ]:
         obj2 = roundtrip(obj)
-        nt.assert_equal(obj, obj2)
+        assert obj == obj2
 
 def test_roundtrip_nested():
     for obj in [
@@ -52,7 +43,7 @@ def test_roundtrip_nested():
         [range(5),[range(3),(1,[b'whoda'])]],
     ]:
         obj2 = roundtrip(obj)
-        nt.assert_equal(obj, obj2)
+        assert obj == obj2
 
 def test_roundtrip_buffered():
     for obj in [
@@ -61,19 +52,19 @@ def test_roundtrip_buffered():
         [b"hello"*501, 1,2,3]
     ]:
         bufs = serialize_object(obj)
-        nt.assert_equal(len(bufs), 2)
+        assert len(bufs) == 2
         obj2, remainder = deserialize_object(bufs)
-        nt.assert_equal(remainder, [])
-        nt.assert_equal(obj, obj2)
+        assert remainder == []
+        assert obj == obj2
 
 def test_roundtrip_memoryview():
     b = b'asdf' * 1025
     view = memoryview(b)
     bufs = serialize_object(view)
-    nt.assert_equal(len(bufs), 2)
+    assert len(bufs) == 2
     v2, remainder = deserialize_object(bufs)
-    nt.assert_equal(remainder, [])
-    nt.assert_equal(v2.tobytes(), b)
+    assert remainder == []
+    assert v2.tobytes() == b
 
 @dec.skip_without('numpy')
 def test_numpy():
@@ -85,9 +76,9 @@ def test_numpy():
             bufs = serialize_object(A)
             bufs = [memoryview(b) for b in bufs]
             B, r = deserialize_object(bufs)
-            nt.assert_equal(r, [])
-            nt.assert_equal(A.shape, B.shape)
-            nt.assert_equal(A.dtype, B.dtype)
+            assert r == []
+            assert A.shape == B.shape
+            assert A.dtype == B.dtype
             assert_array_equal(A,B)
 
 @dec.skip_without('numpy')
@@ -103,9 +94,9 @@ def test_recarray():
 
             bufs = serialize_object(A)
             B, r = deserialize_object(bufs)
-            nt.assert_equal(r, [])
-            nt.assert_equal(A.shape, B.shape)
-            nt.assert_equal(A.dtype, B.dtype)
+            assert r == []
+            assert A.shape == B.shape
+            assert A.dtype == B.dtype
             assert_array_equal(A,B)
 
 @dec.skip_without('numpy')
@@ -117,12 +108,12 @@ def test_numpy_in_seq():
             A = new_array(shape, dtype=dtype)
             bufs = serialize_object((A,1,2,b'hello'))
             canned = pickle.loads(bufs[0])
-            nt.assert_is_instance(canned[0], CannedArray)
+            assert isinstance(canned[0], CannedArray)
             tup, r = deserialize_object(bufs)
             B = tup[0]
-            nt.assert_equal(r, [])
-            nt.assert_equal(A.shape, B.shape)
-            nt.assert_equal(A.dtype, B.dtype)
+            assert r == []
+            assert A.shape == B.shape
+            assert A.dtype == B.dtype
             assert_array_equal(A,B)
 
 @dec.skip_without('numpy')
@@ -134,12 +125,12 @@ def test_numpy_in_dict():
             A = new_array(shape, dtype=dtype)
             bufs = serialize_object(dict(a=A,b=1,c=range(20)))
             canned = pickle.loads(bufs[0])
-            nt.assert_is_instance(canned['a'], CannedArray)
+            assert isinstance(canned['a'], CannedArray)
             d, r = deserialize_object(bufs)
             B = d['a']
-            nt.assert_equal(r, [])
-            nt.assert_equal(A.shape, B.shape)
-            nt.assert_equal(A.dtype, B.dtype)
+            assert r == []
+            assert A.shape == B.shape
+            assert A.dtype == B.dtype
             assert_array_equal(A,B)
 
 def test_class():
@@ -148,10 +139,10 @@ def test_class():
         a=5
     bufs = serialize_object(dict(C=C))
     canned = pickle.loads(bufs[0])
-    nt.assert_is_instance(canned['C'], CannedClass)
+    assert isinstance(canned['C'], CannedClass)
     d, r = deserialize_object(bufs)
     C2 = d['C']
-    nt.assert_equal(C2.a, C.a)
+    assert C2.a == C.a
 
 def test_class_oldstyle():
     @interactive
@@ -160,18 +151,18 @@ def test_class_oldstyle():
 
     bufs = serialize_object(dict(C=C))
     canned = pickle.loads(bufs[0])
-    nt.assert_is_instance(canned['C'], CannedClass)
+    assert isinstance(canned['C'], CannedClass)
     d, r = deserialize_object(bufs)
     C2 = d['C']
-    nt.assert_equal(C2.a, C.a)
+    assert C2.a == C.a
 
 def test_tuple():
     tup = (lambda x:x, 1)
     bufs = serialize_object(tup)
     canned = pickle.loads(bufs[0])
-    nt.assert_is_instance(canned, tuple)
+    assert isinstance(canned, tuple)
     t2, r = deserialize_object(bufs)
-    nt.assert_equal(t2[0](t2[1]), tup[0](tup[1]))
+    assert t2[0](t2[1]) == tup[0](tup[1])
 
 point = namedtuple('point', 'x y')
 
@@ -179,18 +170,18 @@ def test_namedtuple():
     p = point(1,2)
     bufs = serialize_object(p)
     canned = pickle.loads(bufs[0])
-    nt.assert_is_instance(canned, point)
+    assert isinstance(canned, point)
     p2, r = deserialize_object(bufs, globals())
-    nt.assert_equal(p2.x, p.x)
-    nt.assert_equal(p2.y, p.y)
+    assert p2.x == p.x
+    assert p2.y == p.y
 
 def test_list():
     lis = [lambda x:x, 1]
     bufs = serialize_object(lis)
     canned = pickle.loads(bufs[0])
-    nt.assert_is_instance(canned, list)
+    assert isinstance(canned, list)
     l2, r = deserialize_object(bufs)
-    nt.assert_equal(l2[0](l2[1]), lis[0](lis[1]))
+    assert l2[0](l2[1]) == lis[0](lis[1])
 
 def test_class_inheritance():
     @interactive
@@ -203,8 +194,8 @@ def test_class_inheritance():
 
     bufs = serialize_object(dict(D=D))
     canned = pickle.loads(bufs[0])
-    nt.assert_is_instance(canned['D'], CannedClass)
+    assert isinstance(canned['D'], CannedClass)
     d, r = deserialize_object(bufs)
     D2 = d['D']
-    nt.assert_equal(D2.a, D.a)
-    nt.assert_equal(D2.b, D.b)
+    assert D2.a == D.a
+    assert D2.b == D.b

--- a/ipykernel/tests/test_start_kernel.py
+++ b/ipykernel/tests/test_start_kernel.py
@@ -1,5 +1,3 @@
-import nose.tools as nt
-
 from .test_embed_kernel import setup_kernel
 
 TIMEOUT = 15
@@ -15,19 +13,19 @@ def test_ipython_start_kernel_userns():
         content = msg['content']
         assert content['found']
         text = content['data']['text/plain']
-        nt.assert_in(u'123', text)
+        assert u'123' in text
 
         # user_module should be an instance of DummyMod
         msg_id = client.execute("usermod = get_ipython().user_module")
         msg = client.get_shell_msg(block=True, timeout=TIMEOUT)
         content = msg['content']
-        nt.assert_equal(content['status'], u'ok')
+        assert content['status'] == u'ok'
         msg_id = client.inspect('usermod')
         msg = client.get_shell_msg(block=True, timeout=TIMEOUT)
         content = msg['content']
         assert content['found']
         text = content['data']['text/plain']
-        nt.assert_in(u'DummyMod', text)
+        assert u'DummyMod' in text
 
 def test_ipython_start_kernel_no_userns():
     # Issue #4188 - user_ns should be passed to shell as None, not {}
@@ -39,10 +37,10 @@ def test_ipython_start_kernel_no_userns():
         msg_id = client.execute("usermod = get_ipython().user_module")
         msg = client.get_shell_msg(block=True, timeout=TIMEOUT)
         content = msg['content']
-        nt.assert_equal(content['status'], u'ok')
+        assert content['status'] == u'ok'
         msg_id = client.inspect('usermod')
         msg = client.get_shell_msg(block=True, timeout=TIMEOUT)
         content = msg['content']
         assert content['found']
         text = content['data']['text/plain']
-        nt.assert_not_in(u'DummyMod', text)
+        assert u'DummyMod' not in text

--- a/ipykernel/tests/test_zmq_shell.py
+++ b/ipykernel/tests/test_zmq_shell.py
@@ -92,19 +92,19 @@ class ZMQDisplayPublisherTests(unittest.TestCase):
         that keyword args get assigned correctly, and override
         the defaults.
         """
-        self.assertEqual(self.disp_pub.session, self.session)
-        self.assertEqual(self.disp_pub.pub_socket, self.socket)
+        assert self.disp_pub.session == self.session
+        assert self.disp_pub.pub_socket == self.socket
 
     def test_thread_local_hooks(self):
         """
         Confirms that the thread_local attribute is correctly
         initialised with an empty list for the display hooks
         """
-        self.assertEqual(self.disp_pub._hooks, [])
+        assert self.disp_pub._hooks == []
         def hook(msg):
             return msg
         self.disp_pub.register_hook(hook)
-        self.assertEqual(self.disp_pub._hooks, [hook])
+        assert self.disp_pub._hooks == [hook]
 
         q = Queue()
         def set_thread_hooks():
@@ -112,7 +112,7 @@ class ZMQDisplayPublisherTests(unittest.TestCase):
         t = Thread(target=set_thread_hooks)
         t.start()
         thread_hooks = q.get(timeout=10)
-        self.assertEqual(thread_hooks, [])
+        assert thread_hooks == []
 
     def test_publish(self):
         """
@@ -120,10 +120,9 @@ class ZMQDisplayPublisherTests(unittest.TestCase):
         `send` by default.
         """
         data = dict(a = 1)
-
-        self.assertEqual(self.session.send_count, 0)
+        assert self.session.send_count == 0
         self.disp_pub.publish(data)
-        self.assertEqual(self.session.send_count, 1)
+        assert self.session.send_count == 1
 
     def test_display_hook_halts_send(self):
         """
@@ -136,13 +135,13 @@ class ZMQDisplayPublisherTests(unittest.TestCase):
         hook = NoReturnDisplayHook()
 
         self.disp_pub.register_hook(hook)
-        self.assertEqual(hook.call_count, 0)
-        self.assertEqual(self.session.send_count, 0)
+        assert hook.call_count == 0
+        assert self.session.send_count == 0
 
         self.disp_pub.publish(data)
 
-        self.assertEqual(hook.call_count, 1)
-        self.assertEqual(self.session.send_count, 0)
+        assert hook.call_count == 1
+        assert self.session.send_count == 0
 
     def test_display_hook_return_calls_send(self):
         """
@@ -155,13 +154,13 @@ class ZMQDisplayPublisherTests(unittest.TestCase):
         hook = ReturnDisplayHook()
 
         self.disp_pub.register_hook(hook)
-        self.assertEqual(hook.call_count, 0)
-        self.assertEqual(self.session.send_count, 0)
+        assert hook.call_count == 0
+        assert self.session.send_count == 0
 
         self.disp_pub.publish(data)
 
-        self.assertEqual(hook.call_count, 1)
-        self.assertEqual(self.session.send_count, 1)
+        assert hook.call_count == 1
+        assert self.session.send_count == 1
 
     def test_unregister_hook(self):
         """
@@ -172,13 +171,13 @@ class ZMQDisplayPublisherTests(unittest.TestCase):
         hook = NoReturnDisplayHook()
 
         self.disp_pub.register_hook(hook)
-        self.assertEqual(hook.call_count, 0)
-        self.assertEqual(self.session.send_count, 0)
+        assert hook.call_count == 0
+        assert self.session.send_count == 0
 
         self.disp_pub.publish(data)
 
-        self.assertEqual(hook.call_count, 1)
-        self.assertEqual(self.session.send_count, 0)
+        assert hook.call_count == 1
+        assert self.session.send_count == 0
 
         #
         # After unregistering the `NoReturn` hook, any calls
@@ -193,8 +192,8 @@ class ZMQDisplayPublisherTests(unittest.TestCase):
         self.disp_pub.publish(data)
 
         self.assertTrue(first)
-        self.assertEqual(hook.call_count, 1)
-        self.assertEqual(self.session.send_count, 1)
+        assert hook.call_count == 1
+        assert self.session.send_count == 1
 
         #
         # If a hook is not installed, `unregister_hook`

--- a/ipykernel/tests/utils.py
+++ b/ipykernel/tests/utils.py
@@ -17,7 +17,6 @@ except ImportError:
     from Queue import Empty  # Py 2
 
 import nose
-import nose.tools as nt
 
 from jupyter_client import manager
 
@@ -68,12 +67,12 @@ def execute(code='', kc=None, **kwargs):
     validate_message(reply, 'execute_reply', msg_id)
     busy = kc.get_iopub_msg(timeout=TIMEOUT)
     validate_message(busy, 'status', msg_id)
-    nt.assert_equal(busy['content']['execution_state'], 'busy')
+    assert busy['content']['execution_state'] == 'busy'
 
     if not kwargs.get('silent'):
         execute_input = kc.get_iopub_msg(timeout=TIMEOUT)
         validate_message(execute_input, 'execute_input', msg_id)
-        nt.assert_equal(execute_input['content']['code'], code)
+        assert execute_input['content']['code'] == code
 
     # show tracebacks if present for debugging
     if reply['content'].get('traceback'):

--- a/setup.py
+++ b/setup.py
@@ -102,7 +102,11 @@ if any(a.startswith(('bdist', 'build', 'install')) for a in sys.argv):
 
 extras_require = setuptools_args['extras_require'] = {
     'test:python_version=="2.7"': ['mock'],
-    'test': ['nose_warnings_filters', 'nose-timer'],
+    'test': [
+        'pytest',
+        'pytest-cov',
+        'nose', # nose because there are still a few nose.tools imports hanging around
+    ],
 }
 
 if 'setuptools' in sys.modules:

--- a/setup.py
+++ b/setup.py
@@ -102,8 +102,10 @@ if any(a.startswith(('bdist', 'build', 'install')) for a in sys.argv):
 
 extras_require = setuptools_args['extras_require'] = {
     'test:python_version=="2.7"': ['mock'],
+    # pytest 3.3 doesn't work on Python 3.3
+    'test:python_version=="3.3"': ['pytest==3.2.*'],
+    'test:python_version!="3.3"': ['pytest>=3.2'],
     'test': [
-        'pytest',
         'pytest-cov',
         'nose', # nose because there are still a few nose.tools imports hanging around
     ],


### PR DESCRIPTION
Switching the test runner Just Works™. I did a quick find-replace pass on the simpler nose asserts, but didn't get all of them, so `nose` is still sitting as a dependency. Nose asserts work fine in pytest, so I don't feel a lot of pressure to finish this up immediately.

- builtin support for showing slow tests (--durations=N slowest test times)
- better error reporting of failures
- Only downside I think is that we lose nose_warnings_filters. I don't know a pytest equivalent, but it does have good [warnings capture](https://docs.pytest.org/en/latest/warnings.html), so adapting the plugin to run as a pytest fixture shouldn't be too much work.