### PR TITLE
Add offset argument to seek in io test

### DIFF
--- a/ipykernel/tests/test_io.py
+++ b/ipykernel/tests/test_io.py
@@ -35,7 +35,6 @@ def test_io_api():
     with nt.assert_raises(io.UnsupportedOperation):
         stream.readline()
     with nt.assert_raises(io.UnsupportedOperation):
-        stream.seek()
+        stream.seek(0)
     with nt.assert_raises(io.UnsupportedOperation):
         stream.tell()
-


### PR DESCRIPTION
while trying to package ipykernel for pypy on conda, we've run uncovered a small issue:

```
=================================== FAILURES ===================================
_________________________________ test_io_api __________________________________

    def test_io_api():
        """Test that wrapped stdout has the same API as a normal TextIO object"""
        session = Session()
        ctx = zmq.Context()
        pub = ctx.socket(zmq.PUB)
        thread = IOPubThread(pub)
        thread.start()
    
        stream = OutStream(session, thread, 'stdout')
    
        # cleanup unused zmq objects before we start testing
        thread.stop()
        thread.close()
        ctx.term()
    
        assert stream.errors is None
        assert not stream.isatty()
        with nt.assert_raises(io.UnsupportedOperation):
            stream.detach()
        with nt.assert_raises(io.UnsupportedOperation):
            next(stream)
        with nt.assert_raises(io.UnsupportedOperation):
            stream.read()
        with nt.assert_raises(io.UnsupportedOperation):
            stream.readline()
        with nt.assert_raises(io.UnsupportedOperation):
>           stream.seek()
E           TypeError: seek() missing 1 required positional argument: 'offset'
```

Docs suggest this is indeed the case: https://docs.python.org/3/library/io.html#io.IOBase.seek

The fix just gives it `0`, but doesn't seem like it matters much, as it appears we're just checking that it subsequently fails.

Will skip the test on conda-forge, but it would be nice to have this for the next go-around... too bad i didn't find it earlier!