### PR TITLE
Fix compatibility with InProcessKernel

### DIFF
--- a/ipykernel/inprocess/ipkernel.py
+++ b/ipykernel/inprocess/ipkernel.py
@@ -83,7 +83,7 @@ class InProcessKernel(IPythonKernel):
         """ Override registration of dispatchers for streams. """
         self.shell.exit_now = False
 
-    def _abort_queue(self, stream):
+    def _abort_queues(self):
         """ The in-process kernel doesn't abort requests. """
         pass
 


### PR DESCRIPTION
From v5.0.0, the `Kernel` class contains an `_abort_queues` function invoked when the shell executes a request that generates an exception. This schedules a message, which clears the abort when dispatched. 

This does not work in the `InProcessKernel`. After an exception, all shell execute requests return an "ERROR: execution aborted" message. This is fixed by overriding the `_abort_queues` function in the parent `Kernel` class by a dummy function in the `InProcessKernel` sub-class (it actually replaces the `_abort_queue` function, which doesn't appear to be used any more).

This is a fix for #370.