### PR TITLE
Workaround tornado+py38+windows compatibility issue 

### DIFF
--- a/examples/embedding/inprocess_qtconsole.py
+++ b/examples/embedding/inprocess_qtconsole.py
@@ -2,8 +2,8 @@ from __future__ import print_function
 import os
 import sys
 
-from IPython.qt.console.rich_ipython_widget import RichIPythonWidget
-from IPython.qt.inprocess import QtInProcessKernelManager
+from qtconsole.rich_ipython_widget import RichIPythonWidget
+from qtconsole.inprocess import QtInProcessKernelManager
 from IPython.lib import guisupport
 
 

--- a/examples/embedding/inprocess_qtconsole.py
+++ b/examples/embedding/inprocess_qtconsole.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 import os
+import sys
 
 from IPython.qt.console.rich_ipython_widget import RichIPythonWidget
 from IPython.qt.inprocess import QtInProcessKernelManager
@@ -10,10 +11,38 @@ def print_process_id():
     print('Process ID is:', os.getpid())
 
 
+def init_asyncio_patch():
+    """set default asyncio policy to be compatible with tornado
+    Tornado 6 (at least) is not compatible with the default
+    asyncio implementation on Windows
+    Pick the older SelectorEventLoopPolicy on Windows
+    if the known-incompatible default policy is in use.
+    do this as early as possible to make it a low priority and overrideable
+    ref: https://github.com/tornadoweb/tornado/issues/2608
+    FIXME: if/when tornado supports the defaults in asyncio,
+           remove and bump tornado requirement for py38
+    """
+    if sys.platform.startswith("win") and sys.version_info >= (3, 8):
+        import asyncio
+        try:
+            from asyncio import (
+                WindowsProactorEventLoopPolicy,
+                WindowsSelectorEventLoopPolicy,
+            )
+        except ImportError:
+            pass
+            # not affected
+        else:
+            if type(asyncio.get_event_loop_policy()) is WindowsProactorEventLoopPolicy:
+                # WindowsProactorEventLoopPolicy is not compatible with tornado 6
+                # fallback to the pre-3.8 default of Selector
+                asyncio.set_event_loop_policy(WindowsSelectorEventLoopPolicy())
+
 def main():
     # Print the ID of the main process
     print_process_id()
 
+    init_asyncio_patch()
     app = guisupport.get_app_qt4()
 
     # Create an in-process kernel

--- a/examples/embedding/inprocess_terminal.py
+++ b/examples/embedding/inprocess_terminal.py
@@ -2,8 +2,8 @@ from __future__ import print_function
 import os
 import sys
 
-from IPython.kernel.inprocess import InProcessKernelManager
-from IPython.terminal.console.interactiveshell import ZMQTerminalInteractiveShell
+from ipykernel.inprocess import InProcessKernelManager
+from jupyter_console.ptshell import ZMQTerminalInteractiveShell
 
 
 def print_process_id():

--- a/examples/embedding/inprocess_terminal.py
+++ b/examples/embedding/inprocess_terminal.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 import os
+import sys
 
 from IPython.kernel.inprocess import InProcessKernelManager
 from IPython.terminal.console.interactiveshell import ZMQTerminalInteractiveShell
@@ -9,12 +10,41 @@ def print_process_id():
     print('Process ID is:', os.getpid())
 
 
+def init_asyncio_patch():
+    """set default asyncio policy to be compatible with tornado
+    Tornado 6 (at least) is not compatible with the default
+    asyncio implementation on Windows
+    Pick the older SelectorEventLoopPolicy on Windows
+    if the known-incompatible default policy is in use.
+    do this as early as possible to make it a low priority and overrideable
+    ref: https://github.com/tornadoweb/tornado/issues/2608
+    FIXME: if/when tornado supports the defaults in asyncio,
+           remove and bump tornado requirement for py38
+    """
+    if sys.platform.startswith("win") and sys.version_info >= (3, 8):
+        import asyncio
+        try:
+            from asyncio import (
+                WindowsProactorEventLoopPolicy,
+                WindowsSelectorEventLoopPolicy,
+            )
+        except ImportError:
+            pass
+            # not affected
+        else:
+            if type(asyncio.get_event_loop_policy()) is WindowsProactorEventLoopPolicy:
+                # WindowsProactorEventLoopPolicy is not compatible with tornado 6
+                # fallback to the pre-3.8 default of Selector
+                asyncio.set_event_loop_policy(WindowsSelectorEventLoopPolicy())
+
+
 def main():
     print_process_id()
 
     # Create an in-process kernel
     # >>> print_process_id()
     # will print the same process ID as the main process
+    init_asyncio_patch()
     kernel_manager = InProcessKernelManager()
     kernel_manager.start_kernel()
     kernel = kernel_manager.kernel

--- a/examples/embedding/internal_ipkernel.py
+++ b/examples/embedding/internal_ipkernel.py
@@ -5,7 +5,7 @@
 import sys
 
 from IPython.lib.kernel import connect_qtconsole
-from IPython.kernel.zmq.kernelapp import IPKernelApp
+from ipykernel.kernelapp import IPKernelApp
 
 #-----------------------------------------------------------------------------
 # Functions and classes

--- a/ipykernel/ipkernel.py
+++ b/ipykernel/ipkernel.py
@@ -57,25 +57,7 @@ class IPythonKernel(KernelBase):
     _sys_raw_input = Any()
     _sys_eval_input = Any()
 
-    def _init_asyncio_patch(self):
-        if sys.platform.startswith("win") and sys.version_info >= (3, 8):
-            import asyncio
-            try:
-                from asyncio import (
-                    WindowsProactorEventLoopPolicy,
-                    WindowsSelectorEventLoopPolicy,
-                )
-            except ImportError:
-                pass
-                # not affected
-            else:
-                if type(asyncio.get_event_loop_policy()) is WindowsProactorEventLoopPolicy:
-                    # WindowsProactorEventLoopPolicy is not compatible with tornado 6
-                    # fallback to the pre-3.8 default of Selector
-                    asyncio.set_event_loop_policy(WindowsSelectorEventLoopPolicy())
-
     def __init__(self, **kwargs):
-        self._init_asyncio_patch()
         super(IPythonKernel, self).__init__(**kwargs)
 
         # Initialize the InteractiveShell subclass

--- a/ipykernel/ipkernel.py
+++ b/ipykernel/ipkernel.py
@@ -57,7 +57,25 @@ class IPythonKernel(KernelBase):
     _sys_raw_input = Any()
     _sys_eval_input = Any()
 
+    def _init_asyncio_patch(self):
+        if sys.platform.startswith("win") and sys.version_info >= (3, 8):
+            import asyncio
+            try:
+                from asyncio import (
+                    WindowsProactorEventLoopPolicy,
+                    WindowsSelectorEventLoopPolicy,
+                )
+            except ImportError:
+                pass
+                # not affected
+            else:
+                if type(asyncio.get_event_loop_policy()) is WindowsProactorEventLoopPolicy:
+                    # WindowsProactorEventLoopPolicy is not compatible with tornado 6
+                    # fallback to the pre-3.8 default of Selector
+                    asyncio.set_event_loop_policy(WindowsSelectorEventLoopPolicy())
+
     def __init__(self, **kwargs):
+        self._init_asyncio_patch()
         super(IPythonKernel, self).__init__(**kwargs)
 
         # Initialize the InteractiveShell subclass


### PR DESCRIPTION
The example [inprocess_qtconsole.py](https://github.com/ipython/ipykernel/blob/master/examples/embedding/inprocess_qtconsole.py) is not working with python 3.8 on windows and this PR make it work.

Similar fix as #456: set eventloop policy to the old default while tornado is not compatible with the new one.

I don't follow how this works, so I don't know if this is the right fix (just tried to work out where to put the fix from #456) but at least it should highlight where the issue is! ;)