### PR TITLE
Use shell.input_transformer_manager when available

### DIFF
--- a/ipykernel/ipkernel.py
+++ b/ipykernel/ipkernel.py
@@ -445,7 +445,11 @@ class IPythonKernel(KernelBase):
         return dict(status='ok', restart=restart)
 
     def do_is_complete(self, code):
-        status, indent_spaces = self.shell.input_splitter.check_complete(code)
+        transformer_manager = getattr(self.shell, 'input_transformer_manager', None)
+        if transformer_manager is None:
+            # input_splitter attribute is deprecated
+            transformer_manager = self.shell.input_splitter
+        status, indent_spaces = transformer_manager.check_complete(code)
         r = {'status': status}
         if status == 'incomplete':
             r['indent'] = ' ' * indent_spaces


### PR DESCRIPTION
Fixes #375 

With this change we don't trigger the [deprecation warning](https://github.com/ipython/ipython/blob/fb9c8ca5ccd24a897a79a217d446c8ce7c4a715a/IPython/core/interactiveshell.py#L522) on `ipython.core.InteractiveShell` if we can avoid it.

## Testing
I started a kernel (using `ipykernel.kernelapp.launch_new_instance`) on this commit, and on the parent b81632e, and connected to it with `jupyter console`, and confirmed that the deprecation message appeared at the prompt when executing code on  b81632e, but was not present on this commit.