### PR TITLE
include the pytest cache in the gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ __pycache__
 .coverage
 
 data_kernelspec
+.pytest_cache


### PR DESCRIPTION
I wanted to run exactly what was running on Travis and noticed the pytest cache artifacts were not git ignored.