### PR TITLE
Only generate kernelspec when installing or building wheel

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -111,14 +111,14 @@ setup_args = dict(
 )
 
 
-if any(a.startswith(('bdist', 'build', 'install')) for a in sys.argv):
+if any(a.startswith(('bdist', 'install')) for a in sys.argv):
     from ipykernel.kernelspec import write_kernel_spec, make_ipkernel_cmd, KERNEL_NAME
 
     # When building a wheel, the executable specified in the kernelspec is simply 'python'.
-    # When installing from source, the full `sys.executable` can be used.
     if any(a.startswith('bdist') for a in sys.argv):
         argv = make_ipkernel_cmd(executable='python')
-    else:
+    # When installing from source, the full `sys.executable` can be used.
+    if any(a.startswith('install') for a in sys.argv):
         argv = make_ipkernel_cmd()
     dest = os.path.join(here, 'data_kernelspec')
     if os.path.exists(dest):


### PR DESCRIPTION
This slightly changes the kernelspec generation so that it only occurs

 - upon installation from source (with the full sys.executable)
 - or upon wheel generation (with 'python' as executable name)