### PR TITLE
Make pdb on Windows interruptible

### DIFF
--- a/ipykernel/kernelapp.py
+++ b/ipykernel/kernelapp.py
@@ -535,7 +535,11 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp,
                     asyncio.set_event_loop_policy(WindowsSelectorEventLoopPolicy())
 
     def init_pdb(self):
-        """Replace pdb with IPython's version that is e.g. interruptible."""
+        """Replace pdb with IPython's version that is interruptible.
+        
+        With the non-interruptible version, stopping pdb() locks up the kernel in a
+        non-recoverable state.
+        """
         import pdb
         from IPython.core import debugger
         debugger.Pdb = debugger.InterruptiblePdb

--- a/ipykernel/kernelapp.py
+++ b/ipykernel/kernelapp.py
@@ -534,6 +534,13 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp,
                     # fallback to the pre-3.8 default of Selector
                     asyncio.set_event_loop_policy(WindowsSelectorEventLoopPolicy())
 
+    def init_pdb(self):
+        """Replace pdb with IPython's version that is e.g. interruptible."""
+        import pdb
+        from IPython.core import debugger
+        pdb.Pdb = debugger.Pdb
+        pdb.set_trace = debugger.set_trace
+
     @catch_config_error
     def initialize(self, argv=None):
         self._init_asyncio_patch()
@@ -541,6 +548,7 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp,
         if self.subapp is not None:
             return
 
+        self.init_pdb()
         self.init_blackhole()
         self.init_connection_file()
         self.init_poller()

--- a/ipykernel/kernelapp.py
+++ b/ipykernel/kernelapp.py
@@ -547,9 +547,11 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp,
         """
         import pdb
         from IPython.core import debugger
-        debugger.Pdb = debugger.InterruptiblePdb
-        pdb.Pdb = debugger.Pdb
-        pdb.set_trace = debugger.set_trace
+        if hasattr(debugger, "InterruptiblePdb"):
+            # Only available in newer IPython releases:
+            debugger.Pdb = debugger.InterruptiblePdb
+            pdb.Pdb = debugger.Pdb
+            pdb.set_trace = debugger.set_trace
 
     @catch_config_error
     def initialize(self, argv=None):

--- a/ipykernel/kernelapp.py
+++ b/ipykernel/kernelapp.py
@@ -538,6 +538,7 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp,
         """Replace pdb with IPython's version that is e.g. interruptible."""
         import pdb
         from IPython.core import debugger
+        debugger.Pdb = debugger.InterruptiblePdb
         pdb.Pdb = debugger.Pdb
         pdb.set_trace = debugger.set_trace
 

--- a/ipykernel/tests/test_kernel.py
+++ b/ipykernel/tests/test_kernel.py
@@ -12,8 +12,10 @@ import time
 
 import nose.tools as nt
 from flaky import flaky
+import pytest
 
 from IPython.testing import decorators as dec, tools as tt
+import IPython
 from ipython_genutils import py3compat
 from IPython.paths import locate_profile
 from ipython_genutils.tempdir import TemporaryDirectory
@@ -381,6 +383,10 @@ def test_interrupt_during_input():
         validate_message(reply, 'execute_reply', msg_id)
 
 
+@pytest.mark.skipif(
+    tuple(map(int, IPython.__version__.split("."))) < (7, 14, 0),
+    reason="Need new IPython"
+)
 def test_interrupt_during_pdb_set_trace():
     """
     The kernel exits after being interrupted while waiting in pdb.set_trace().

--- a/ipykernel/tests/test_kernel.py
+++ b/ipykernel/tests/test_kernel.py
@@ -387,6 +387,8 @@ def test_interrupt_during_pdb_set_trace():
 
     Merely testing input() isn't enough, pdb has its own issues that need
     to be handled in addition.
+
+    This test will fail with versions of IPython < 7.14.0.
     """
     with new_kernel() as kc:
         km = kc.parent

--- a/ipykernel/tests/test_kernel.py
+++ b/ipykernel/tests/test_kernel.py
@@ -13,6 +13,7 @@ import time
 import nose.tools as nt
 from flaky import flaky
 import pytest
+from packaging import version
 
 from IPython.testing import decorators as dec, tools as tt
 import IPython
@@ -384,7 +385,7 @@ def test_interrupt_during_input():
 
 
 @pytest.mark.skipif(
-    tuple(map(int, IPython.__version__.split("."))) < (7, 14, 0),
+    version.parse(IPython.__version__) < version.parse("7.14.0"),
     reason="Need new IPython"
 )
 def test_interrupt_during_pdb_set_trace():


### PR DESCRIPTION
This is the final fix for https://github.com/ipython/ipython/issues/10516

Without the fix:

1. The test fails.
2. If you open Jupyter on Windows, run `pdb.set_trace()`, and then _in same cell_ run some other code while pdb is still waiting for input, the interrupt button won't work.

With the fix:

1. The test passes.
2. `pdb.set_trace()` is finally interruptible on Windows, even in the scenario described above.