### PR TITLE
PR: Don't enter None eventloop

### DIFF
--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -298,6 +298,7 @@ class Kernel(SingletonConfigurable):
         if eventloop is None:
             self.log.info("Exiting as there is no eventloop")
             return
+
         def advance_eventloop():
             # check if eventloop changed:
             if self.eventloop is not eventloop:

--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -295,6 +295,9 @@ class Kernel(SingletonConfigurable):
         self.log.info("Entering eventloop %s", self.eventloop)
         # record handle, so we can check when this changes
         eventloop = self.eventloop
+        if eventloop is None:
+            self.log.info("Exiting as there is no eventloop")
+            return
         def advance_eventloop():
             # check if eventloop changed:
             if self.eventloop is not eventloop:


### PR DESCRIPTION
I had a case where eventloop was None here (I couldn't find a reproducible example).
It doesn't make sense to enter the eventloop if there is no eventloop.