### PR TITLE
ensure qt zmq streams starts in a clean state

### DIFF
--- a/ipykernel/eventloops.py
+++ b/ipykernel/eventloops.py
@@ -41,6 +41,11 @@ def _notify_stream_qt(kernel, stream):
     fd = stream.getsockopt(zmq.FD)
     notifier = QtCore.QSocketNotifier(fd, QtCore.QSocketNotifier.Read, kernel.app)
     notifier.activated.connect(process_stream_events)
+    # there may already be events waiting,
+    # which won't wake zmq's edge-triggered FD
+    # make sure that waiting events are processed immediately
+    # so we start in a clean state
+    process_stream_events()
 
 # mapping of keys to loop functions
 loop_map = {


### PR DESCRIPTION
adding a listener on stream.FD won’t reliably wake the eventloop if there are already events waiting to be processed. We must check socket.EVENTS and process any waiting events before waiting on zmq.FD, or we will never wake.

This fixes the bug reported in https://github.com/zeromq/pyzmq/issues/1140

It's caused by updating pyzmq to version 17,
where the tornado eventloop integration also relies on zmq.FD rather than zmq_poll, which allows the initial state of the FD to be consumed (by tornado) while there are events waiting to be processed (because tornado is paused indefinitely).

I think there's something fragile in our multi-eventloop integration because we aren't explicitly advancing the tornado eventloop at all when a GUI eventloop is running, only our `kernel.do_one_iteration` callback. This means that any callbacks registered directly with tornado/asyncio will not run while eventloop integration is enabled.

cc @ccordoba12 who reported the issue. Can you confirm this fixes it for you?