### PR TITLE
Handle signal exceptions, fix for issue 11258

### DIFF
--- a/ipykernel/kernelapp.py
+++ b/ipykernel/kernelapp.py
@@ -474,7 +474,13 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp,
         # file is definitely available at the time someone reads the log.
         self.log_connection_info()
         self.init_io()
-        self.init_signal()
+        try:
+            self.init_signal()
+        except:
+            # Catch exception when initializing signal fails, eg when running the 
+            # kernel on a separate thread 
+            if self.log_level < logging.CRITICAL:
+                self.log.error("Unable to initialize signal:", exc_info=True)
         self.init_kernel()
         # shell init steps
         self.init_path()

--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -254,13 +254,19 @@ class Kernel(SingletonConfigurable):
             self.log.warning("Unknown message type: %r", msg_type)
         else:
             self.log.debug("%s: %s", msg_type, msg)
-            self.pre_handler_hook()
+            try:
+                self.pre_handler_hook()
+            except Exception:
+                self.log.debug("Unable to signal in pre_handler_hook:", exc_info=True)
             try:
                 yield gen.maybe_future(handler(stream, idents, msg))
             except Exception:
                 self.log.error("Exception in message handler:", exc_info=True)
             finally:
-                self.post_handler_hook()
+                try:
+                    self.post_handler_hook()
+                except Exception:
+                    self.log.debug("Unable to signal in post_handler_hook:", exc_info=True)
 
         sys.stdout.flush()
         sys.stderr.flush()


### PR DESCRIPTION
Prior to this change, signal throws an unhandled exception which terminates the ipykernel when ran on a separate thread. This is a problem for embedded applications which need the main thread dedicated to window event polling (eg for GLFW) and would like an ipython kernel running in a separate thread.

With these changes, the unhandled exception is now caught, and displayed as an error, and the kernel keeps running. 

https://github.com/ipython/ipython/issues/11258
