### PR TITLE
Fix QSocketNotifier in the Qt event loop not being disabled for the control channel

### DIFF
--- a/ipykernel/eventloops.py
+++ b/ipykernel/eventloops.py
@@ -36,6 +36,12 @@ def _notify_stream_qt(kernel, stream):
         if stream.flush(limit=1):
             notifier.setEnabled(False)
             kernel.app.quit()
+        else:
+            # Even if there's nothing to flush, we need to disable the
+            # notifier in order to connect a new one in the next
+            # execution. This applies to the control channel.
+            notifier.setEnabled(False)
+            kernel.app.quit()
 
     fd = stream.getsockopt(zmq.FD)
     notifier = QtCore.QSocketNotifier(fd, QtCore.QSocketNotifier.Read, kernel.app)


### PR DESCRIPTION
This was generating a flush of warnings in qtconsole and Spyder.

Fixes jupyter/qtconsole#332
Fixes spyder-ide/spyder#13275