### PR TITLE
ipykernel implements protocol v5.3

### DIFF
--- a/ipykernel/_version.py
+++ b/ipykernel/_version.py
@@ -12,5 +12,5 @@ if len(version_info) == 4:
 if len(version_info) > 4:
     raise NotImplementedError
 
-kernel_protocol_version_info = (5, 1)
+kernel_protocol_version_info = (5, 3)
 kernel_protocol_version = '%s.%s' % kernel_protocol_version_info


### PR DESCRIPTION
the updates to the protocol add specificity, but ipykernel fully implements the latest spec