### PR TITLE
Fix exception causes in zmqshell.py

### DIFF
--- a/ipykernel/zmqshell.py
+++ b/ipykernel/zmqshell.py
@@ -423,8 +423,8 @@ class KernelMagics(Magics):
 
         try:
             interval = int(arg_s)
-        except ValueError:
-            raise UsageError("%%autosave requires an integer, got %r" % arg_s)
+        except ValueError as e:
+            raise UsageError("%%autosave requires an integer, got %r" % arg_s) from e
 
         # javascript wants milliseconds
         milliseconds = 1000 * interval
@@ -485,7 +485,7 @@ class ZMQInteractiveShell(InteractiveShell):
             real_enable_gui(gui)
             self.active_eventloop = gui
         except ValueError as e:
-            raise UsageError("%s" % e)
+            raise UsageError("%s" % e) from e
 
     def init_environment(self):
         """Configure the user's environment."""


### PR DESCRIPTION
I recently went over [Matplotlib](https://github.com/matplotlib/matplotlib/pull/16706), [Pandas](https://github.com/pandas-dev/pandas/pull/32322) and [NumPy](https://github.com/numpy/numpy/pull/15731), fixing a small mistake in the way that Python 3's exception chaining is used. If you're interested, I can do it here too. I've done it on just one file right now. 

The mistake is this: In some parts of the code, an exception is being caught and replaced with a more user-friendly error. In these cases the syntax `raise new_error from old_error` needs to be used.

Python 3's exception chaining means it shows not only the traceback of the current exception, but that of the original exception (and possibly more.) This is regardless of `raise from`. The usage of `raise from` tells Python to put a more accurate message between the tracebacks. Instead of this: 

    During handling of the above exception, another exception occurred:

You'll get this: 

    The above exception was the direct cause of the following exception:

The first is inaccurate, because it signifies a bug in the exception-handling code itself, which is a separate situation than wrapping an exception.

Let me know what you think! 