### PR TITLE
ensure control stream is flushed before processing shell messages

### DIFF
--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -225,10 +225,6 @@ class Kernel(SingletonConfigurable):
     @gen.coroutine
     def dispatch_shell(self, stream, msg):
         """dispatch shell requests"""
-        # flush control requests first
-        if self.control_stream:
-            self.control_stream.flush()
-
         idents, msg = self.session.feed_identities(msg, copy=False)
         try:
             msg = self.session.deserialize(msg, content=True, copy=False)
@@ -373,6 +369,9 @@ class Kernel(SingletonConfigurable):
         """
 
         while True:
+            # ensure control stream is flushed before processing shell messages
+            if self.control_stream:
+                self.control_stream.flush()
             # receive the next message and handle it
             try:
                 yield self.process_one()


### PR DESCRIPTION
previous flush was not handled at the right time with new async dispatch to ensure control stream priority

Affected case:

- shell request 1 takes a long time to process, is blocking (no async)
- shell request 2 arrives, is received and queued
- control request arrives later, but before shell request 1 is processed, and has not been queued thanks to no `awaits`

It's possible that shell request 2 is in our Python queue, but control request is still waiting one ioloop iteration
to be handled from zmq, and we want to make sure that we still process the control message first.

This is causing test failures in IPython parallel because task abort relies on proper queue priority handling.