### PR TITLE
PR: Skip unregistering comm with destructor.

### DIFF
--- a/ipykernel/comm/comm.py
+++ b/ipykernel/comm/comm.py
@@ -73,7 +73,7 @@ class Comm(LoggingConfigurable):
 
     def __del__(self):
         """trigger close on gc"""
-        self.close()
+        self.close(deleting=True)
 
     # publishing messages
 
@@ -98,7 +98,7 @@ class Comm(LoggingConfigurable):
             comm_manager.unregister_comm(self)
             raise
 
-    def close(self, data=None, metadata=None, buffers=None):
+    def close(self, data=None, metadata=None, buffers=None, deleting=False):
         """Close the frontend-side version of this comm"""
         if self._closed:
             # only close once
@@ -113,7 +113,9 @@ class Comm(LoggingConfigurable):
         self._publish_msg('comm_close',
             data=data, metadata=metadata, buffers=buffers,
         )
-        self.kernel.comm_manager.unregister_comm(self)
+        if not deleting:
+            # If deleting, the comm can't be registered
+            self.kernel.comm_manager.unregister_comm(self)
 
     def send(self, data=None, metadata=None, buffers=None):
         """Send a message to the frontend-side version of this comm"""


### PR DESCRIPTION
The comm can not still be registered when `__del__` is being called:
 - if `__del__` is called, the reference count is at 0.
 - if the reference count is at 0, then the comm manager doesn't have a reference to the comm. 

This avoids https://github.com/spyder-ide/spyder-kernels/issues/145