### PR TITLE
Moved InProcessKernelClient.flush to DummySocket

### DIFF
--- a/ipykernel/inprocess/client.py
+++ b/ipykernel/inprocess/client.py
@@ -172,9 +172,6 @@ class InProcessKernelClient(KernelClient):
         idents, reply_msg = self.session.recv(stream, copy=False)
         self.shell_channel.call_handlers_later(reply_msg)
 
-    def flush(self):
-        """no-op to comply with stream API"""
-
 
 #-----------------------------------------------------------------------------
 # ABC Registration

--- a/ipykernel/inprocess/socket.py
+++ b/ipykernel/inprocess/socket.py
@@ -61,4 +61,7 @@ class DummySocket(HasTraits):
         self.queue.put_nowait(msg_parts)
         self.message_sent += 1
 
+    def flush(self):
+        """no-op to comply with stream API"""
+
 SocketABC.register(DummySocket)

--- a/ipykernel/inprocess/socket.py
+++ b/ipykernel/inprocess/socket.py
@@ -61,7 +61,8 @@ class DummySocket(HasTraits):
         self.queue.put_nowait(msg_parts)
         self.message_sent += 1
 
-    def flush(self):
+    def flush(self, timeout=1.0):
         """no-op to comply with stream API"""
+        pass
 
 SocketABC.register(DummySocket)


### PR DESCRIPTION
Corrects the wrong placement of the flush method implemented in https://github.com/ipython/ipykernel/pull/405. Don't know how this has happened, but the method should obviously have been implemented for the `DummySocket` class, not for `InProcessKernelClient`...