### PR TITLE
Check that sys.stdout/err is not None before flushing

### DIFF
--- a/ipykernel/kernelapp.py
+++ b/ipykernel/kernelapp.py
@@ -323,7 +323,8 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp,
         """Redirect input streams and set a display hook."""
         if self.outstream_class:
             outstream_factory = import_item(str(self.outstream_class))
-            sys.stdout.flush()
+            if sys.stdout is not None:
+                sys.stdout.flush()
 
             e_stdout = None if self.quiet else sys.__stdout__
             e_stderr = None if self.quiet else sys.__stderr__
@@ -331,7 +332,8 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp,
             sys.stdout = outstream_factory(self.session, self.iopub_thread,
                                            u'stdout',
                                            echo=e_stdout)
-            sys.stderr.flush()
+            if sys.stderr is not None:
+                sys.stderr.flush()
             sys.stderr = outstream_factory(self.session, self.iopub_thread,
                                            u'stderr',
                                            echo=e_stderr)


### PR DESCRIPTION
On Windows it seems that sys.stdout and possibly sys.stderr can be None. 
This happens at startup of the kernel in Spyder e.g 
https://github.com/spyder-ide/spyder/issues/7842 and multiple duplicates.

The change to flush was introduced in 4.9 with https://github.com/ipython/ipykernel/pull/314

Checking that setout/stderr is not None before flushing seems to be enough to fix the issue for me. 

