### PR TITLE
Remove colors_force flag

### DIFF
--- a/ipykernel/zmqshell.py
+++ b/ipykernel/zmqshell.py
@@ -453,7 +453,6 @@ class ZMQInteractiveShell(InteractiveShell):
     # Override the traitlet in the parent class, because there's no point using
     # readline for the kernel. Can be removed when the readline code is moved
     # to the terminal frontend.
-    colors_force = CBool(True)
     readline_use = CBool(False)
     # autoindent has no meaning in a zmqshell, and attempting to enable it
     # will print a warning in the absence of readline.

--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,7 @@ setup_args = dict(
     keywords=['Interactive', 'Interpreter', 'Shell', 'Web'],
     python_requires='>=3.4',
     install_requires=[
-        'ipython>=4.0.0',
+        'ipython>=5.0.0',
         'traitlets>=4.1.0',
         'jupyter_client',
         'tornado>=4.2',


### PR DESCRIPTION
See ipython/ipython#9673.

This will disable colours if ipykernel is installed with IPython <5, so
I'm bumping the IPython requirement in setup.py. So this probably can't
be merged until after IPython 5 is released.

-- 

Replace #146 