### PR TITLE
workaround tornado+py38+windows compatibility issue

### DIFF
--- a/ipykernel/kernelapp.py
+++ b/ipykernel/kernelapp.py
@@ -514,13 +514,45 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp,
         handler.setFormatter(formatter)
         logger.addHandler(handler)
 
+    def _init_asyncio_patch(self):
+        """set default asyncio policy to be compatible with tornado
+
+        Tornado 6 (at least) is not compatible with the default
+        asyncio implementation on Windows
+
+        Pick the older SelectorEventLoopPolicy on Windows
+        if the known-incompatible default policy is in use.
+
+        do this as early as possible to make it a low priority and overrideable
+
+        ref: https://github.com/tornadoweb/tornado/issues/2608
+
+        FIXME: if/when tornado supports the defaults in asyncio,
+               remove and bump tornado requirement for py38
+        """
+        if sys.platform.startswith("win") and sys.version_info >= (3, 8):
+            import asyncio
+            try:
+                from asyncio import (
+                    WindowsProactorEventLoopPolicy,
+                    WindowsSelectorEventLoopPolicy,
+                )
+            except ImportError:
+                pass
+                # not affected
+            else:
+                if type(asyncio.get_event_loop_policy()) is WindowsProactorEventLoopPolicy:
+                    # WindowsProactorEventLoopPolicy is not compatible with tornado 6
+                    # fallback to the pre-3.8 default of Selector
+                    asyncio.set_event_loop_policy(WindowsSelectorEventLoopPolicy())
+
     @catch_config_error
     def initialize(self, argv=None):
+        self._init_asyncio_patch()
         super(IPKernelApp, self).initialize(argv)
         if self.subapp is not None:
             return
-        # register zmq IOLoop with tornado
-        zmq_ioloop.install()
+
         self.init_blackhole()
         self.init_connection_file()
         self.init_poller()


### PR DESCRIPTION
set eventloop policy to the old default while tornado is not compatible with the new one

same as https://github.com/jupyter/notebook/pull/5047

cross-ref: https://github.com/tornadoweb/tornado/issues/2608