### PR TITLE
Adds metadata to help display matplotlib figures legibly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ python:
     - 3.6
     - 3.5
     - 3.4
-    - 3.3
     - 2.7
 sudo: false
 install:

--- a/setup.py
+++ b/setup.py
@@ -16,8 +16,8 @@ name = 'ipykernel'
 import sys
 
 v = sys.version_info
-if v[:2] < (2,7) or (v[0] >= 3 and v[:2] < (3,3)):
-    error = "ERROR: %s requires Python version 2.7 or 3.3 or above." % name
+if v[:2] < (2,7) or (v[0] >= 3 and v[:2] < (3,4)):
+    error = "ERROR: %s requires Python version 2.7 or 3.4 or above." % name
     print(error, file=sys.stderr)
     sys.exit(1)
 
@@ -103,10 +103,8 @@ if any(a.startswith(('bdist', 'build', 'install')) for a in sys.argv):
 
 extras_require = setuptools_args['extras_require'] = {
     'test:python_version=="2.7"': ['mock'],
-    # pytest 3.3 doesn't work on Python 3.3
-    'test:python_version=="3.3"': ['pytest==3.2.*'],
-    'test:python_version!="3.3"': ['pytest>=3.2'],
     'test': [
+        'pytest',
         'pytest-cov',
         'nose', # nose because there are still a few nose.tools imports hanging around
     ],

--- a/setup.py
+++ b/setup.py
@@ -101,6 +101,9 @@ if any(a.startswith(('bdist', 'build', 'install')) for a in sys.argv):
          glob(pjoin('data_kernelspec', '*'))),
     ]
 
+
+setuptools_args['python_requires'] = '>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*'
+
 extras_require = setuptools_args['extras_require'] = {
     'test:python_version=="2.7"': ['mock'],
     'test': [


### PR DESCRIPTION
This is the sister PR of jupyterlab/jupyterlab#5232.

This PR adds some code so that when the matplotlib inline backend is enabled, one piece of extra metadata (`'needs-background'`) is passed along with each figure. This allows frontends to intelligently display a background behind the figure if it's needed to make the tick labels on the figure legible. This is implemented as so:

Whenever the inline backend calls the `display(fig, metadata)` function, `fig` is first checked to see if it has a transparent background. If it does, the color of each tick label in the figure is checked to see if it's light or dark. If all of the ticks are light, then `'needs-background': 'light'` is added to `metadata`, or if all are dark then `'needs-background': 'dark'` is added. Otherwise, nothing is added to `metadata`.

See jupyterlab/jupyterlab#5232 for an example of an implementation of a frontend legibility fix using `'needs-background'`.