### PR TITLE
BF: Stop searching when a port is found/bound

### DIFF
--- a/ipykernel/heartbeat.py
+++ b/ipykernel/heartbeat.py
@@ -72,6 +72,7 @@ class Heartbeat(Thread):
         for attempt in range(max_attempts):
             try:
                 self._try_bind_socket()
+                break
             except zmq.ZMQError as ze:
                 if attempt == max_attempts - 1:
                     raise


### PR DESCRIPTION
Fixes (what I think is) a trivial bug in `ipykernel/heartbeat.py`.

This loop in the `Heartbeat,_bind_socket` method should be broken as soon as an available port number is found.