### PR TITLE
Add control channel

### DIFF
--- a/ipykernel/inprocess/client.py
+++ b/ipykernel/inprocess/client.py
@@ -41,6 +41,7 @@ class InProcessKernelClient(KernelClient):
     shell_channel_class = Type(InProcessChannel)
     iopub_channel_class = Type(InProcessChannel)
     stdin_channel_class = Type(InProcessChannel)
+    control_channel_class = Type(InProcessChannel)
     hb_channel_class = Type(InProcessHBChannel)
 
     kernel = Instance('ipykernel.inprocess.ipkernel.InProcessKernel',
@@ -81,6 +82,12 @@ class InProcessKernelClient(KernelClient):
         if self._stdin_channel is None:
             self._stdin_channel = self.stdin_channel_class(self)
         return self._stdin_channel
+
+    @property
+    def control_channel(self):
+        if self._control_channel is None:
+            self._control_channel = self.control_channel_class(self)
+        return self._control_channel
 
     @property
     def hb_channel(self):


### PR DESCRIPTION
`jupyter_client` v6.0.0 requires a control channel.
Fixes https://github.com/jupyter/jupyter_client/issues/523