### PR TITLE
Revert "Add activate_matplotlib() to _enable_matplotlib_integration()"

### DIFF
--- a/ipykernel/pylab/backend_inline.py
+++ b/ipykernel/pylab/backend_inline.py
@@ -150,14 +150,12 @@ def _enable_matplotlib_integration():
     ip = get_ipython()
     backend = get_backend()
     if ip and backend == 'module://%s' % __name__:
-        from IPython.core.pylabtools import configure_inline_support, activate_matplotlib
+        from IPython.core.pylabtools import configure_inline_support
         try:
-            activate_matplotlib(backend)
             configure_inline_support(ip, backend)
-        except (ImportError, AttributeError):
+        except ImportError:
             # bugs may cause a circular import on Python 2
             def configure_once(*args):
-                activate_matplotlib(backend)
                 configure_inline_support(ip, backend)
                 ip.events.unregister('post_run_cell', configure_once)
             ip.events.register('post_run_cell', configure_once)


### PR DESCRIPTION
This reverts commit 42afe03eff5be34737ed88b9b852161132628997.

Prior to this, one had to explicitly call %matplotlib inline. Avoiding this was useful for generating plots across multiple cells, which is impossible with it activated. Moreover, calling activate_matplotlib() overrides matplotlibrc for important properties like the figure DPI, which can be avoided by not calling it.
  