### PR TITLE
Update version str to be pep 440 compliant, start beta1

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,8 +9,10 @@ Changes in IPython kernel
 
 `5.0.0 on GitHub <https://github.com/ipython/ipykernel/milestones/5.0>`__
 
+- Drop support for Python 2. ``ipykernel`` 5.0 requires Python >= 3.4
 - Add support for IPython's asynchronous code execution (:ghpull:`323`)
 - Update release process in ``CONTRIBUTING.md`` (:ghpull:`339`)
+
 
 4.9
 ---

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,17 @@
 Changes in IPython kernel
 =========================
 
+5.0
+---
+
+5.0.0
+*****
+
+`4.9.0 on GitHub <https://github.com/ipython/ipykernel/milestones/5.0>`__
+
+- Add Support for IPython's Asynchronous code execution (:ghpull:`323`)
+- Update release Process in ``Contributing.md`` (:ghpull:`339`)
+
 4.9
 ---
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,10 +7,10 @@ Changes in IPython kernel
 5.0.0
 *****
 
-`4.9.0 on GitHub <https://github.com/ipython/ipykernel/milestones/5.0>`__
+`5.0.0 on GitHub <https://github.com/ipython/ipykernel/milestones/5.0>`__
 
-- Add Support for IPython's Asynchronous code execution (:ghpull:`323`)
-- Update release Process in ``Contributing.md`` (:ghpull:`339`)
+- Add support for IPython's asynchronous code execution (:ghpull:`323`)
+- Update release process in ``CONTRIBUTING.md`` (:ghpull:`339`)
 
 4.9
 ---

--- a/ipykernel/_version.py
+++ b/ipykernel/_version.py
@@ -1,5 +1,16 @@
-version_info = (5, 0, 0, 'dev')
-__version__ = '.'.join(map(str, version_info))
+version_info = (5, 0, 0, 'b1')
+__version__ = '.'.join(map(str, version_info[:3]))
+
+# pep440 is annoying, beta/alpha/rc should _not_ have dots or pip/setuptools
+# confuses which one between the wheel and sdist is the most recent.
+if len(version_info) == 4:
+    extra = version_info[3]
+    if extra.startswith(('a','b','rc')):
+        __version__ = __version__+extra
+    else:
+        __version__ = __version__+'.'+extra
+if len(version_info) > 4:
+    raise NotImplementedError
 
 kernel_protocol_version_info = (5, 1)
 kernel_protocol_version = '%s.%s' % kernel_protocol_version_info

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ name = 'ipykernel'
 #-----------------------------------------------------------------------------
 
 import sys
+import re
 
 v = sys.version_info
 if v[:2] < (3, 4):
@@ -60,10 +61,16 @@ version_ns = {}
 with open(pjoin(here, name, '_version.py')) as f:
     exec(f.read(), {}, version_ns)
 
+current_version = version_ns['__version__']
+
+loose_pep440re = re.compile(r'^(\d+)\.(\d+)\.(\d+((a|b|rc)\d+)?)(\.post\d+)?(\.dev\d*)?$')
+if not loose_pep440re.match(current_version):
+    raise ValueError("Version number '%s' is not valid (should match [N!]N(.N)*[{a|b|rc}N][.postN][.devN])" % current_version)
+
 
 setup_args = dict(
     name=name,
-    version=version_ns['__version__'],
+    version=current_version,
     cmdclass={
         'bdist_egg': bdist_egg if 'bdist_egg' in sys.argv else bdist_egg_disabled,
     },


### PR DESCRIPTION
- should we also drop 3.4 in IPykernel 5.0 ? 
- Jump version number ot 7.0 to re-sync with IPython ? 