### PR TITLE
PR: Flush from process even without newline

### DIFF
--- a/ipykernel/iostream.py
+++ b/ipykernel/iostream.py
@@ -406,6 +406,8 @@ class OutStream(TextIOBase):
                 # and this helps.
                 if '\n' in string:
                     self.flush()
+                else:
+                    self.pub_thread.schedule(self._flush)
             else:
                 self._schedule_flush()
 

--- a/ipykernel/iostream.py
+++ b/ipykernel/iostream.py
@@ -296,6 +296,7 @@ class OutStream(TextIOBase):
         self.parent_header = {}
         self._master_pid = os.getpid()
         self._flush_pending = False
+        self._subprocess_flush_pending = False
         self._io_loop = pub_thread.io_loop
         self._new_buffer()
         self.echo = None
@@ -362,6 +363,7 @@ class OutStream(TextIOBase):
         unless the thread has been destroyed (e.g. forked subprocess).
         """
         self._flush_pending = False
+        self._subprocess_flush_pending = False
 
         if self.echo is not None:
             try:
@@ -401,13 +403,13 @@ class OutStream(TextIOBase):
             # only touch the buffer in the IO thread to avoid races
             self.pub_thread.schedule(lambda : self._buffer.write(string))
             if is_child:
-                # newlines imply flush in subprocesses
                 # mp.Pool cannot be trusted to flush promptly (or ever),
                 # and this helps.
-                if '\n' in string:
-                    self.flush()
-                else:
-                    self.pub_thread.schedule(self._flush)
+                if self._subprocess_flush_pending:
+                    return
+                self._subprocess_flush_pending = True
+                # We can not rely on self._io_loop.call_later from a subprocess
+                self.pub_thread.schedule(self._flush)
             else:
                 self._schedule_flush()
 


### PR DESCRIPTION
Solves a bug where calling `print(text, end='')` from `mp.Pool` doesn't print any text until the processing is finished.
eg:
```
import time
from multiprocessing import Process


def f(name):
    print('hello', end='')
    time.sleep(2)


if __name__ == '__main__':
    p = Process(target=f, args=('bob',))
    p.start()
    p.join()
```
only shows `hello` after 2 seconds and not immediately as expected.