### PR TITLE
fix %gui asyncio with tornado 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,6 @@ install:
     - |
       pip install --upgrade setuptools pip
       pip install --pre .
-      # temp fix: pin tornado < 5
-      pip install 'tornado<5'
       pip install ipykernel[test] codecov
     - |
       if [[ "$TRAVIS_PYTHON_VERSION" == "3.6" ||  "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,7 +25,6 @@ install:
         pip install ipykernel[test]
   - cmd: |
         pip install matplotlib numpy
-        pip install "tornado<5"
         pip freeze
   - cmd: python -c "import ipykernel.kernelspec; ipykernel.kernelspec.install(user=True)"
 test_script:

--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -257,7 +257,7 @@ class Kernel(SingletonConfigurable):
             # which may be skipped by entering the eventloop
             stream.flush(zmq.POLLOUT)
         # restore default_int_handler
-        signal(SIGINT, default_int_handler)
+        self.pre_handler_hook()
         while self.eventloop is not None:
             try:
                 self.eventloop(self)
@@ -269,6 +269,7 @@ class Kernel(SingletonConfigurable):
                 # eventloop exited cleanly, this means we should stop (right?)
                 self.eventloop = None
                 break
+        self.post_handler_hook()
         self.log.info("exiting eventloop")
 
     def start(self):

--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -50,7 +50,8 @@ class Kernel(SingletonConfigurable):
     def _update_eventloop(self, change):
         """schedule call to eventloop from IOLoop"""
         loop = ioloop.IOLoop.current()
-        loop.add_callback(self.enter_eventloop)
+        if change.new is not None:
+            loop.add_callback(self.enter_eventloop)
 
     session = Instance(Session, allow_none=True)
     profile_dir = Instance('IPython.core.profiledir.ProfileDir', allow_none=True)


### PR DESCRIPTION
Fixes test failures when tornado runs on asyncio (tornado 5 + Python ≥3.5).