### PR TITLE
Fix matplotlib's param not updated in the first cell

### DIFF
--- a/ipykernel/pylab/backend_inline.py
+++ b/ipykernel/pylab/backend_inline.py
@@ -154,14 +154,14 @@ def _enable_matplotlib_integration():
     ip = get_ipython()
     backend = get_backend()
     if ip and backend == 'module://%s' % __name__:
-        from IPython.core.pylabtools import configure_inline_support, activate_matplotlib
+        from IPython.core.pylabtools import configure_inline_support
         try:
-            activate_matplotlib(backend)
+            matplotlib.interactive(True)
             configure_inline_support(ip, backend)
         except (ImportError, AttributeError):
             # bugs may cause a circular import on Python 2
             def configure_once(*args):
-                activate_matplotlib(backend)
+                matplotlib.interactive(True)
                 configure_inline_support(ip, backend)
                 ip.events.unregister('post_run_cell', configure_once)
             ip.events.register('post_run_cell', configure_once)


### PR DESCRIPTION
## Background

#264 is made to remove the necessity of `plt.show()`. However, it causes various problems as reported at #295, https://github.com/jupyter/notebook/issues/3385, https://github.com/ipython/ipython/issues/11098. In addition, even with #264, we need to call `plt.show()` in the first cell. I think that somehow, the line [matplotlib.pyplot.switch_backend(backend)](https://github.com/ipython/ipython/blob/master/IPython/core/pylabtools.py#L314) causes problem. Docs of `switch_backend` method says that "Switching to an interactive backend is possible only if no event loop for another interactive backend has started. Switching to and from non-interactive backends is always possible." As I understand, we should not call `switch_backend` two times in the same cell (even if we have the same backend).

This PR tries to solve above problems by not calling `activate_matplotlib(backend)` but only setting `matplotlib.interactive(True)` in `_enable_matplotlib_integration()` method.

The result works well in my system. RCparams are updated in the first cell. In addition, we don't need to call `plt.show` in the first cell.
