### PR TITLE
Trio loop

### DIFF
--- a/ipykernel/trio_runner.py
+++ b/ipykernel/trio_runner.py
@@ -1,0 +1,38 @@
+import builtins
+import logging
+import traceback
+
+import trio
+
+
+class TrioRunner:
+    def __init__(self):
+        self._trio_token = None
+
+    def run(self):
+        def log_nursery_exc(exc):
+            exc = '\n'.join(traceback.format_exception(type(exc), exc,
+                exc.__traceback__))
+            logging.error('An exception occurred in a global nursery task.\n%s',
+                exc)
+
+        async def trio_main():
+            self._trio_token = trio.hazmat.current_trio_token()
+            async with trio.open_nursery() as nursery:
+                # TODO This hack prevents the nursery from cancelling all child
+                # tasks when an uncaught exception occurs, but it's ugly.
+                nursery._add_exc = log_nursery_exc
+                builtins.GLOBAL_NURSERY = nursery
+                await trio.sleep_forever()
+
+        trio.run(trio_main)
+
+    def __call__(self, async_fn):
+        async def loc(coro):
+            """
+            We need the dummy no-op async def to protect from
+            trio's internal. See https://github.com/python-trio/trio/issues/89
+            """
+            return await coro
+
+        return trio.from_thread.run(loc, async_fn, trio_token=self._trio_token)


### PR DESCRIPTION
This PR adds support for running a long-lived Trio event loop on the foreground thread and pushes the ZMQ/other kernel stuff into a background thread. When Trio runs on the main thread, all cells are executed as tasks inside a global nursery. The global nursery is also injected into `builtins` as `GLOBAL_NURSERY` so that notebook users can run tasks in the background even after a cell finishes executing. Exceptions in background tasks are caught and displayed in the current cell.

**This requires [a matching PR on IPython itself!!](https://github.com/ipython/ipython/pull/12097)**

The loop is activated by passing a kernel flag, so by default this PR doesn't affect any current users—not even existing `%autoawait trio` users. It's completely opt-in. The following example configuration shows how to start a kernel in Trio loop mode:

```json
{
 "argv": [
  "python",
  "-m",
  "ipykernel_launcher",
  "-f",
  "{connection_file}",
  "--IPKernelApp.trio_loop=True"
 ],
 "display_name": "Python 3 Trio",
 "language": "python"
}
```

(Save this file as `.../share/jupyter/python-trio/kernel.json`. The leading `...` part will vary depending on whether you're installing system-wide, per-user, or within a Python venv.)

In Trio loop mode, the kernel implicitly runs `%autoawait trio` at startup. It also disables the `%autoawait` magic to prevent users from trying to switch loops, which would certainly fail.

Here's an example notebooks session running in this mode:

![notebook running in trio loop mode](https://user-images.githubusercontent.com/320904/73103396-0499fe80-3ec2-11ea-8e35-3c909d18c8a0.png)

We know the code isn't pretty, and we're seeking feedback on some of the implementation decisions, including (but not limited to):

* How to make a global nursery available to notebook users? Injecting into `builtins` is pretty hacky, as is hard-coding the name `GLOBAL_NURSERY`.
* How to inject the `TrioRunner` created in `kernelapp.py` into the shell instance, where it is needed to run cells on the main Trio loop.
* Whether to disable `%autoawait` and how best to do so. If disabled, what's the best way to warn the user?