### PR TITLE
PR: [alternative to  #438] Update matplotlib figures while waiting for input

### DIFF
--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -41,7 +41,7 @@ from jupyter_client.session import Session
 
 from ._version import kernel_protocol_version
 
-from matplotlib import _pylab_helpers
+from matplotlib._pylab_helpers import Gcf
 
 CONTROL_PRIORITY = 1
 SHELL_PRIORITY = 10
@@ -892,7 +892,7 @@ class Kernel(SingletonConfigurable):
                     # Allow comms and other messages to be processed
                     self.do_one_iteration()
                     # Allow matplotlib figures with e.g. qt5 to update
-                    manager = _pylab_helpers.Gcf.get_active()
+                    manager = Gcf.get_active()
                     if manager is not None:
                         manager.canvas.flush_events()
 

--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -13,6 +13,7 @@ from signal import signal, default_int_handler, SIGINT
 import sys
 import time
 import uuid
+import threading
 
 try:
     # jupyter_client >= 5, use tz-aware now
@@ -917,8 +918,15 @@ class Kernel(SingletonConfigurable):
 
     def _input_request_loop_step(self):
         """Do one step of the input request loop."""
-        # Allow matplotlib figures using GUI frameworks (e.g. qt, wx, gtk, tk) to update
-        if 'matplotlib.pyplot' in sys.modules:
+        # Allow matplotlib figures using GUI frameworks (e.g. qt, wx, gtk, tk)
+        # to update
+        if sys.version_info >= (3, 4):
+            is_main_thread = (threading.current_thread() is
+                              threading.main_thread())
+        else:
+            is_main_thread = isinstance(threading.current_thread(),
+                                        threading._MainThread)
+        if is_main_thread and 'matplotlib.pyplot' in sys.modules:
             # matplotlib needs to be imported after app.launch_new_instance()
             import matplotlib.pyplot as plt
             if plt.get_fignums():

--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -31,7 +31,7 @@ from zmq.eventloop.zmqstream import ZMQStream
 from traitlets.config.configurable import SingletonConfigurable
 from IPython.core.error import StdinNotImplementedError
 from ipython_genutils import py3compat
-from ipython_genutils.py3compat import unicode_type, string_types
+from ipython_genutils.py3compat import unicode_type, string_types, PY3
 from ipykernel.jsonutil import json_clean
 from traitlets import (
     Any, Instance, Float, Dict, List, Set, Integer, Unicode, Bool,
@@ -920,10 +920,11 @@ class Kernel(SingletonConfigurable):
         """Do one step of the input request loop."""
         # Allow matplotlib figures using GUI frameworks (e.g. qt, wx, gtk, tk)
         # to update
-        if sys.version_info >= (3, 4):
+        if PY3:
             is_main_thread = (threading.current_thread() is
                               threading.main_thread())
         else:
+            # Python 2
             is_main_thread = isinstance(threading.current_thread(),
                                         threading._MainThread)
         if (is_main_thread and 'matplotlib.pyplot' in sys.modules and

--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -41,10 +41,6 @@ from jupyter_client.session import Session
 
 from ._version import kernel_protocol_version
 
-try:
-    from matplotlib._pylab_helpers import Gcf
-except ImportError:
-    Gcf = None
 
 CONTROL_PRIORITY = 1
 SHELL_PRIORITY = 10
@@ -866,6 +862,13 @@ class Kernel(SingletonConfigurable):
         )
 
     def _input_request(self, prompt, ident, parent, password=False):
+        """Send an input request to the frontend and wait for the reply."""
+        # matplotlib needs to be imported after app.launch_new_instance()
+        try:
+            from matplotlib._pylab_helpers import Gcf
+        except ImportError:
+            Gcf = None
+
         # Flush output before making the request.
         sys.stderr.flush()
         sys.stdout.flush()

--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -917,7 +917,7 @@ class Kernel(SingletonConfigurable):
 
     def _input_request_loop_step(self):
         """Do one step of the input request loop."""
-        # Allow matplotlib figures with e.g. qt5 to update
+        # Allow matplotlib figures using GUI frameworks (e.g. qt, wx, gtk, tk) to update
         if 'matplotlib.pyplot' in sys.modules:
             # matplotlib needs to be imported after app.launch_new_instance()
             import matplotlib.pyplot as plt

--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -41,7 +41,10 @@ from jupyter_client.session import Session
 
 from ._version import kernel_protocol_version
 
-from matplotlib._pylab_helpers import Gcf
+try:
+    from matplotlib._pylab_helpers import Gcf
+except ImportError:
+    Gcf = None
 
 CONTROL_PRIORITY = 1
 SHELL_PRIORITY = 10
@@ -892,9 +895,8 @@ class Kernel(SingletonConfigurable):
                     # Allow comms and other messages to be processed
                     self.do_one_iteration()
                     # Allow matplotlib figures with e.g. qt5 to update
-                    manager = Gcf.get_active()
-                    if manager is not None:
-                        manager.canvas.flush_events()
+                    if Gcf and Gcf.get_active():
+                        Gcf.get_active().canvas.flush_events()
 
             except Exception:
                 self.log.warning("Invalid Message:", exc_info=True)

--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -863,12 +863,6 @@ class Kernel(SingletonConfigurable):
 
     def _input_request(self, prompt, ident, parent, password=False):
         """Send an input request to the frontend and wait for the reply."""
-        # matplotlib needs to be imported after app.launch_new_instance()
-        try:
-            from matplotlib._pylab_helpers import Gcf
-        except ImportError:
-            Gcf = None
-
         # Flush output before making the request.
         sys.stderr.flush()
         sys.stdout.flush()
@@ -906,6 +900,12 @@ class Kernel(SingletonConfigurable):
         ------
         KeyboardInterrupt if a keyboard interrupt is recieved.
         """
+        # matplotlib needs to be imported after app.launch_new_instance()
+        try:
+            from matplotlib._pylab_helpers import Gcf
+        except ImportError:
+            Gcf = None
+
         # Await a response.
         reply = None
         while reply is None:

--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -172,6 +172,7 @@ class Kernel(SingletonConfigurable):
         for msg_type in self.control_msg_types:
             self.control_handlers[msg_type] = getattr(self, msg_type)
 
+        self._stdin_lock = threading.Lock()
     @gen.coroutine
     def dispatch_control(self, msg):
         """dispatch control requests"""
@@ -876,12 +877,13 @@ class Kernel(SingletonConfigurable):
                 else:
                     raise
 
-        # Send the input request.
-        content = json_clean(dict(prompt=prompt, password=password))
-        self.session.send(self.stdin_socket, u'input_request', content, parent,
-                          ident=ident)
-        # Await a response.
-        reply = self._wait_input_request_reply()
+        with self._stdin_lock:
+            # Send the input request.
+            content = json_clean(dict(prompt=prompt, password=password))
+            self.session.send(self.stdin_socket, u'input_request', content, parent,
+                              ident=ident)
+            # Await a response.
+            reply = self._wait_input_request_reply()
 
         try:
             value = py3compat.unicode_to_str(reply['content']['value'])

--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -173,6 +173,8 @@ class Kernel(SingletonConfigurable):
             self.control_handlers[msg_type] = getattr(self, msg_type)
 
         self._stdin_lock = threading.Lock()
+        self._enable_input_matplotlib_processing = True
+
     @gen.coroutine
     def dispatch_control(self, msg):
         """dispatch control requests"""
@@ -924,7 +926,8 @@ class Kernel(SingletonConfigurable):
         else:
             is_main_thread = isinstance(threading.current_thread(),
                                         threading._MainThread)
-        if is_main_thread and 'matplotlib.pyplot' in sys.modules:
+        if (is_main_thread and 'matplotlib.pyplot' in sys.modules and
+                self._enable_input_matplotlib_processing):
             ident, reply = self.session.recv(self.stdin_socket, zmq.NOBLOCK)
             if reply:
                 return reply


### PR DESCRIPTION
This PR process events for any open matplotlib figure while waiting for an input.
This allow interaction with matplotlib figures while debugging.
Unlike #438, it doesn't process any other events that might come from a gui app, which would make debugging these apps difficult.