### PR TITLE
Change registration of the qt eventloop after a similar change in IPython

### DIFF
--- a/ipykernel/eventloops.py
+++ b/ipykernel/eventloops.py
@@ -96,7 +96,7 @@ def _loop_qt(app):
     app._in_event_loop = False
 
 
-@register_integration('qt', 'qt4')
+@register_integration('qt4')
 def loop_qt4(kernel):
     """Start a kernel with PyQt4 event loop integration."""
 
@@ -116,7 +116,7 @@ def loop_qt4_exit(kernel):
     kernel.app.exit()
 
 
-@register_integration('qt5')
+@register_integration('qt', 'qt5')
 def loop_qt5(kernel):
     """Start a kernel with PyQt5 event loop integration."""
     os.environ['QT_API'] = 'pyqt5'


### PR DESCRIPTION
It took me several hours to figure this one out!! After ipython/ipython#10756, you can't run `%matplotlib qt5` in any Jupyter client that uses `ipykernel` because it's broken.

This was reported in spyder-ide/spyder#6091 and I created spyder-ide/spyder#6121 to deal with this problem in our side.


  