### PR TITLE
Add release process to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,60 @@
 # Contributing
 
-We follow the [IPython Contributing Guide](https://github.com/ipython/ipython/blob/master/CONTRIBUTING.md).
+Welcome!
+
+For contributing tips, follow the [Jupyter Contributing Guide](https://jupyter.readthedocs.io/en/latest/contributor/content-contributor.html).
+Please make sure to follow the [Jupyter Code of Conduct](https://github.com/jupyter/governance/blob/master/conduct/code_of_conduct.md).
+
+## Installing ipykernel for development
+
+ipykernel is a pure Python package, so setting up for development is the same as most other Python projects:
+
+```bash
+# clone the repo
+git clone https://github.com/ipython/ipykernel
+cd ipykernel
+# do a 'development' or 'editable' install with pip:
+pip install -e .
+```
+
+## Releasing ipykernel
+
+Releasing ipykernel is *almost* standard for a Python package:
+
+- set version for release
+- make and publish tag
+- publish release to PyPI
+- set version back to development
+
+The one extra step for ipykernel is that we need to make separate wheels for Python 2 and 3
+because the bundled kernelspec has different contents for Python 2 and 3.
+
+The full release process is available below:
+
+```bash
+# make sure version is set in ipykernel/_version.py
+VERSION="4.9.0"
+# commit the version and make a release tag
+git add ipykernel/_version.py
+git commit -m "release $VERSION"
+git tag -am "release $VERSION" $VERSION
+
+# push the changes to the repo
+git push
+git push --tags
+
+# publish the release to PyPI
+# note the extra `python2 setup.py bdist_wheel` for creating
+# the wheel for Python 2
+pip install --upgrade twine
+git clean -xfd
+python3 setup.py sdist bdist_wheel
+python2 setup.py bdist_wheel  # the extra step!
+twine upload dist/*
+
+# set the version back to '.dev' in ipykernel/_version.py
+# e.g. 4.10.0.dev if we just released 4.9.0
+git add ipykernel/_version.py
+git commit -m "back to dev"
+git push
+```

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
 include COPYING.md
 include CONTRIBUTING.md
 include README.md
+include pyproject.toml
 
 # Documentation
 graft docs

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,7 +18,7 @@ init:
   - cmd: set PATH=%python%;%python%\scripts;%PATH%
 install:
   - cmd: |
-        python -m pip install --upgrade pip wheel
+        python -m pip install --upgrade setuptools pip wheel
         pip --version
   - cmd: |
         pip install --pre -e .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,8 @@
+[build-system]
+requires=[
+  "setuptools",
+  "wheel",
+  "ipython>=5",
+  "jupyter_core>=4.2",
+  "jupyter_client",
+]

--- a/setup.py
+++ b/setup.py
@@ -78,6 +78,7 @@ setup_args = dict(
     author_email='ipython-dev@scipy.org',
     url='https://ipython.org',
     license='BSD',
+    long_description="The IPython kernel for Jupyter",
     platforms="Linux, Mac OS X, Windows",
     keywords=['Interactive', 'Interpreter', 'Shell', 'Web'],
     python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,6 @@ setup_args = dict(
     platforms="Linux, Mac OS X, Windows",
     keywords=['Interactive', 'Interpreter', 'Shell', 'Web'],
     python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
-    setup_requires=['ipython', 'jupyter_core>=4.2'],
     install_requires=[
         'ipython>=4.0.0',
         'traitlets>=4.1.0',


### PR DESCRIPTION
- setup.py updated to use setuptools unconditionally (bdist_egg_disabled for disabling implicit eggs)
- setup.py adds setup_requires needed for the kernelspec step when installing from sdist (fixes #338)
- add release process to CONTRIBUTING.md