### PR TITLE
set ROUTER_HANDOVER where available

### DIFF
--- a/ipykernel/kernelapp.py
+++ b/ipykernel/kernelapp.py
@@ -248,6 +248,14 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp,
         self.control_port = self._bind_socket(self.control_socket, self.control_port)
         self.log.debug("control ROUTER Channel on port: %i" % self.control_port)
 
+        if hasattr(zmq, 'ROUTER_HANDOVER'):
+            # set router-handover to workaround zeromq reconnect problems
+            # in certain rare circumstances
+            # see ipython/ipykernel#270 and zeromq/libzmq#2892
+            self.shell_socket.router_handover = \
+                self.control_socket.router_handover = \
+                self.stdin_socket.router_handover = 1
+
         self.init_iopub(context)
 
     def init_iopub(self, context):


### PR DESCRIPTION
workaround libzmq bug when reconnecting sockets with the same identity while *not* in libzmq API call (i.e. kernel busy)

workaround for zeromq/libzmq#2892

closes #270