### PR TITLE
only flush stream in dispatch_shell if possible

### DIFF
--- a/ipykernel/inprocess/client.py
+++ b/ipykernel/inprocess/client.py
@@ -172,6 +172,9 @@ class InProcessKernelClient(KernelClient):
         idents, reply_msg = self.session.recv(stream, copy=False)
         self.shell_channel.call_handlers_later(reply_msg)
 
+    def flush(self):
+        # dummy method (see https://github.com/ipython/ipykernel/pull/405)
+
 
 #-----------------------------------------------------------------------------
 # ABC Registration

--- a/ipykernel/inprocess/client.py
+++ b/ipykernel/inprocess/client.py
@@ -173,7 +173,7 @@ class InProcessKernelClient(KernelClient):
         self.shell_channel.call_handlers_later(reply_msg)
 
     def flush(self):
-        # dummy method (see https://github.com/ipython/ipykernel/pull/405)
+        """no-op to comply with stream API"""
 
 
 #-----------------------------------------------------------------------------

--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -245,10 +245,7 @@ class Kernel(SingletonConfigurable):
             self._publish_status(u'idle')
             # flush to ensure reply is sent before
             # handling the next request
-            try:
-                stream.flush(zmq.POLLOUT)
-            except AttributeError:
-                pass
+            stream.flush(zmq.POLLOUT)
             return
 
         msg_type = msg['header']['msg_type']
@@ -286,10 +283,7 @@ class Kernel(SingletonConfigurable):
         self._publish_status(u'idle')
         # flush to ensure reply is sent before
         # handling the next request
-        try:
-            stream.flush(zmq.POLLOUT)
-        except AttributeError:
-            pass
+        stream.flush(zmq.POLLOUT)
 
     def pre_handler_hook(self):
         """Hook to execute before calling message handler"""

--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -245,7 +245,10 @@ class Kernel(SingletonConfigurable):
             self._publish_status(u'idle')
             # flush to ensure reply is sent before
             # handling the next request
-            stream.flush(zmq.POLLOUT)
+            try:
+                stream.flush(zmq.POLLOUT)
+            except AttributeError:
+                pass
             return
 
         msg_type = msg['header']['msg_type']
@@ -283,7 +286,10 @@ class Kernel(SingletonConfigurable):
         self._publish_status(u'idle')
         # flush to ensure reply is sent before
         # handling the next request
-        stream.flush(zmq.POLLOUT)
+        try:
+            stream.flush(zmq.POLLOUT)
+        except AttributeError:
+            pass
 
     def pre_handler_hook(self):
         """Hook to execute before calling message handler"""


### PR DESCRIPTION
When using an inprocess kernel, the kernel client calls the `dispatch_shell` method with an `ipykernel.inprocess.socker.DummySocket`

https://github.com/ipython/ipykernel/blob/b81632e0a26671e6b100471282cf49ca4a21e681/ipykernel/inprocess/client.py#L170

This method, however, expects the given stream to have a `flush` method 

https://github.com/ipython/ipykernel/blob/b81632e0a26671e6b100471282cf49ca4a21e681/ipykernel/kernelbase.py#L286

which is not True, for the `DummySocket`. This PR proposes to accept failures for the latter by replacing this line with

```python
try:
    stream.flush(zmq.POLLOUT)
except AttributeError:
    pass
```