### PR TITLE
Allow interrupting input() on Windows, as part of effort to make pdb interruptible

### DIFF
--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -893,7 +893,9 @@ class Kernel(SingletonConfigurable):
                 # re-raise KeyboardInterrupt, to truncate traceback
                 raise KeyboardInterrupt("Interrupted by user") from None
             else:
-                # Use polling with sleep so KeyboardInterrupts can get through:
+                # Use polling with sleep so KeyboardInterrupts can get through;
+                # doing a blocking recv() means stdin reads are uninterruptible
+                # on Windows:
                 if (ident, reply) == (None, None):
                     time.sleep(0.001)
                 else:

--- a/ipykernel/parentpoller.py
+++ b/ipykernel/parentpoller.py
@@ -113,8 +113,6 @@ class ParentPollerWindows(Thread):
                     # check if signal handler is callable
                     # to avoid 'int not callable' error (Python issue #23395)
                     if callable(signal.getsignal(signal.SIGINT)):
-                        # interrupt_main() doesn't seem to interrupt input(),
-                        # so use a different mechanism:
                         raise_signal(signal.SIGINT)
 
                 elif handle == self.parent_handle:

--- a/ipykernel/parentpoller.py
+++ b/ipykernel/parentpoller.py
@@ -14,16 +14,6 @@ try:
 except ImportError:
     from thread import interrupt_main  # Py 2
 from threading import Thread
-if hasattr(signal, "raise_signal"):
-    # Python 3.8 and later:
-    raise_signal = signal.raise_signal
-elif ctypes:
-    # Emulate raise_signal using ctypes:
-    raise_signal = getattr(ctypes.PyDLL(None), "raise")
-else:
-    # Give up:
-    def raise_signal(sig):
-        warnings.warn("Process interruption won't work, upgrade to Python 3.8")
 
 from traitlets.log import get_logger
 
@@ -113,7 +103,7 @@ class ParentPollerWindows(Thread):
                     # check if signal handler is callable
                     # to avoid 'int not callable' error (Python issue #23395)
                     if callable(signal.getsignal(signal.SIGINT)):
-                        raise_signal(signal.SIGINT)
+                        interrupt_main()
 
                 elif handle == self.parent_handle:
                     get_logger().warning("Parent appears to have exited, shutting down.")

--- a/ipykernel/tests/test_kernel.py
+++ b/ipykernel/tests/test_kernel.py
@@ -333,7 +333,8 @@ def test_shutdown():
 
 
 def test_interrupt_during_input():
-    """The kernel exits after being interrupted while waiting in input().
+    """
+    The kernel exits after being interrupted while waiting in input().
     
     input() appears to have issues other functions don't, and it needs to be
     interruptible in order for pdb to be interruptible.

--- a/ipykernel/tests/test_kernel.py
+++ b/ipykernel/tests/test_kernel.py
@@ -333,7 +333,7 @@ def test_shutdown():
 
 
 def test_interrupt_during_input():
-    """The kernel exits after being interrupted, while waiting in input().
+    """The kernel exits after being interrupted while waiting in input().
     
     input() appears to have issues other functions don't, and it needs to be
     interruptible in order for pdb to be interruptible.

--- a/ipykernel/tests/test_kernel.py
+++ b/ipykernel/tests/test_kernel.py
@@ -333,13 +333,16 @@ def test_shutdown():
 
 
 def test_interrupt_during_input():
-    """Kernel exits after being interrupted, while waiting in input()."""
+    """Kernel exits after being interrupted, while waiting in input().
+    
+    input() appears to have issues other functions don't, and it needs to be
+    interruptible for pdb to be interruptible.
+    """
     with new_kernel() as kc:
         km = kc.parent
         msg_id = kc.execute("input()")
         time.sleep(1)  # Make sure it's actually waiting for input.
         km.interrupt_kernel()
-
         # If we failed to interrupt interrupt, this will timeout:
         reply = kc.get_shell_msg(timeout=TIMEOUT)
         from .test_message_spec import validate_message

--- a/ipykernel/tests/test_kernel.py
+++ b/ipykernel/tests/test_kernel.py
@@ -330,3 +330,17 @@ def test_shutdown():
             else:
                 break
         assert not km.is_alive()
+
+
+def test_interrupt_during_input():
+    """Kernel exits after being interrupted, while waiting in input()."""
+    with new_kernel() as kc:
+        km = kc.parent
+        msg_id = kc.execute("input()")
+        time.sleep(1)  # Make sure it's actually waiting for input.
+        km.interrupt_kernel()
+
+        # If we failed to interrupt interrupt, this will timeout:
+        reply = kc.get_shell_msg(timeout=TIMEOUT)
+        from .test_message_spec import validate_message
+        validate_message(reply, 'execute_reply', msg_id)

--- a/ipykernel/tests/test_kernel.py
+++ b/ipykernel/tests/test_kernel.py
@@ -333,10 +333,10 @@ def test_shutdown():
 
 
 def test_interrupt_during_input():
-    """Kernel exits after being interrupted, while waiting in input().
+    """The kernel exits after being interrupted, while waiting in input().
     
     input() appears to have issues other functions don't, and it needs to be
-    interruptible for pdb to be interruptible.
+    interruptible in order for pdb to be interruptible.
     """
     with new_kernel() as kc:
         km = kc.parent


### PR DESCRIPTION
This is part of the solution to https://github.com/ipython/ipython/issues/10516.