### PR TITLE
add py38 and py35 to the appveyor matrix

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,6 +15,7 @@ cache:
 
 init:
   - cmd: set PATH=%python%;%python%\scripts;%PATH%
+
 install:
   - cmd: |
         python -m pip install --upgrade setuptools pip wheel
@@ -26,8 +27,9 @@ install:
         pip install matplotlib numpy
         pip freeze
   - cmd: python -c "import ipykernel.kernelspec; ipykernel.kernelspec.install(user=True)"
+
 test_script:
-  - cmd: pytest -v --cov ipykernel ipykernel
+  - cmd: pytest -v -x --cov ipykernel ipykernel
 
 on_success:
   - cmd: pip install codecov

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,8 +6,9 @@ clone_depth: 1
 environment:
 
   matrix:
+    - python: "C:/Python38-x64"
     - python: "C:/Python36-x64"
-    - python: "C:/Python36"
+    - python: "C:/Python35"
 
 cache:
   - C:\Users\appveyor\AppData\Local\pip\Cache

--- a/ipykernel/inprocess/tests/test_kernel.py
+++ b/ipykernel/inprocess/tests/test_kernel.py
@@ -20,9 +20,43 @@ else:
     from StringIO import StringIO
 
 
+def _init_asyncio_patch():
+    """set default asyncio policy to be compatible with tornado
+
+    Tornado 6 (at least) is not compatible with the default
+    asyncio implementation on Windows
+
+    Pick the older SelectorEventLoopPolicy on Windows
+    if the known-incompatible default policy is in use.
+
+    do this as early as possible to make it a low priority and overrideable
+
+    ref: https://github.com/tornadoweb/tornado/issues/2608
+
+    FIXME: if/when tornado supports the defaults in asyncio,
+           remove and bump tornado requirement for py38
+    """
+    if sys.platform.startswith("win") and sys.version_info >= (3, 8):
+        import asyncio
+        try:
+            from asyncio import (
+                WindowsProactorEventLoopPolicy,
+                WindowsSelectorEventLoopPolicy,
+            )
+        except ImportError:
+            pass
+            # not affected
+        else:
+            if type(asyncio.get_event_loop_policy()) is WindowsProactorEventLoopPolicy:
+                # WindowsProactorEventLoopPolicy is not compatible with tornado 6
+                # fallback to the pre-3.8 default of Selector
+                asyncio.set_event_loop_policy(WindowsSelectorEventLoopPolicy())
+
+
 class InProcessKernelTestCase(unittest.TestCase):
 
     def setUp(self):
+        _init_asyncio_patch()
         self.km = InProcessKernelManager()
         self.km.start_kernel()
         self.kc = self.km.client()

--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,7 @@ setup_args = dict(
     ],
     extras_require={
         'test': [
-            'pytest',
+            'pytest !=5.3.4',
             'pytest-cov',
             'flaky',
             'nose',  # nose because there are still a few nose.tools imports hanging around


### PR DESCRIPTION
Further investigates whether the current release meets the need on python 3.8 on windows.
Also changes one of the 3.6 excursions to 3.5. The `setup.py` _claims_ 3.4, but meh, and ensures the (apparently) broken `pytest 5.3.4` is not used...

see also:
- https://github.com/conda-forge/ipykernel-feedstock/pull/52
- https://github.com/conda-forge/ipykernel-feedstock/pull/51