### PR TITLE
FIX: add missing import from backend_agg

### DIFF
--- a/ipykernel/pylab/backend_inline.py
+++ b/ipykernel/pylab/backend_inline.py
@@ -6,7 +6,11 @@
 from __future__ import print_function
 
 import matplotlib
-from matplotlib.backends.backend_agg import new_figure_manager, FigureCanvasAgg # analysis: ignore
+from matplotlib.backends.backend_agg import (
+    new_figure_manager,
+    FigureCanvasAgg,
+    new_figure_manager_given_figure,
+) # analysis: ignore
 from matplotlib import colors
 from matplotlib._pylab_helpers import Gcf
 


### PR DESCRIPTION
closes #231 and https://github.com/matplotlib/matplotlib/issues/8291

We have simplified the process of writing an external backend (which makes sure to not miss these helper functions), but this is the minimal fix to enable figures using the inline backend to be pickled.