### PR TITLE
WIP: Feature: fork kernel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ __pycache__
 
 data_kernelspec
 .pytest_cache
+.idea

--- a/ipykernel/heartbeat.py
+++ b/ipykernel/heartbeat.py
@@ -32,7 +32,7 @@ class Heartbeat(Thread):
     def __init__(self, context, addr=None):
         if addr is None:
             addr = ('tcp', localhost(), 0)
-        Thread.__init__(self)
+        Thread.__init__(self, name="Heartbeat")
         self.context = context
         self.transport, self.ip, self.port = addr
         self.original_port = self.port

--- a/ipykernel/iostream.py
+++ b/ipykernel/iostream.py
@@ -69,7 +69,7 @@ class IOPubThread(object):
         self._local = threading.local()
         self._events = deque()
         self._setup_event_pipe()
-        self.thread = threading.Thread(target=self._thread_main)
+        self.thread = threading.Thread(target=self._thread_main, name="IOPub")
         self.thread.daemon = True
 
     def _thread_main(self):

--- a/ipykernel/ipkernel.py
+++ b/ipykernel/ipkernel.py
@@ -164,7 +164,7 @@ class IPythonKernel(KernelBase):
         # This is required by ipyparallel < 5.0
         metadata['status'] = reply_content['status']
         if reply_content['status'] == 'error' and reply_content['ename'] == 'UnmetDependency':
-                metadata['dependencies_met'] = False
+            metadata['dependencies_met'] = False
 
         return metadata
 

--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -171,7 +171,7 @@ class Kernel(SingletonConfigurable):
             metadata = {}
             metadata = self.finish_metadata(parent, metadata, reply_content)
 
-            self.session.send(stream, u'execute_reply',
+            self.session.send(stream, u'fork_reply',
                                         reply_content, parent, metadata=metadata,
                                         ident=ident)
 

--- a/ipykernel/tests/test_kernel.py
+++ b/ipykernel/tests/test_kernel.py
@@ -333,7 +333,7 @@ def test_fork_metadata():
         km = kc.parent
         fork_msg_id = kc.fork()
         fork_reply = kc.get_shell_msg(block=True, timeout=TIMEOUT)
-        # validate_message(fork_reply, "execute_reply", fork_msg_id)  # TODO: Make it work (need the `fork_reply`)
+        validate_message(fork_reply, "fork_reply", fork_msg_id)
         assert fork_msg_id == fork_reply['parent_header']['msg_id'] == fork_msg_id
         assert fork_reply['content']['conn']['key'] != kc.session.key.decode()
         fork_pid = fork_reply['content']['pid']

--- a/ipykernel/tests/test_kernel.py
+++ b/ipykernel/tests/test_kernel.py
@@ -17,10 +17,11 @@ from ipython_genutils import py3compat
 from IPython.paths import locate_profile
 from ipython_genutils.tempdir import TemporaryDirectory
 
+from ipykernel.tests.test_message_spec import validate_message
 from .utils import (
     new_kernel, kernel, TIMEOUT, assemble_output, execute,
     flush_channels, wait_for_idle,
-)
+    connect_to_kernel)
 
 
 def _check_master(kc, expected=True, stream="stdout"):
@@ -326,3 +327,43 @@ def test_shutdown():
             else:
                 break
         assert not km.is_alive()
+
+def test_fork_metadata():
+    with kernel() as kc:
+        km = kc.parent
+        fork_msg_id = kc.fork()
+        fork_reply = kc.get_shell_msg(block=True, timeout=TIMEOUT)
+        # validate_message(fork_reply, "execute_reply", fork_msg_id)  # TODO: Make it work (need the `fork_reply`)
+        assert fork_msg_id == fork_reply['parent_header']['msg_id'] == fork_msg_id
+        assert fork_reply['content']['conn']['key'] != kc.session.key.decode()
+        fork_pid = fork_reply['content']['pid']
+        _check_status(fork_reply['content'])
+        wait_for_idle(kc)
+
+        assert fork_pid != km.kernel.pid
+        #TODO: Inspect if `fork_pid` is running? Might need to use `psutil` for this in order to be cross platform
+
+        with connect_to_kernel(fork_reply['content']['conn'], TIMEOUT) as kc_fork:
+            assert fork_reply['content']['conn']['key'] == kc_fork.session.key.decode()
+            kc_fork.shutdown()
+
+def test_fork():
+    def execute_with_user_expression(kc, code, user_expression):
+        _, reply = execute(code, kc=kc, user_expressions={"my-user-expression": user_expression})
+        content = reply["user_expressions"]["my-user-expression"]["data"]["text/plain"]
+        wait_for_idle(kc)
+        return content
+
+    """Kernel forks after fork_request"""
+    with kernel() as kc:
+        assert execute_with_user_expression(kc, u'a = 1', "a") == "1"
+        assert execute_with_user_expression(kc, u'b = 2', "b") == "2"
+        kc.fork()
+        fork_reply = kc.get_shell_msg(block=True, timeout=TIMEOUT)
+        wait_for_idle(kc)
+
+        with connect_to_kernel(fork_reply['content']['conn'], TIMEOUT) as kc_fork:
+            assert execute_with_user_expression(kc_fork, 'a = 11', "a, b") == str((11, 2))
+            assert execute_with_user_expression(kc_fork, 'b = 12', "a, b") == str((11, 12))
+            assert execute_with_user_expression(kc, 'z = 20', "a, b") == str((1, 2))
+            kc_fork.shutdown()

--- a/ipykernel/tests/test_message_spec.py
+++ b/ipykernel/tests/test_message_spec.py
@@ -195,6 +195,11 @@ class IsCompleteReplyIncomplete(Reference):
     indent = Unicode()
 
 
+class ForkReply(Reply):
+    pid = Integer()
+    conn = Dict()
+
+
 # IOPub messages
 
 class ExecuteInput(Reference):
@@ -240,6 +245,7 @@ references = {
     'stream' : Stream(),
     'display_data' : DisplayData(),
     'header' : RHeader(),
+    'fork_reply' : ForkReply(),
 }
 """
 Specifications of `content` part of the reply messages.

--- a/ipykernel/tests/utils.py
+++ b/ipykernel/tests/utils.py
@@ -170,3 +170,14 @@ def wait_for_idle(kc):
         content = msg['content']
         if msg_type == 'status' and content['execution_state'] == 'idle':
             break
+
+@contextmanager
+def connect_to_kernel(connection_info, timeout):
+    from jupyter_client import BlockingKernelClient
+    kc = BlockingKernelClient()
+    kc.log.setLevel('DEBUG')
+    kc.load_connection_info(connection_info)
+    kc.start_channels()
+    kc.wait_for_ready(timeout)
+    yield kc
+    kc.stop_channels()

--- a/ipykernel/tests/utils.py
+++ b/ipykernel/tests/utils.py
@@ -33,11 +33,11 @@ def start_new_kernel(**kwargs):
 
     Integrates with our output capturing for tests.
     """
+    kwargs['stderr'] = STDOUT
     try:
-        stdout = nose.iptest_stdstreams_fileno()
+        kwargs['stdout'] = nose.iptest_stdstreams_fileno()
     except AttributeError:
-        stdout = open(os.devnull)
-    kwargs.update(dict(stdout=stdout, stderr=STDOUT))
+        pass
     return manager.start_new_kernel(startup_timeout=STARTUP_TIMEOUT, **kwargs)
 
 
@@ -131,8 +131,11 @@ def new_kernel(argv=None):
     -------
     kernel_client: connected KernelClient instance
     """
-    stdout = getattr(nose, 'iptest_stdstreams_fileno', open(os.devnull))
-    kwargs = dict(stdout=stdout, stderr=STDOUT)
+    kwargs = {'stderr': STDOUT}
+    try:
+        kwargs['stdout'] = nose.iptest_stdstreams_fileno()
+    except AttributeError:
+        pass
     if argv is not None:
         kwargs['extra_arguments'] = argv
     return manager.run_kernel(**kwargs)


### PR DESCRIPTION
# Issue
For dashboarding, it is useful to have a kernel + the final state ready instantly. If for instance, it takes ~5 minutes to execute a notebook, it does not lead to good user experience.

# Solution
Execute a notebook, and after it is done, consider it a template, and give each user a `fork()` of this template process.

# Implementation
The kernel gets a new message, which is simply called `fork`.  Asyncio/tornado-ioloop with fork is a no-go, it is basically not supported. To avoid this, we stop the current ioloop, and use the ioloop object to communicate the fork request up the callstack. The kernelapp now checks if a fork was requested and it  will fork:
 * The parent resumes the ioloop
 * The child should clean up the ioloop and start listening on new ports:

# Usage (although it does not work yet)

It also needs this PR: https://github.com/jupyter/jupyter_client/pull/441

Shell1:
```bash
$ python -m ipykernel_launcher -f conn.json --debug
```
Shell2:
```bash
$ python fork_kernel.py ./conn.json # this will print the result of the fork
DEBUG:traitlets:Loading connection file ./conn.json
DEBUG:traitlets:connecting shell channel to tcp://127.0.0.1:56573
DEBUG:traitlets:Connecting to: tcp://127.0.0.1:56573
DEBUG:traitlets:connecting iopub channel to tcp://127.0.0.1:56574
DEBUG:traitlets:Connecting to: tcp://127.0.0.1:56574
DEBUG:traitlets:connecting stdin channel to tcp://127.0.0.1:56575
DEBUG:traitlets:Connecting to: tcp://127.0.0.1:56575
DEBUG:traitlets:connecting heartbeat channel to tcp://127.0.0.1:56577
{'header': {'msg_id': '81e4a9b2-155b535e6541ce736c126d47', 'msg_type': 'execute_reply', 'username': 'maartenbreddels', 'session': 'b5b03194-ba9276d2bbc5a711d5e5d44c', 'date': datetime.datetime(2019, 5, 28, 21, 39, 2, 604627, tzinfo=tzutc()), 'version': '5.3'}, 'msg_id': '81e4a9b2-155b535e6541ce736c126d47', 'msg_type': 'execute_reply', 'parent_header': {'msg_id': '73914843-0da368d574d8c114b8dfd531', 'msg_type': 'fork', 'username': 'maartenbreddels', 'session': '9c61f20c-d8a4e43f945eaf915031a3d4', 'date': datetime.datetime(2019, 5, 28, 21, 39, 2, 596944, tzinfo=tzutc()), 'version': '5.3'}, 'metadata': {'status': 'ok'}, 'content': {'status': 'ok', 'fork_id': 1042}, 'buffers': []}
$ python fork_kernel.py  /Users/maartenbreddels/Library/Jupyter/runtime/conn_fork.json
DEBUG:traitlets:Loading connection file /Users/maartenbreddels/Library/Jupyter/runtime/conn_fork.json
DEBUG:traitlets:connecting shell channel to tcp://127.0.0.1:54452
DEBUG:traitlets:Connecting to: tcp://127.0.0.1:54452
DEBUG:traitlets:connecting iopub channel to tcp://127.0.0.1:54455
DEBUG:traitlets:Connecting to: tcp://127.0.0.1:54455
DEBUG:traitlets:connecting stdin channel to tcp://127.0.0.1:54453
DEBUG:traitlets:Connecting to: tcp://127.0.0.1:54453
DEBUG:traitlets:connecting heartbeat channel to tcp://127.0.0.1:54457
^[[A^CTraceback (most recent call last):
  File "fork_kernel.py", line 12, in <module>
    client.wait_for_ready(100)
  File "/Users/maartenbreddels/src/jupyter/jupyter_client/jupyter_client/blocking/client.py", line 111, in wait_for_ready
    msg = self.shell_channel.get_msg(block=True, timeout=1)
  File "/Users/maartenbreddels/src/jupyter/jupyter_client/jupyter_client/blocking/channels.py", line 50, in get_msg
    ready = self.socket.poll(timeout)
  File "/Users/maartenbreddels/miniconda3/envs/kernel_fork/lib/python3.7/site-packages/zmq/sugar/socket.py", line 697, in poll
    evts = dict(p.poll(timeout))
  File "/Users/maartenbreddels/miniconda3/envs/kernel_fork/lib/python3.7/site-packages/zmq/sugar/poll.py", line 99, in poll
    return zmq_poll(self.sockets, timeout=timeout)
  File "zmq/backend/cython/_poll.pyx", line 123, in zmq.backend.cython._poll.zmq_poll
  File "zmq/backend/cython/checkrc.pxd", line 12, in zmq.backend.cython.checkrc._check_rc
KeyboardInterrupt
```

The last command never does anything, so I ctrl-c'ed it, so the stacktrace is included.

# Problem
It doesn't work 😄. The forked child process doesn't seem to be reachable by zmq, and no debug info is printed, so I'm giving up here, and hope that someone else has good ideas or wants to pick this up.

# Side uses
Forking the kernel could be used for 'undoing' the excution of a cell/line, by forking after each `execute(..)`. Note that since fork uses copy on write, this will be fairly cheap in resource usage.

