### PR TITLE
Further cleanup on shutdown

### DIFF
--- a/ipykernel/kernelapp.py
+++ b/ipykernel/kernelapp.py
@@ -309,6 +309,8 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp,
 
     def close(self):
         """Close zmq sockets in an orderly fashion"""
+        # un-capture IO before we start closing channels
+        self.reset_io()
         self.log.info("Cleaning up sockets")
         if self.heartbeat:
             self.log.debug("Closing heartbeat channel")
@@ -390,6 +392,15 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp,
             sys.displayhook = self.displayhook
 
         self.patch_io()
+
+    def reset_io(self):
+        """restore original io
+
+        restores state after init_io
+        """
+        sys.stdout = sys.__stdout__
+        sys.stderr = sys.__stderr__
+        sys.displayhook = sys.__displayhook__
 
     def patch_io(self):
         """Patch important libraries that can't handle sys.stdout forwarding"""

--- a/ipykernel/kernelapp.py
+++ b/ipykernel/kernelapp.py
@@ -314,7 +314,6 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp,
         self.log.info("Cleaning up sockets")
         if self.heartbeat:
             self.log.debug("Closing heartbeat channel")
-            self.heartbeat.socket.close()
             self.heartbeat.context.term()
         if self.iopub_thread:
             self.log.debug("Closing iopub channel")


### PR DESCRIPTION
- restore sys.stdout, etc. prior to closing forwarded io streams.
  This prevents errors if print, excepthook, etc. are called during shutdown.
- cleanup heartbeat thread in the right order:
  - terminate context from main thread (context.term is the only threadsafe zmq method)
  - catch resulting ETERM in thread and close socket

cf #412 and jupyter/nbconvert#1052