### PR TITLE
Include minor version in KERNEL_SPEC

### DIFF
--- a/ipykernel/kernelspec.py
+++ b/ipykernel/kernelspec.py
@@ -16,7 +16,7 @@ from jupyter_client.kernelspec import KernelSpecManager
 
 pjoin = os.path.join
 
-KERNEL_NAME = 'python%i' % sys.version_info[0]
+KERNEL_NAME = 'python%i.%i' % (sys.version_info[0], sys.version_info[1])
 
 # path to kernelspec resources
 RESOURCES = pjoin(os.path.dirname(__file__), 'resources')


### PR DESCRIPTION
This change allows concurrent installation of ipykernel under
multiple minor versions of the same major version because of files
that are installed to share/jupyter/kernels/${KERNEL_NAME}.