### PR TITLE
avoid absolute paths in data_files

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -97,7 +97,8 @@ if any(a.startswith(('bdist', 'build', 'install')) for a in sys.argv):
     write_kernel_spec(dest, overrides={'argv': argv})
 
     setup_args['data_files'] = [
-        (pjoin('share', 'jupyter', 'kernels', KERNEL_NAME), glob(pjoin(dest, '*'))),
+        (pjoin('share', 'jupyter', 'kernels', KERNEL_NAME),
+         glob(pjoin('data_kernelspec', '*'))),
     ]
 
 extras_require = setuptools_args['extras_require'] = {


### PR DESCRIPTION
usig absolute paths here causes problems for installs from sdist

We should release 4.8.1 with this, since installations are having issues on Windows.