### PR TITLE
PR: Add flaky

### DIFF
--- a/ipykernel/tests/test_embed_kernel.py
+++ b/ipykernel/tests/test_embed_kernel.py
@@ -56,13 +56,11 @@ def setup_kernel(cmd):
         client.load_connection_file()
         client.start_channels()
         client.wait_for_ready()
-    except:
-        kernel.terminate()
-
-    try:
-        yield client
+        try:
+            yield client
+        finally:
+            client.stop_channels()
     finally:
-        client.stop_channels()
         kernel.terminate()
 
 

--- a/ipykernel/tests/test_embed_kernel.py
+++ b/ipykernel/tests/test_embed_kernel.py
@@ -52,9 +52,12 @@ def setup_kernel(cmd):
         raise IOError("Connection file %r never arrived" % connection_file)
 
     client = BlockingKernelClient(connection_file=connection_file)
-    client.load_connection_file()
-    client.start_channels()
-    client.wait_for_ready()
+    try:
+        client.load_connection_file()
+        client.start_channels()
+        client.wait_for_ready()
+    except:
+        kernel.terminate()
 
     try:
         yield client

--- a/ipykernel/tests/test_embed_kernel.py
+++ b/ipykernel/tests/test_embed_kernel.py
@@ -9,6 +9,7 @@ import time
 
 from contextlib import contextmanager
 from subprocess import Popen, PIPE
+from flaky import flaky
 
 from jupyter_client import BlockingKernelClient
 from jupyter_core import paths
@@ -61,6 +62,8 @@ def setup_kernel(cmd):
         client.stop_channels()
         kernel.terminate()
 
+
+@flaky(max_runs=3)
 def test_embed_kernel_basic():
     """IPython.embed_kernel() is basically functional"""
     cmd = '\n'.join([
@@ -93,6 +96,8 @@ def test_embed_kernel_basic():
         text = content['data']['text/plain']
         assert '10' in text
 
+
+@flaky(max_runs=3)
 def test_embed_kernel_namespace():
     """IPython.embed_kernel() inherits calling namespace"""
     cmd = '\n'.join([
@@ -128,6 +133,7 @@ def test_embed_kernel_namespace():
         content = msg['content']
         assert not content['found']
 
+@flaky(max_runs=3)
 def test_embed_kernel_reentrant():
     """IPython.embed_kernel() can be called multiple times"""
     cmd = '\n'.join([

--- a/ipykernel/tests/test_embed_kernel.py
+++ b/ipykernel/tests/test_embed_kernel.py
@@ -30,29 +30,29 @@ def setup_kernel(cmd):
     kernel_manager: connected KernelManager instance
     """
     kernel = Popen([sys.executable, '-c', cmd], stdout=PIPE, stderr=PIPE)
-    connection_file = os.path.join(
-        paths.jupyter_runtime_dir(),
-        'kernel-%i.json' % kernel.pid,
-    )
-    # wait for connection file to exist, timeout after 5s
-    tic = time.time()
-    while not os.path.exists(connection_file) \
-        and kernel.poll() is None \
-        and time.time() < tic + SETUP_TIMEOUT:
-        time.sleep(0.1)
-
-    if kernel.poll() is not None:
-        o,e = kernel.communicate()
-        e = py3compat.cast_unicode(e)
-        raise IOError("Kernel failed to start:\n%s" % e)
-
-    if not os.path.exists(connection_file):
-        if kernel.poll() is None:
-            kernel.terminate()
-        raise IOError("Connection file %r never arrived" % connection_file)
-
-    client = BlockingKernelClient(connection_file=connection_file)
     try:
+        connection_file = os.path.join(
+            paths.jupyter_runtime_dir(),
+            'kernel-%i.json' % kernel.pid,
+        )
+        # wait for connection file to exist, timeout after 5s
+        tic = time.time()
+        while not os.path.exists(connection_file) \
+            and kernel.poll() is None \
+            and time.time() < tic + SETUP_TIMEOUT:
+            time.sleep(0.1)
+
+        if kernel.poll() is not None:
+            o,e = kernel.communicate()
+            e = py3compat.cast_unicode(e)
+            raise IOError("Kernel failed to start:\n%s" % e)
+
+        if not os.path.exists(connection_file):
+            if kernel.poll() is None:
+                kernel.terminate()
+            raise IOError("Connection file %r never arrived" % connection_file)
+
+        client = BlockingKernelClient(connection_file=connection_file)
         client.load_connection_file()
         client.start_channels()
         client.wait_for_ready()

--- a/ipykernel/tests/test_kernel.py
+++ b/ipykernel/tests/test_kernel.py
@@ -11,6 +11,7 @@ import sys
 import time
 
 import nose.tools as nt
+import flaky as flaky
 
 from IPython.testing import decorators as dec, tools as tt
 from ipython_genutils import py3compat
@@ -75,6 +76,7 @@ def test_sys_path_profile_dir():
     assert '' in sys_path
 
 
+@flaky(max_runs=3)
 @dec.skipif(sys.platform == 'win32', "subprocess prints fail on Windows")
 def test_subprocess_print():
     """printing from forked mp.Process"""
@@ -104,6 +106,7 @@ def test_subprocess_print():
         _check_master(kc, expected=True, stream="stderr")
 
 
+@flaky(max_runs=3)
 def test_subprocess_noprint():
     """mp.Process without print doesn't trigger iostream mp_mode"""
     with kernel() as kc:
@@ -126,6 +129,7 @@ def test_subprocess_noprint():
         _check_master(kc, expected=True, stream="stderr")
 
 
+@flaky(max_runs=3)
 @dec.skipif(sys.platform == 'win32', "subprocess prints fail on Windows")
 def test_subprocess_error():
     """error in mp.Process doesn't crash"""

--- a/ipykernel/tests/test_kernel.py
+++ b/ipykernel/tests/test_kernel.py
@@ -11,7 +11,7 @@ import sys
 import time
 
 import nose.tools as nt
-import flaky as flaky
+from flaky import flaky
 
 from IPython.testing import decorators as dec, tools as tt
 from ipython_genutils import py3compat

--- a/ipykernel/tests/test_start_kernel.py
+++ b/ipykernel/tests/test_start_kernel.py
@@ -1,7 +1,10 @@
 from .test_embed_kernel import setup_kernel
+from flaky import flaky
 
 TIMEOUT = 15
 
+
+@flaky(max_runs=3)
 def test_ipython_start_kernel_userns():
     cmd = ('from IPython import start_kernel\n'
            'ns = {"tre": 123}\n'
@@ -27,6 +30,8 @@ def test_ipython_start_kernel_userns():
         text = content['data']['text/plain']
         assert u'DummyMod' in text
 
+
+@flaky(max_runs=3)
 def test_ipython_start_kernel_no_userns():
     # Issue #4188 - user_ns should be passed to shell as None, not {}
     cmd = ('from IPython import start_kernel\n'

--- a/setup.py
+++ b/setup.py
@@ -97,6 +97,7 @@ setup_args = dict(
         'test': [
             'pytest',
             'pytest-cov',
+            'flaky',
             'nose',  # nose because there are still a few nose.tools imports hanging around
         ],
     },


### PR DESCRIPTION
Sometimes, `with setup_kernel(cmd) as client:` fails. This repeats the failing tests at most 3 times.