### PR TITLE
Allow `do_inspect` to return a rich display when `enable_html_pager` is True

### DIFF
--- a/ipykernel/ipkernel.py
+++ b/ipykernel/ipkernel.py
@@ -400,18 +400,22 @@ class IPythonKernel(KernelBase):
 
     def do_inspect(self, code, cursor_pos, detail_level=0):
         name = token_at_cursor(code, cursor_pos)
-        info = self.shell.object_inspect(name)
 
         reply_content = {'status' : 'ok'}
-        reply_content['data'] = data = {}
+        reply_content['data'] = {}
         reply_content['metadata'] = {}
-        reply_content['found'] = info['found']
-        if info['found']:
-            info_text = self.shell.object_inspect_text(
-                name,
-                detail_level=detail_level,
+        try:
+            reply_content['data'].update(
+                self.shell.object_inspect_mime(
+                    name,
+                    detail_level=detail_level
+                )
             )
-            data['text/plain'] = info_text
+            if not self.shell.enable_html_pager:
+                reply_content['data'].pop('text/html')
+            reply_content['found'] = True
+        except KeyError:
+            reply_content['found'] = False
 
         return reply_content
 


### PR DESCRIPTION
The JupyterLab inspector can will accept __text/html__ results.  This pull request uses `object_inspect_mime` instead of `object_inspect_text` to inspect objects.  `object_inspect_text` is already calling `object_inspect_mime` to return __plain/text__.  This new feature optionally removes the __text/html__ result data if `enable_html_pager` is False.

This also addresses an old issue #51 and inspects the object once.