### PR TITLE
Add and register a comm to register *other* comms

### DIFF
--- a/ipykernel/comm/comms.py
+++ b/ipykernel/comm/comms.py
@@ -1,0 +1,17 @@
+REGISTER_TARGET_COMM_TARGET_NAME = 'register_target'
+
+
+def configure_comm(comm, comm_id, msg_callback):
+    comm.comm_id = comm_id
+    comm.on_msg(msg_callback)
+
+
+def register_target_comm_open(comm, open_msg):
+    # Register a new comm target.
+    def msg_callback(msg):
+        data = msg['content']['data']
+        comm.kernel.comm_manager.register_target(
+            target_name=data['new_target_name'],
+            f=data['comm_open_callback']
+        )
+    configure_comm(comm, comm_id='', msg_callback=msg_callback)

--- a/ipykernel/ipkernel.py
+++ b/ipykernel/ipkernel.py
@@ -8,7 +8,7 @@ from ipython_genutils.py3compat import builtin_mod, PY3, unicode_type, safe_unic
 from IPython.utils.tokenutil import token_at_cursor, line_at_cursor
 from traitlets import Instance, Type, Any, List, Bool
 
-from .comm import CommManager
+from .comm import CommManager, comms
 from .kernelbase import Kernel as KernelBase
 from .zmqshell import ZMQInteractiveShell
 
@@ -69,6 +69,11 @@ class IPythonKernel(KernelBase):
         comm_msg_types = [ 'comm_open', 'comm_msg', 'comm_close' ]
         for msg_type in comm_msg_types:
             self.shell_handlers[msg_type] = getattr(self.comm_manager, msg_type)
+
+        self.comm_manager.register_target(
+            target_name=comms.REGISTER_TARGET_COMM_TARGET_NAME,
+            f=comms.register_target_comm_open
+        )
 
     help_links = List([
         {


### PR DESCRIPTION
This comm allows a client to send comm-messages to it, containing
data specifying a new comm to register on the kernel. This minimal
comm allows much greater extension of the kernel's behaviour, when
access to the kernel object isn't available.

The comm is registered, but not started, when the kernel is
initialized. A comm-open message can be sent to start it, then
comm-messages sent to register new comms, to perform arbitrary
actions on the kernel side.