### PR TITLE
Revert "Fix QSocketNotifier in the Qt event loop not being disabled for the control channel

### DIFF
--- a/ipykernel/eventloops.py
+++ b/ipykernel/eventloops.py
@@ -36,12 +36,6 @@ def _notify_stream_qt(kernel, stream):
         if stream.flush(limit=1):
             notifier.setEnabled(False)
             kernel.app.quit()
-        else:
-            # Even if there's nothing to flush, we need to disable the
-            # notifier in order to connect a new one in the next
-            # execution. This applies to the control channel.
-            notifier.setEnabled(False)
-            kernel.app.quit()
 
     fd = stream.getsockopt(zmq.FD)
     notifier = QtCore.QSocketNotifier(fd, QtCore.QSocketNotifier.Read, kernel.app)


### PR DESCRIPTION
Reverts #525 in light of #528