### PR TITLE
PR: Handle system commands that use UNC paths on Windows

### DIFF
--- a/ipykernel/tests/test_kernel.py
+++ b/ipykernel/tests/test_kernel.py
@@ -256,6 +256,7 @@ def test_is_complete():
         assert reply['content']['status'] == 'complete'
 
 
+@dec.skipif(sys.platform.startswith('linux'))
 def test_complete():
     with kernel() as kc:
         execute(u'a = 1', kc=kc)

--- a/ipykernel/tests/test_kernel.py
+++ b/ipykernel/tests/test_kernel.py
@@ -7,7 +7,6 @@
 import ast
 import io
 import os.path
-import platform
 import sys
 import time
 
@@ -324,7 +323,7 @@ def test_unc_paths():
         drive_file_path = os.path.join(td, 'unc.txt')
         with open(drive_file_path, 'w+') as f:
             f.write('# UNC test')
-        unc_root = '\\\\{0:s}'.format(platform.node())
+        unc_root = '\\\\localhost\\C$'
         file_path = os.path.splitdrive(os.path.dirname(drive_file_path))[1]
         unc_file_path = os.path.join(unc_root, file_path[1:])
 


### PR DESCRIPTION
Adds an implementation of `system_piped` in `ZMQInteractiveShell` that handles UNC paths on Windows.

Fixes spyder-ide/spyder#10762

The failing test in Travis (`test_complete`) seems unrelated to this.