### PR TITLE
fix: method flush() in iostream.py 

### DIFF
--- a/ipykernel/iostream.py
+++ b/ipykernel/iostream.py
@@ -338,7 +338,7 @@ class OutStream(TextIOBase):
 
         send will happen in the background thread
         """
-        if self.pub_thread.thread.is_alive():
+        if self.pub_thread and self.pub_thread.thread is not None and self.pub_thread.thread.is_alive():
             # request flush on the background thread
             self.pub_thread.schedule(self._flush)
             # wait for flush to actually get through, if we can.


### PR DESCRIPTION
When shutting down, the  flush() method does not work correctly.

> if self.pub_thread.thread.is_alive():
> AttributeError: 'NoneType' object has no attribute 'thread'

> [C 02:15:42.905 NotebookApp] Shutdown confirmed
[I 02:15:42.908 NotebookApp] Shutting down 2 kernels
Error in atexit._run_exitfuncs:
Traceback (most recent call last):
  File "/Users/valentin/brew/Cellar/python/3.7.5/Frameworks/Python.framework/Versions/3.7/lib/python3.7/logging/__init__.py", line 2033, in shutdown
    h.flush()
  File "/Users/valentin/.pyenv3/tensorflow/lib/python3.7/site-packages/absl/logging/__init__.py", line 891, in flush
    self._current_handler.flush()
  File "/Users/valentin/.pyenv3/tensorflow/lib/python3.7/site-packages/absl/logging/__init__.py", line 785, in flush
    self.stream.flush()
  File "/Users/valentin/.pyenv3/tensorflow/lib/python3.7/site-packages/ipykernel/iostream.py", line 341, in flush
    if self.pub_thread.thread.is_alive():
AttributeError: 'NoneType' object has no attribute 'thread'
[I 02:15:43.531 NotebookApp] Kernel shutdown: d514bdbe-8879-44de-b4d9-01d160a5be94
[I 02:15:43.534 NotebookApp] Kernel shutdown: 7579b41f-76f6-4a7c-8dd8-c35bf90dbbba
