### PR TITLE
Remove usage of deprecated utils.

### DIFF
--- a/ipykernel/eventloops.py
+++ b/ipykernel/eventloops.py
@@ -13,7 +13,6 @@ import zmq
 
 from distutils.version import LooseVersion as V
 from traitlets.config.application import Application
-from IPython.utils import io
 
 
 def _use_appnope():
@@ -299,7 +298,7 @@ def loop_cocoa(kernel):
         # wake the eventloop when we get a signal
         stop()
         if etype is KeyboardInterrupt:
-            io.raw_print("KeyboardInterrupt caught in CFRunLoop")
+            print("KeyboardInterrupt caught in CFRunLoop", file=sys.__stdout__)
         else:
             real_excepthook(etype, value, tb)
 
@@ -319,7 +318,7 @@ def loop_cocoa(kernel):
                 raise
         except KeyboardInterrupt:
             # Ctrl-C shouldn't crash the kernel
-            io.raw_print("KeyboardInterrupt caught in kernel")
+            print("KeyboardInterrupt caught in kernel", file=sys.__stdout__)
         finally:
             # ensure excepthook is restored
             sys.excepthook = real_excepthook

--- a/ipykernel/inprocess/blocking.py
+++ b/ipykernel/inprocess/blocking.py
@@ -8,14 +8,13 @@ Useful for test suites and blocking terminal interfaces.
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING.txt, distributed as part of this software.
 #-----------------------------------------------------------------------------
-
+import sys
 try:
     from queue import Queue, Empty  # Py 3
 except ImportError:
     from Queue import Queue, Empty  # Py 2
 
 # IPython imports
-from IPython.utils.io import raw_print
 from traitlets import Type
 
 # Local imports
@@ -66,7 +65,8 @@ class BlockingInProcessStdInChannel(BlockingInProcessChannel):
         if msg_type == 'input_request':
             _raw_input = self.client.kernel._sys_raw_input
             prompt = msg['content']['prompt']
-            raw_print(prompt, end='')
+            print(prompt, end='', file=sys.__stdout__)
+            sys.__stdout__.flush()
             self.client.input(_raw_input())
 
 class BlockingInProcessKernelClient(InProcessKernelClient):

--- a/ipykernel/kernelapp.py
+++ b/ipykernel/kernelapp.py
@@ -24,7 +24,6 @@ from IPython.core.profiledir import ProfileDir
 from IPython.core.shellapp import (
     InteractiveShellApp, shell_flags, shell_aliases
 )
-from IPython.utils import io
 from ipython_genutils.path import filefind, ensure_dir_exists
 from traitlets import (
     Any, Instance, Dict, Unicode, Integer, Bool, DottedObjectName, Type, default
@@ -302,9 +301,9 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp,
         # also raw print to the terminal if no parent_handle (`ipython kernel`)
         # unless log-level is CRITICAL (--quiet)
         if not self.parent_handle and self.log_level < logging.CRITICAL:
-            io.raw_print(_ctrl_c_message)
+            print(_ctrl_c_message, file=sys.__stdout__)
             for line in lines:
-                io.raw_print(line)
+                print(line, file=sys.__stdout__)
 
         self.ports = dict(shell=self.shell_port, iopub=self.iopub_port,
                                 stdin=self.stdin_port, hb=self.hb_port,


### PR DESCRIPTION
IPython.utils.io.raw_print* have been deprected. Do not use, and print
directly to __stdout__, flushing if end is not a new line.