### PR TITLE
PR: Run GUI eventloop while waiting for input

### DIFF
--- a/ipykernel/eventloops.py
+++ b/ipykernel/eventloops.py
@@ -116,7 +116,7 @@ def loop_qt4(kernel):
     kernel.app = get_app_qt4([" "])
     kernel.app.setQuitOnLastWindowClosed(False)
 
-    for s in kernel.shell_streams + [kernel.stdin_stream]:
+    for s in kernel.io_streams:
         _notify_stream_qt(kernel, s)
 
     _loop_qt(kernel.app)
@@ -159,7 +159,7 @@ def loop_wx(kernel):
 
     def wake():
         """wake from wx"""
-        for stream in kernel.shell_streams + [kernel.stdin_stream]:
+        for stream in kernel.io_streams:
             if stream.flush(limit=1):
                 kernel.app.ExitMainLoop()
                 return
@@ -225,7 +225,7 @@ def loop_tk(kernel):
     # For Tkinter, we create a Tk object and call its withdraw method.
     kernel.app = app = Tk()
     kernel.app.withdraw()
-    for stream in kernel.shell_streams + [kernel.stdin_stream]:
+    for stream in kernel.io_streams:
         notifier = partial(process_stream_events, stream)
         # seems to be needed for tk
         notifier.__name__ = 'notifier'
@@ -296,7 +296,7 @@ def loop_cocoa(kernel):
                 # don't let interrupts during mainloop invoke crash_handler:
                 sys.excepthook = handle_int
                 mainloop(kernel._poll_interval)
-                for stream in kernel.shell_streams + [kernel.stdin_stream]:
+                for stream in kernel.io_streams:
                     if stream.flush(limit=1):
                         # events to process, return control to kernel
                         return
@@ -337,7 +337,7 @@ def loop_asyncio(kernel):
         if stream.flush(limit=1):
             loop.stop()
 
-    for stream in kernel.shell_streams + [kernel.stdin_stream]:
+    for stream in kernel.io_streams:
         fd = stream.getsockopt(zmq.FD)
         notifier = partial(process_stream_events, stream)
         loop.add_reader(fd, notifier)

--- a/ipykernel/eventloops.py
+++ b/ipykernel/eventloops.py
@@ -116,7 +116,7 @@ def loop_qt4(kernel):
     kernel.app = get_app_qt4([" "])
     kernel.app.setQuitOnLastWindowClosed(False)
 
-    for s in kernel.shell_streams:
+    for s in kernel.shell_streams + [kernel.stdin_stream]:
         _notify_stream_qt(kernel, s)
 
     _loop_qt(kernel.app)
@@ -159,7 +159,7 @@ def loop_wx(kernel):
 
     def wake():
         """wake from wx"""
-        for stream in kernel.shell_streams:
+        for stream in kernel.shell_streams + [kernel.stdin_stream]:
             if stream.flush(limit=1):
                 kernel.app.ExitMainLoop()
                 return
@@ -225,7 +225,7 @@ def loop_tk(kernel):
     # For Tkinter, we create a Tk object and call its withdraw method.
     kernel.app = app = Tk()
     kernel.app.withdraw()
-    for stream in kernel.shell_streams:
+    for stream in kernel.shell_streams + [kernel.stdin_stream]:
         notifier = partial(process_stream_events, stream)
         # seems to be needed for tk
         notifier.__name__ = 'notifier'
@@ -296,7 +296,7 @@ def loop_cocoa(kernel):
                 # don't let interrupts during mainloop invoke crash_handler:
                 sys.excepthook = handle_int
                 mainloop(kernel._poll_interval)
-                for stream in kernel.shell_streams:
+                for stream in kernel.shell_streams + [kernel.stdin_stream]:
                     if stream.flush(limit=1):
                         # events to process, return control to kernel
                         return
@@ -337,7 +337,7 @@ def loop_asyncio(kernel):
         if stream.flush(limit=1):
             loop.stop()
 
-    for stream in kernel.shell_streams:
+    for stream in kernel.shell_streams + [kernel.stdin_stream]:
         fd = stream.getsockopt(zmq.FD)
         notifier = partial(process_stream_events, stream)
         loop.add_reader(fd, notifier)

--- a/ipykernel/ipkernel.py
+++ b/ipykernel/ipkernel.py
@@ -85,6 +85,8 @@ class IPythonKernel(KernelBase):
             import appnope
             appnope.nope()
 
+        self.shell.magics_manager.register_function(self.input_eventloop)
+
     help_links = List([
         {
             'text': "Python Reference",

--- a/ipykernel/kernelapp.py
+++ b/ipykernel/kernelapp.py
@@ -448,7 +448,6 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp,
                                 user_ns=self.user_ns,
         )
         kernel.stdin_stream = stdin_stream
-        kernel._stdin_msg = None
 
         def handle_msg(msg):
             idents, msg = self.session.feed_identities(msg, copy=False)

--- a/ipykernel/kernelapp.py
+++ b/ipykernel/kernelapp.py
@@ -433,7 +433,6 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp,
         """Create the Kernel object itself"""
         shell_stream = ZMQStream(self.shell_socket)
         control_stream = ZMQStream(self.control_socket)
-        stdin_stream = ZMQStream(self.stdin_socket)
 
         kernel_factory = self.kernel_class.instance
 
@@ -447,18 +446,7 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp,
                                 profile_dir=self.profile_dir,
                                 user_ns=self.user_ns,
         )
-        kernel.stdin_stream = stdin_stream
 
-        def handle_msg(msg):
-            idents, msg = self.session.feed_identities(msg, copy=False)
-            try:
-                msg = self.session.deserialize(msg, content=True, copy=False)
-            except:
-                self.log.error("Invalid Message", exc_info=True)
-                return
-            kernel._stdin_msg = msg
-
-        kernel.stdin_stream.on_recv(handle_msg, copy=False)
         kernel.record_ports({
             name + '_port': port for name, port in self.ports.items()
         })

--- a/ipykernel/kernelapp.py
+++ b/ipykernel/kernelapp.py
@@ -446,7 +446,6 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp,
                                 profile_dir=self.profile_dir,
                                 user_ns=self.user_ns,
         )
-
         kernel.record_ports({
             name + '_port': port for name, port in self.ports.items()
         })

--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -41,7 +41,7 @@ from jupyter_client.session import Session
 
 from ._version import kernel_protocol_version
 
-from matplotlib import _pylab_helpers
+from matplotlib._pylab_helpers import Gcf
 
 CONTROL_PRIORITY = 1
 SHELL_PRIORITY = 10
@@ -892,7 +892,7 @@ class Kernel(SingletonConfigurable):
                     # Allow comms and other messages to be processed
                     self.do_one_iteration()
                     # Allow matplotlib figures with e.g. qt5 to update
-                    manager = _pylab_helpers.Gcf.get_active()
+                    manager = Gcf.get_active()
                     if manager is not None:
                         manager.canvas.flush_events()
 

--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -926,7 +926,7 @@ class Kernel(SingletonConfigurable):
             self.eventloop(self)
             return self._stdin_msg
         else:
-            ident, reply = self.session.recv(self.stdin_socket)
+            ident, reply = self.session.recv(self.stdin_socket, 0)
             return reply
 
     def _at_shutdown(self):

--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -13,6 +13,7 @@ from signal import signal, default_int_handler, SIGINT
 import sys
 import time
 import uuid
+import threading
 
 try:
     # jupyter_client >= 5, use tz-aware now
@@ -917,8 +918,15 @@ class Kernel(SingletonConfigurable):
 
     def _input_request_loop_step(self):
         """Do one step of the input request loop."""
-        # Allow matplotlib figures using GUI frameworks (e.g. qt, wx, gtk, tk) to update
-        if 'matplotlib.pyplot' in sys.modules:
+        # Allow matplotlib figures using GUI frameworks (e.g. qt, wx, gtk, tk)
+        # to update
+        if sys.version_info >= (3, 4):
+            is_main_thread = (threading.current_thread() is
+                              threading.main_thread())
+        else:
+            is_main_thread = isinstance(threading.current_thread(),
+                                        threading._MainThread)
+        if is_main_thread and 'matplotlib.pyplot' in sys.modules:
             # matplotlib needs to be imported after app.launch_new_instance()
             import matplotlib.pyplot as plt
             if plt.get_fignums():

--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -41,10 +41,6 @@ from jupyter_client.session import Session
 
 from ._version import kernel_protocol_version
 
-try:
-    from matplotlib._pylab_helpers import Gcf
-except ImportError:
-    Gcf = None
 
 CONTROL_PRIORITY = 1
 SHELL_PRIORITY = 10
@@ -866,6 +862,13 @@ class Kernel(SingletonConfigurable):
         )
 
     def _input_request(self, prompt, ident, parent, password=False):
+        """Send an input request to the frontend and wait for the reply."""
+        # matplotlib needs to be imported after app.launch_new_instance()
+        try:
+            from matplotlib._pylab_helpers import Gcf
+        except ImportError:
+            Gcf = None
+
         # Flush output before making the request.
         sys.stderr.flush()
         sys.stdout.flush()

--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -917,7 +917,7 @@ class Kernel(SingletonConfigurable):
 
     def _input_request_loop_step(self):
         """Do one step of the input request loop."""
-        # Allow matplotlib figures with e.g. qt5 to update
+        # Allow matplotlib figures using GUI frameworks (e.g. qt, wx, gtk, tk) to update
         if 'matplotlib.pyplot' in sys.modules:
             # matplotlib needs to be imported after app.launch_new_instance()
             import matplotlib.pyplot as plt

--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -41,7 +41,10 @@ from jupyter_client.session import Session
 
 from ._version import kernel_protocol_version
 
-from matplotlib._pylab_helpers import Gcf
+try:
+    from matplotlib._pylab_helpers import Gcf
+except ImportError:
+    Gcf = None
 
 CONTROL_PRIORITY = 1
 SHELL_PRIORITY = 10
@@ -892,9 +895,8 @@ class Kernel(SingletonConfigurable):
                     # Allow comms and other messages to be processed
                     self.do_one_iteration()
                     # Allow matplotlib figures with e.g. qt5 to update
-                    manager = Gcf.get_active()
-                    if manager is not None:
-                        manager.canvas.flush_events()
+                    if Gcf and Gcf.get_active():
+                        Gcf.get_active().canvas.flush_events()
 
             except Exception:
                 self.log.warning("Invalid Message:", exc_info=True)

--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -863,12 +863,6 @@ class Kernel(SingletonConfigurable):
 
     def _input_request(self, prompt, ident, parent, password=False):
         """Send an input request to the frontend and wait for the reply."""
-        # matplotlib needs to be imported after app.launch_new_instance()
-        try:
-            from matplotlib._pylab_helpers import Gcf
-        except ImportError:
-            Gcf = None
-
         # Flush output before making the request.
         sys.stderr.flush()
         sys.stdout.flush()
@@ -906,6 +900,12 @@ class Kernel(SingletonConfigurable):
         ------
         KeyboardInterrupt if a keyboard interrupt is recieved.
         """
+        # matplotlib needs to be imported after app.launch_new_instance()
+        try:
+            from matplotlib._pylab_helpers import Gcf
+        except ImportError:
+            Gcf = None
+
         # Await a response.
         reply = None
         while reply is None:

--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -194,6 +194,11 @@ class Kernel(SingletonConfigurable):
         # Should the eventloop be run while waiting for input
         self._input_eventloop = False
 
+    @property
+    def io_streams(self):
+        """Return all I/O streams."""
+        return self.shell_streams + [self.stdin_stream]
+
     def input_eventloop(self, active):
         """
         Activates and desactivates the eventloop while waiting for input.

--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -31,7 +31,7 @@ from zmq.eventloop.zmqstream import ZMQStream
 from traitlets.config.configurable import SingletonConfigurable
 from IPython.core.error import StdinNotImplementedError, UsageError
 from ipython_genutils import py3compat
-from ipython_genutils.py3compat import unicode_type, string_types
+from ipython_genutils.py3compat import unicode_type, string_types, PY3
 from ipykernel.jsonutil import json_clean
 from traitlets import (
     Any, Instance, Float, Dict, List, Set, Integer, Unicode, Bool,
@@ -920,8 +920,8 @@ class Kernel(SingletonConfigurable):
             self._stdin_msg = None
             # Send the input request.
             content = json_clean(dict(prompt=prompt, password=password))
-            self.session.send(self.stdin_socket, u'input_request', content, parent,
-                              ident=ident)
+            self.session.send(self.stdin_socket, u'input_request',
+                              content, parent, ident=ident)
             # Await a response.
             reply = self._wait_input_request_reply()
 
@@ -957,12 +957,12 @@ class Kernel(SingletonConfigurable):
     def _input_request_loop_step(self):
         """Do one step of the input request loop."""
         # Allow GUI event loop to update
-        if sys.version_info >= (3, 4):
-            is_main_thread = (threading.current_thread() is
-                              threading.main_thread())
+        if PY3:
+            is_main_thread = (
+                threading.current_thread() is threading.main_thread())
         else:
-            is_main_thread = isinstance(threading.current_thread(),
-                                        threading._MainThread)
+            is_main_thread = isinstance(
+                threading.current_thread(), threading._MainThread)
         if is_main_thread and self.eventloop and self._input_eventloop:
             self.eventloop(self)
             return self._stdin_msg

--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -41,6 +41,7 @@ from traitlets import (
 from jupyter_client.session import Session
 
 from ._version import kernel_protocol_version
+from .inprocess.socket import DummySocket
 
 CONTROL_PRIORITY = 1
 SHELL_PRIORITY = 10
@@ -173,6 +174,11 @@ class Kernel(SingletonConfigurable):
 
         self._stdin_msg = None
         self._stdin_lock = threading.Lock()
+
+        if isinstance(self.stdin_socket, DummySocket):
+            # This is a test
+            self.stdin_stream = None
+            return
         self.stdin_stream = ZMQStream(self.stdin_socket)
 
         def handle_msg(msg):


### PR DESCRIPTION
While waiting for the PY2 `raw_input` / PY3 `input` function, ipykernel is now completely blocked.
This is a problem for example while debugging. (Pdb uses `input` to get a command).
This PR would allow two new things to happen while waiting an input:
 - `self.do_one_iteration(`) would give a chance to process `comms` messages.
 - `manager.canvas.flush_events()` would give a change to any matplotlib backend to update.