### PR TITLE
Fixed socket binding race conditions

### DIFF
--- a/ipykernel/heartbeat.py
+++ b/ipykernel/heartbeat.py
@@ -35,27 +35,60 @@ class Heartbeat(Thread):
         Thread.__init__(self)
         self.context = context
         self.transport, self.ip, self.port = addr
-        if self.port == 0:
-            if addr[0] == 'tcp':
-                s = socket.socket()
-                # '*' means all interfaces to 0MQ, which is '' to socket.socket
-                s.bind(('' if self.ip == '*' else self.ip, 0))
-                self.port = s.getsockname()[1]
-                s.close()
-            elif addr[0] == 'ipc':
-                self.port = 1
-                while os.path.exists("%s-%s" % (self.ip, self.port)):
-                    self.port = self.port + 1
-            else:
-                raise ValueError("Unrecognized zmq transport: %s" % addr[0])
+        self.original_port = self.port
+        if self.original_port == 0:
+            self.pick_port()
         self.addr = (self.ip, self.port)
         self.daemon = True
+
+    def pick_port(self):
+        if self.transport == 'tcp':
+            s = socket.socket()
+            # '*' means all interfaces to 0MQ, which is '' to socket.socket
+            s.bind(('' if self.ip == '*' else self.ip, 0))
+            self.port = s.getsockname()[1]
+            s.close()
+        elif self.transport == 'ipc':
+            self.port = 1
+            while os.path.exists("%s-%s" % (self.ip, self.port)):
+                self.port = self.port + 1
+        else:
+            raise ValueError("Unrecognized zmq transport: %s" % self.transport)
+        return self.port
+
+    def _try_bind_socket(self):
+        c = ':' if self.transport == 'tcp' else '-'
+        return self.socket.bind('%s://%s' % (self.transport, self.ip) + c + str(self.port))
+
+    def _bind_socket(self):
+        try:
+            win_in_use = errno.WSAEADDRINUSE
+        except AttributeError:
+            win_in_use = None
+
+        # Try up to 100 times to bind a port when in conflict to avoid
+        # infinite attempts in bad setups
+        max_attempts = 100
+        for attempt in range(max_attempts):
+            try:
+                self._try_bind_socket()
+            except zmq.ZMQError as ze:
+                if attempt == max_attempts - 1:
+                    raise
+                # Raise if we have any error not related to socket binding
+                if ze.errno != errno.EADDRINUSE and ze.errno != win_in_use:
+                    raise
+                # Raise if we have any error not related to socket binding
+                if self.original_port == 0:
+                    self.pick_port()
+                else:
+                    raise
 
     def run(self):
         self.socket = self.context.socket(zmq.ROUTER)
         self.socket.linger = 1000
-        c = ':' if self.transport == 'tcp' else '-'
-        self.socket.bind('%s://%s' % (self.transport, self.ip) + c + str(self.port))
+        self._bind_socket()
+
         while True:
             try:
                 zmq.device(zmq.QUEUE, self.socket, self.socket)

--- a/ipykernel/heartbeat.py
+++ b/ipykernel/heartbeat.py
@@ -87,7 +87,11 @@ class Heartbeat(Thread):
     def run(self):
         self.socket = self.context.socket(zmq.ROUTER)
         self.socket.linger = 1000
-        self._bind_socket()
+        try:
+            self._bind_socket()
+        except Exception:
+            self.socket.close()
+            raise
 
         while True:
             try:

--- a/ipykernel/heartbeat.py
+++ b/ipykernel/heartbeat.py
@@ -68,7 +68,7 @@ class Heartbeat(Thread):
 
         # Try up to 100 times to bind a port when in conflict to avoid
         # infinite attempts in bad setups
-        max_attempts = 100
+        max_attempts = 1 if self.original_port else 100
         for attempt in range(max_attempts):
             try:
                 self._try_bind_socket()

--- a/ipykernel/inprocess/socket.py
+++ b/ipykernel/inprocess/socket.py
@@ -20,7 +20,7 @@ from ipython_genutils.py3compat import with_metaclass
 #-----------------------------------------------------------------------------
 
 class SocketABC(with_metaclass(abc.ABCMeta, object)):
-    
+
     @abc.abstractmethod
     def recv_multipart(self, flags=0, copy=True, track=False):
         raise NotImplementedError
@@ -28,7 +28,7 @@ class SocketABC(with_metaclass(abc.ABCMeta, object)):
     @abc.abstractmethod
     def send_multipart(self, msg_parts, flags=0, copy=True, track=False):
         raise NotImplementedError
-    
+
     @classmethod
     def register(cls, other_cls):
         if other_cls is not DummySocket:
@@ -47,7 +47,7 @@ class DummySocket(HasTraits):
     message_sent = Int(0) # Should be an Event
     context = Instance(zmq.Context)
     def _context_default(self):
-        return zmq.Context.instance()
+        return zmq.Context()
 
     #-------------------------------------------------------------------------
     # Socket interface

--- a/ipykernel/iostream.py
+++ b/ipykernel/iostream.py
@@ -167,14 +167,14 @@ class IOPubThread(object):
             return MASTER
         else:
             return CHILD
-    
+
     def start(self):
         """Start the IOPub thread"""
         self.thread.start()
         # make sure we don't prevent process exit
         # I'm not sure why setting daemon=True above isn't enough, but it doesn't appear to be.
         atexit.register(self.stop)
-    
+
     def stop(self):
         """Stop the IOPub thread"""
         if not self.thread.is_alive():
@@ -183,7 +183,7 @@ class IOPubThread(object):
         self.thread.join()
         if hasattr(self._local, 'event_pipe'):
             self._local.event_pipe.close()
-    
+
     def close(self):
         self.socket.close()
         self.socket = None
@@ -206,11 +206,11 @@ class IOPubThread(object):
 
     def send_multipart(self, *args, **kwargs):
         """send_multipart schedules actual zmq send in my thread.
-        
+
         If my thread isn't running (e.g. forked process), send immediately.
         """
         self.schedule(lambda : self._really_send(*args, **kwargs))
-    
+
     def _really_send(self, msg, *args, **kwargs):
         """The callback that actually sends messages"""
         mp_mode = self._check_mp_mode()
@@ -231,10 +231,10 @@ class IOPubThread(object):
 class BackgroundSocket(object):
     """Wrapper around IOPub thread that provides zmq send[_multipart]"""
     io_thread = None
-    
+
     def __init__(self, io_thread):
         self.io_thread = io_thread
-    
+
     def __getattr__(self, attr):
         """Wrap socket attr access for backward-compatibility"""
         if attr.startswith('__') and attr.endswith('__'):
@@ -245,7 +245,7 @@ class BackgroundSocket(object):
                 DeprecationWarning, stacklevel=2)
             return getattr(self.io_thread.socket, attr)
         super(BackgroundSocket, self).__getattr__(attr)
-    
+
     def __setattr__(self, attr, value):
         if attr == 'io_thread' or (attr.startswith('__' and attr.endswith('__'))):
             super(BackgroundSocket, self).__setattr__(attr, value)
@@ -253,7 +253,7 @@ class BackgroundSocket(object):
             warnings.warn("Setting zmq Socket attribute %s on BackgroundSocket" % attr,
                 DeprecationWarning, stacklevel=2)
             setattr(self.io_thread.socket, attr, value)
-    
+
     def send(self, msg, *args, **kwargs):
         return self.send_multipart([msg], *args, **kwargs)
 
@@ -264,7 +264,7 @@ class BackgroundSocket(object):
 
 class OutStream(TextIOBase):
     """A file like object that publishes the stream to a 0MQ PUB socket.
-    
+
     Output is handed off to an IO Thread
     """
 
@@ -419,7 +419,7 @@ class OutStream(TextIOBase):
 
     def _flush_buffer(self):
         """clear the current buffer and return the current buffer data.
-        
+
         This should only be called in the IO thread.
         """
         data = u''

--- a/ipykernel/iostream.py
+++ b/ipykernel/iostream.py
@@ -185,6 +185,8 @@ class IOPubThread(object):
             self._local.event_pipe.close()
 
     def close(self):
+        if self.closed:
+            return
         self.socket.close()
         self.socket = None
 

--- a/ipykernel/kernelapp.py
+++ b/ipykernel/kernelapp.py
@@ -199,7 +199,7 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp,
 
         # Try up to 100 times to bind a port when in conflict to avoid
         # infinite attempts in bad setups
-        max_attempts = 1 if port else 1
+        max_attempts = 1 if port else 100
         for attempt in range(max_attempts):
             try:
                 return self._try_bind_socket(s, port)

--- a/ipykernel/kernelapp.py
+++ b/ipykernel/kernelapp.py
@@ -199,7 +199,7 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp,
 
         # Try up to 100 times to bind a port when in conflict to avoid
         # infinite attempts in bad setups
-        max_attempts = 100
+        max_attempts = 1 if port else 1
         for attempt in range(max_attempts):
             try:
                 return self._try_bind_socket(s, port)
@@ -251,7 +251,7 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp,
         self.log.info("Starting the kernel at pid: %i", os.getpid())
         context = zmq.Context()
         # Uncomment this to try closing the context.
-        # atexit.register(context.term)
+        atexit.register(context.term)
 
         self.shell_socket = context.socket(zmq.ROUTER)
         self.shell_socket.linger = 1000

--- a/ipykernel/tests/test_async.py
+++ b/ipykernel/tests/test_async.py
@@ -14,14 +14,14 @@ from .test_message_spec import validate_message
 KC = KM = None
 
 
-def setup():
+def setup_function():
     """start the global kernel (if it isn't running) and return its client"""
     global KM, KC
     KM, KC = start_new_kernel()
     flush_channels(KC)
 
 
-def teardown():
+def teardown_function():
     KC.stop_channels()
     KM.shutdown_kernel(now=True)
 

--- a/ipykernel/tests/test_heartbeat.py
+++ b/ipykernel/tests/test_heartbeat.py
@@ -1,0 +1,54 @@
+"""Tests for heartbeat thread"""
+
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+import json
+import os
+import pytest
+import errno
+import zmq
+
+from mock import patch
+
+from ipykernel.heartbeat import Heartbeat
+
+
+def test_port_bind_failure_raises():
+    heart = Heartbeat(None)
+    with patch.object(heart, '_try_bind_socket') as mock_try_bind:
+        mock_try_bind.side_effect = zmq.ZMQError(-100, "fails for unknown error types")
+        with pytest.raises(zmq.ZMQError):
+            heart._bind_socket()
+        assert mock_try_bind.call_count == 1
+
+
+def test_port_bind_failure_recovery():
+    try:
+        errno.WSAEADDRINUSE
+    except AttributeError:
+        # Fake windows address in-use code
+        errno.WSAEADDRINUSE = 12345
+
+    try:
+        heart = Heartbeat(None)
+        with patch.object(heart, '_try_bind_socket') as mock_try_bind:
+            mock_try_bind.side_effect = [
+                zmq.ZMQError(errno.EADDRINUSE, "fails for non-bind unix"),
+                zmq.ZMQError(errno.WSAEADDRINUSE, "fails for non-bind windows")
+            ] + [0] * 100
+            # Shouldn't raise anything as retries will kick in
+            heart._bind_socket()
+    finally:
+        # Cleanup fake assignment
+        if errno.WSAEADDRINUSE == 12345:
+            del errno.WSAEADDRINUSE
+
+
+def test_port_bind_failure_gives_up_retries():
+    heart = Heartbeat(None)
+    with patch.object(heart, '_try_bind_socket') as mock_try_bind:
+        mock_try_bind.side_effect = zmq.ZMQError(errno.EADDRINUSE, "fails for non-bind")
+        with pytest.raises(zmq.ZMQError):
+            heart._bind_socket()
+        assert mock_try_bind.call_count == 100

--- a/ipykernel/tests/test_heartbeat.py
+++ b/ipykernel/tests/test_heartbeat.py
@@ -3,13 +3,11 @@
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-import json
-import os
-import pytest
 import errno
-import zmq
+from unittest.mock import patch
 
-from mock import patch
+import pytest
+import zmq
 
 from ipykernel.heartbeat import Heartbeat
 

--- a/ipykernel/tests/test_io.py
+++ b/ipykernel/tests/test_io.py
@@ -39,4 +39,3 @@ def test_io_api():
     with nt.assert_raises(io.UnsupportedOperation):
         stream.tell()
 
-    

--- a/ipykernel/tests/test_kernel.py
+++ b/ipykernel/tests/test_kernel.py
@@ -320,7 +320,7 @@ def test_shutdown():
         execute(u'a = 1', kc=kc)
         wait_for_idle(kc)
         kc.shutdown()
-        for i in range(100): # 10s timeout
+        for i in range(300): # 30s timeout
             if km.is_alive():
                 time.sleep(.1)
             else:


### PR DESCRIPTION
Following [fixes in jupyter_client around zeroMQ thread safety issues](https://github.com/jupyter/jupyter_client/pull/437) I found and closed a couple races in the ipykernel wrapper as well that I found during testing of concurrent patterns with nbconvert.

The first is zeroMQ contexts using `.instance()` which is causes a shared object that's not thread / multiprocessing safe to use. Forcing new context objects to be allocated rather than using a global instance costs a small memory footprint to avoid race condition failures around those context objects.

The second race I found was rare but enough travis builds gave the stack trace below. This points to port binding where a port is picked first, then used in a later call. But that port which was picked could be picked by a concurrent execution at the same time, resulting in a port binding error for one half of the race. To fix this I added some logic to wrap port binding with retry on address taken exceptions. I've tested an early version of this fix extensively in tracking down concurrency issues in notebook executions in nbconvert and upstream libraries, so I'm quite confident this port binding issue is what caused the error seen in travis builds. 100 retries, rather than infinite retries, seemed like a safe compromise as port bind conflicts are difficult to trigger and if you get more than a couple dozen something more serious is wrong.

```
___________________________ test_parallel_notebooks ____________________________
capfd = <_pytest.capture.CaptureFixture object at 0x7fbbe7dc2790>
tmpdir = local('/tmp/pytest-of-travis/pytest-0/test_parallel_notebooks0')
    def test_parallel_notebooks(capfd, tmpdir):
        """Two notebooks should be able to be run simultaneously without problems.
    
        The two notebooks spawned here use the filesystem to check that the other notebook
        wrote to the filesystem."""
    
        opts = dict(kernel_name="python")
        input_name = "Parallel Execute.ipynb"
        input_file = os.path.join(current_dir, "files", input_name)
        res = notebook_resources()
    
        with modified_env({"NBEXECUTE_TEST_PARALLEL_TMPDIR": str(tmpdir)}):
            threads = [
                threading.Thread(
                    target=run_notebook,
                    args=(
                        input_file,
                        opts,
                        res,
                        functools.partial(label_parallel_notebook, label=label),
                    ),
                )
                for label in ("A", "B")
            ]
            [t.start() for t in threads]
            [t.join(timeout=2) for t in threads]
    
        captured = capfd.readouterr()
>       assert captured.err == ""
E       assert 'Traceback (m...kernel_info\n\n' == ''
E         - Traceback (most recent call last):
E         -   File "/opt/python/2.7.15/lib/python2.7/runpy.py", line 174, in _run_module_as_main
E         -     "__main__", fname, loader, pkg_name)
E         -   File "/opt/python/2.7.15/lib/python2.7/runpy.py", line 72, in _run_code
E         -     exec code in run_globals
E         -   File "/home/travis/virtualenv/python2.7.15/lib/python2.7/site-packages/ipykernel_launcher.py", line 16, in <module>
E         -     app.launch_new_instance()
E         -   File "/home/travis/virtualenv/python2.7.15/lib/python2.7/site-packages/traitlets/config/application.py", line 657, in launch_instance
E         -     app.initialize(argv)
E         -   File "</home/travis/virtualenv/python2.7.15/lib/python2.7/site-packages/decorator.pyc:decorator-gen-121>", line 2, in initialize
E         -   File "/home/travis/virtualenv/python2.7.15/lib/python2.7/site-packages/traitlets/config/application.py", line 87, in catch_config_error
E         -     return method(app, *args, **kwargs)
E         -   File "/home/travis/virtualenv/python2.7.15/lib/python2.7/site-packages/ipykernel/kernelapp.py", line 469, in initialize
E         -     self.init_sockets()
E         -   File "/home/travis/virtualenv/python2.7.15/lib/python2.7/site-packages/ipykernel/kernelapp.py", line 239, in init_sockets
E         -     self.shell_port = self._bind_socket(self.shell_socket, self.shell_port)
E         -   File "/home/travis/virtualenv/python2.7.15/lib/python2.7/site-packages/ipykernel/kernelapp.py", line 181, in _bind_socket
E         -     s.bind("tcp://%s:%i" % (self.ip, port))
E         -   File "zmq/backend/cython/socket.pyx", line 547, in zmq.backend.cython.socket.Socket.bind
E         -   File "zmq/backend/cython/checkrc.pxd", line 25, in zmq.backend.cython.checkrc._check_rc
E         -     raise ZMQError(errno)
E         - ZMQError: Address already in use
E         - Exception in thread Thread-16:
E         - Traceback (most recent call last):
E         -   File "/opt/python/2.7.15/lib/python2.7/threading.py", line 801, in __bootstrap_inner
E         -     self.run()
E         -   File "/opt/python/2.7.15/lib/python2.7/threading.py", line 754, in run
E         -     self.__target(*self.__args, **self.__kwargs)
E         -   File "/home/travis/virtualenv/python2.7.15/lib/python2.7/site-packages/nbconvert/preprocessors/tests/test_execute.py", line 97, in run_notebook
E         -     output_nb, _ = preprocessor(cleaned_input_nb, resources)
E         -   File "/home/travis/virtualenv/python2.7.15/lib/python2.7/site-packages/nbconvert/preprocessors/base.py", line 47, in __call__
E         -     return self.preprocess(nb, resources)
E         -   File "/home/travis/virtualenv/python2.7.15/lib/python2.7/site-packages/nbconvert/preprocessors/execute.py", line 400, in preprocess
E         -     with self.setup_preprocessor(nb, resources, km=km):
E         -   File "/opt/python/2.7.15/lib/python2.7/contextlib.py", line 17, in __enter__
E         -     return self.gen.next()
E         -   File "/home/travis/virtualenv/python2.7.15/lib/python2.7/site-packages/nbconvert/preprocessors/execute.py", line 345, in setup_preprocessor
E         -     self.km, self.kc = self.start_new_kernel(**kwargs)
E         -   File "/home/travis/virtualenv/python2.7.15/lib/python2.7/site-packages/nbconvert/preprocessors/execute.py", line 296, in start_new_kernel
E         -     kc.wait_for_ready(timeout=self.startup_timeout)
E         -   File "/home/travis/virtualenv/python2.7.15/lib/python2.7/site-packages/jupyter_client/blocking/client.py", line 120, in wait_for_ready
E         -     raise RuntimeError('Kernel died before replying to kernel_info')
E         - RuntimeError: Kernel died before replying to kernel_info
E         -
/home/travis/virtualenv/python2.7.15/lib/python2.7/site-packages/nbconvert/preprocessors/tests/test_execute.py:305: AssertionError
```