### PR TITLE
Check and adjust permissions before kernel spec is written

### DIFF
--- a/ipykernel/kernelspec.py
+++ b/ipykernel/kernelspec.py
@@ -77,9 +77,6 @@ def write_kernel_spec(path=None, overrides=None, extra_arguments=None):
 
     # change permission if resources directory is not read-write able
     if not os.access(path, os.W_OK | os.R_OK):
-        warnings.warn(
-            UserWarning("resources is not writable, adjusting permissions before creating kernel")
-        )
         # changes permissions only for owner, do not touch group/other
         os.chmod(path, os.stat(path).st_mode | 0o700)
         for f in os.listdir(path):

--- a/ipykernel/kernelspec.py
+++ b/ipykernel/kernelspec.py
@@ -59,7 +59,7 @@ def get_kernel_dict(extra_arguments=None):
     }
 
 
-def write_kernel_spec(path=None, overrides=None, extra_arguments=None, resources=RESOURCES):
+def write_kernel_spec(path=None, overrides=None, extra_arguments=None):
     """Write a kernel spec directory to `path`
 
     If `path` is not specified, a temporary directory is created.
@@ -72,7 +72,7 @@ def write_kernel_spec(path=None, overrides=None, extra_arguments=None, resources
         path = os.path.join(tempfile.mkdtemp(suffix='_kernels'), KERNEL_NAME)
 
     # stage resources
-    shutil.copytree(resources, path)
+    shutil.copytree(RESOURCES, path)
 
     # change permission if resources directory is not read-write able
     if not os.access(path, os.W_OK | os.R_OK):
@@ -96,10 +96,10 @@ def write_kernel_spec(path=None, overrides=None, extra_arguments=None, resources
 def install(kernel_spec_manager=None, user=False, kernel_name=KERNEL_NAME, display_name=None,
             prefix=None, profile=None):
     """Install the IPython kernelspec for Jupyter
-    
+
     Parameters
     ----------
-    
+
     kernel_spec_manager: KernelSpecManager [optional]
         A KernelSpecManager to use for installation.
         If none provided, a default instance will be created.
@@ -118,7 +118,7 @@ def install(kernel_spec_manager=None, user=False, kernel_name=KERNEL_NAME, displ
 
     Returns
     -------
-    
+
     The path where the kernelspec was installed.
     """
     if kernel_spec_manager is None:
@@ -153,12 +153,12 @@ from traitlets.config import Application
 class InstallIPythonKernelSpecApp(Application):
     """Dummy app wrapping argparse"""
     name = 'ipython-kernel-install'
-    
+
     def initialize(self, argv=None):
         if argv is None:
             argv = sys.argv[1:]
         self.argv = argv
-    
+
     def start(self):
         import argparse
         parser = argparse.ArgumentParser(prog=self.name,

--- a/ipykernel/kernelspec.py
+++ b/ipykernel/kernelspec.py
@@ -11,7 +11,6 @@ import os
 import shutil
 import sys
 import tempfile
-import warnings
 
 from jupyter_client.kernelspec import KernelSpecManager
 

--- a/ipykernel/kernelspec.py
+++ b/ipykernel/kernelspec.py
@@ -11,6 +11,7 @@ import os
 import shutil
 import sys
 import tempfile
+import warnings
 
 from jupyter_client.kernelspec import KernelSpecManager
 
@@ -76,6 +77,9 @@ def write_kernel_spec(path=None, overrides=None, extra_arguments=None):
 
     # change permission if resources directory is not read-write able
     if not os.access(path, os.W_OK | os.R_OK):
+        warnings.warn(
+            UserWarning("resources is not writable, adjusting permissions before creating kernel")
+        )
         # changes permissions only for owner, do not touch group/other
         os.chmod(path, os.stat(path).st_mode | 0o700)
         for f in os.listdir(path):

--- a/ipykernel/tests/test_kernelspec.py
+++ b/ipykernel/tests/test_kernelspec.py
@@ -89,7 +89,8 @@ def test_write_kernel_spec_path():
     assert_is_spec(path)
     shutil.rmtree(path)
 
-
+@pytest.mark.skipif(sys.platform == 'win32',
+                    reason="does not run on windows")
 def test_write_kernel_spec_permissions():
     read_only_resources = os.path.join(tempfile.mkdtemp(), "_RESOURCES")
     shutil.copytree(RESOURCES, read_only_resources)

--- a/ipykernel/tests/test_kernelspec.py
+++ b/ipykernel/tests/test_kernelspec.py
@@ -96,7 +96,6 @@ def test_write_kernel_spec_permissions():
     os.chmod(read_only_resources, 0o500)
     for f in os.listdir(read_only_resources):
         os.chmod(os.path.join(read_only_resources, f), 0o400)
-        print(os.path.join(read_only_resources, f), oct(os.stat(os.path.join(read_only_resources, f)).st_mode))
 
     path = write_kernel_spec(resources=read_only_resources)
     assert_is_spec(path)

--- a/ipykernel/tests/test_kernelspec.py
+++ b/ipykernel/tests/test_kernelspec.py
@@ -92,8 +92,8 @@ def test_write_kernel_spec_path():
 
 @pytest.mark.skipif(sys.platform == 'win32',
                     reason="does not run on windows")
-def test_write_kernel_spec_permissions():
-    read_only_resources = os.path.join(tempfile.mkdtemp(), "_RESOURCES")
+def test_write_kernel_spec_permissions(tmp_path):
+    read_only_resources = os.path.join(tmp_path, "_RESOURCES")
     shutil.copytree(RESOURCES, read_only_resources)
 
     # file used to check that the correct (mocked) resource directory was used

--- a/ipykernel/tests/test_kernelspec.py
+++ b/ipykernel/tests/test_kernelspec.py
@@ -91,8 +91,8 @@ def test_write_kernel_spec_path():
 
 
 def test_write_kernel_spec_permissions():
-    read_only_resources = tempfile.mkdtemp()
-    shutil.copytree(RESOURCES, read_only_resources, dirs_exist_ok=True)
+    read_only_resources = os.path.join(tempfile.mkdtemp(), "_RESOURCES")
+    shutil.copytree(RESOURCES, read_only_resources)
 
     # create copy of `RESOURCES` with no write permissions
     os.chmod(read_only_resources, 0o500)


### PR DESCRIPTION
If the permissions for the `resources` directory do not allow the owner to write into it (e.g. as is the case in some directories using ACL, or if `site-packages` is set to read-only) then the install phase will fail with an error saying that `kernel.json` could not be written as the copied `resources` directory is read-only.

This PR fixes that by adding a permission check to `write_kernel_spec`. If `resources` has no write permissions it sets only the owner permission (leaving group/other unchanged) to 7 so that `kernel.json` can be written into it.

Also added in a test which creates a `resources` directory with read-only permissions to check that this has worked correctly. For the test to work `write_kernel_spec` now has a new `resources` optional argument, which is set to `RESOURCES` by default.

@takluyver :smile: 