### PR TITLE
Remove most of the python 2 compat code

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 #
 # IPython Kernel documentation build configuration file, created by
 # sphinx-quickstart on Mon Oct  5 11:32:44 2015.

--- a/examples/embedding/inprocess_qtconsole.py
+++ b/examples/embedding/inprocess_qtconsole.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os
 import sys
 

--- a/examples/embedding/inprocess_terminal.py
+++ b/examples/embedding/inprocess_terminal.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os
 import sys
 

--- a/ipykernel/codeutil.py
+++ b/ipykernel/codeutil.py
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 """Utilities to enable code objects to be pickled.
 
 Any process that import this module will be able to pickle code objects.  This

--- a/ipykernel/codeutil.py
+++ b/ipykernel/codeutil.py
@@ -14,12 +14,9 @@ Reference: A. Tremols, P Cogolo, "Python Cookbook," p 302-305
 import warnings
 warnings.warn("ipykernel.codeutil is deprecated since IPykernel 4.3.1. It has moved to ipyparallel.serialize", DeprecationWarning)
 
+import copyreg
 import sys
 import types
-try:
-    import copyreg  # Py 3
-except ImportError:
-    import copy_reg as copyreg  # Py 2
 
 def code_ctor(*args):
     return types.CodeType(*args)

--- a/ipykernel/comm/manager.py
+++ b/ipykernel/comm/manager.py
@@ -9,7 +9,6 @@ import logging
 from traitlets.config import LoggingConfigurable
 
 from ipython_genutils.importstring import import_item
-from ipython_genutils.py3compat import string_types
 from traitlets import Instance, Unicode, Dict, Any, default
 
 from .comm import Comm
@@ -34,7 +33,7 @@ class CommManager(LoggingConfigurable):
 
         f can be a Python callable or an import string for one.
         """
-        if isinstance(f, string_types):
+        if isinstance(f, str):
             f = import_item(f)
 
         self.targets[target_name] = f

--- a/ipykernel/connect.py
+++ b/ipykernel/connect.py
@@ -3,8 +3,6 @@
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-from __future__ import absolute_import
-
 import json
 import sys
 from subprocess import Popen, PIPE

--- a/ipykernel/connect.py
+++ b/ipykernel/connect.py
@@ -11,7 +11,7 @@ import warnings
 from IPython.core.profiledir import ProfileDir
 from IPython.paths import get_ipython_dir
 from ipython_genutils.path import filefind
-from ipython_genutils.py3compat import str_to_bytes, PY3
+from ipython_genutils.py3compat import str_to_bytes
 
 import jupyter_client
 from jupyter_client import write_connection_file
@@ -168,10 +168,9 @@ def connect_qtconsole(connection_file=None, argv=None, profile=None):
     ])
 
     kwargs = {}
-    if PY3:
-        # Launch the Qt console in a separate session & process group, so
-        # interrupting the kernel doesn't kill it. This kwarg is not on Py2.
-        kwargs['start_new_session'] = True
+    # Launch the Qt console in a separate session & process group, so
+    # interrupting the kernel doesn't kill it.
+    kwargs['start_new_session'] = True
 
     return Popen([sys.executable, '-c', cmd, '--existing', cf] + argv,
         stdout=PIPE, stderr=PIPE, close_fds=(sys.platform != 'win32'),

--- a/ipykernel/displayhook.py
+++ b/ipykernel/displayhook.py
@@ -7,7 +7,6 @@ import sys
 
 from IPython.core.displayhook import DisplayHook
 from ipykernel.jsonutil import encode_images, json_clean
-from ipython_genutils.py3compat import builtin_mod
 from traitlets import Instance, Dict, Any
 from jupyter_client.session import extract_header, Session
 
@@ -30,7 +29,7 @@ class ZMQDisplayHook(object):
         if obj is None:
             return
 
-        builtin_mod._ = obj
+        builtins._ = obj
         sys.stdout.flush()
         sys.stderr.flush()
         contents = {'execution_count': self.get_execution_count(),

--- a/ipykernel/displayhook.py
+++ b/ipykernel/displayhook.py
@@ -3,6 +3,7 @@
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
 
+import builtins
 import sys
 
 from IPython.core.displayhook import DisplayHook

--- a/ipykernel/eventloops.py
+++ b/ipykernel/eventloops.py
@@ -1,4 +1,3 @@
-# encoding: utf-8
 """Event loop integration for the ZeroMQ-based kernels."""
 
 # Copyright (c) IPython Development Team.

--- a/ipykernel/inprocess/blocking.py
+++ b/ipykernel/inprocess/blocking.py
@@ -8,11 +8,8 @@ Useful for test suites and blocking terminal interfaces.
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING.txt, distributed as part of this software.
 #-----------------------------------------------------------------------------
+from queue import Queue, Empty
 import sys
-try:
-    from queue import Queue, Empty  # Py 3
-except ImportError:
-    from Queue import Queue, Empty  # Py 2
 
 # IPython imports
 from traitlets import Type

--- a/ipykernel/inprocess/socket.py
+++ b/ipykernel/inprocess/socket.py
@@ -10,13 +10,12 @@ import warnings
 import zmq
 
 from traitlets import HasTraits, Instance, Int
-from ipython_genutils.py3compat import with_metaclass
 
 #-----------------------------------------------------------------------------
 # Generic socket interface
 #-----------------------------------------------------------------------------
 
-class SocketABC(with_metaclass(abc.ABCMeta, object)):
+class SocketABC(object, metaclass=abc.ABCMeta):
 
     @abc.abstractmethod
     def recv_multipart(self, flags=0, copy=True, track=False):

--- a/ipykernel/inprocess/socket.py
+++ b/ipykernel/inprocess/socket.py
@@ -4,11 +4,8 @@
 # Distributed under the terms of the Modified BSD License.
 
 import abc
+from queue import Queue
 import warnings
-try:
-    from queue import Queue  # Py 3
-except ImportError:
-    from Queue import Queue  # Py 2
 
 import zmq
 

--- a/ipykernel/inprocess/tests/test_kernel.py
+++ b/ipykernel/inprocess/tests/test_kernel.py
@@ -1,6 +1,7 @@
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
 
+from io import StringIO
 import sys
 import unittest
 
@@ -10,12 +11,6 @@ from ipykernel.inprocess.ipkernel import InProcessKernel
 from ipykernel.tests.utils import assemble_output
 from IPython.testing.decorators import skipif_not_matplotlib
 from IPython.utils.io import capture_output
-from ipython_genutils import py3compat
-
-if py3compat.PY3:
-    from io import StringIO
-else:
-    from StringIO import StringIO
 
 
 def _init_asyncio_patch():
@@ -76,10 +71,7 @@ class InProcessKernelTestCase(unittest.TestCase):
         sys_stdin = sys.stdin
         sys.stdin = io
         try:
-            if py3compat.PY3:
-                self.kc.execute('x = input()')
-            else:
-                self.kc.execute('x = raw_input()')
+            self.kc.execute('x = input()')
         finally:
             sys.stdin = sys_stdin
         assert self.km.kernel.shell.user_ns.get('x') == 'foobar'

--- a/ipykernel/inprocess/tests/test_kernel.py
+++ b/ipykernel/inprocess/tests/test_kernel.py
@@ -1,8 +1,6 @@
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-from __future__ import print_function
-
 import sys
 import unittest
 

--- a/ipykernel/inprocess/tests/test_kernelmanager.py
+++ b/ipykernel/inprocess/tests/test_kernelmanager.py
@@ -1,8 +1,6 @@
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-from __future__ import print_function
-
 import unittest
 
 from ipykernel.inprocess.blocking import BlockingInProcessKernelClient

--- a/ipykernel/iostream.py
+++ b/ipykernel/iostream.py
@@ -6,10 +6,7 @@
 import atexit
 from binascii import b2a_hex
 from collections import deque
-try:
-    from importlib import lock_held as import_lock_held
-except ImportError:
-    from imp import lock_held as import_lock_held
+from importlib import lock_held as import_lock_held
 import os
 import sys
 import threading

--- a/ipykernel/iostream.py
+++ b/ipykernel/iostream.py
@@ -6,7 +6,7 @@
 import atexit
 from binascii import b2a_hex
 from collections import deque
-from importlib import lock_held as import_lock_held
+from imp import lock_held as import_lock_held
 import os
 import sys
 import threading

--- a/ipykernel/iostream.py
+++ b/ipykernel/iostream.py
@@ -4,7 +4,6 @@
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-from __future__ import print_function
 import atexit
 from binascii import b2a_hex
 from collections import deque

--- a/ipykernel/iostream.py
+++ b/ipykernel/iostream.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 """Wrappers for forwarding stdout/stderr over zmq"""
 
 # Copyright (c) IPython Development Team.

--- a/ipykernel/iostream.py
+++ b/ipykernel/iostream.py
@@ -20,7 +20,6 @@ from zmq.eventloop.zmqstream import ZMQStream
 from jupyter_client.session import extract_header
 
 from ipython_genutils import py3compat
-from ipython_genutils.py3compat import unicode_type
 
 #-----------------------------------------------------------------------------
 # Globals
@@ -391,7 +390,7 @@ class OutStream(TextIOBase):
             raise ValueError('I/O operation on closed file')
         else:
             # Make sure that we're handling unicode
-            if not isinstance(string, unicode_type):
+            if not isinstance(string, str):
                 string = string.decode(self.encoding, 'replace')
 
             is_child = (not self._is_master_process())

--- a/ipykernel/ipkernel.py
+++ b/ipykernel/ipkernel.py
@@ -8,7 +8,7 @@ import signal
 import sys
 
 from IPython.core import release
-from ipython_genutils.py3compat import builtin_mod, PY3, unicode_type, safe_unicode
+from ipython_genutils.py3compat import builtin_mod, PY3, safe_unicode
 from IPython.utils.tokenutil import token_at_cursor, line_at_cursor
 from tornado import gen
 from traitlets import Instance, Type, Any, List, Bool
@@ -319,7 +319,7 @@ class IPythonKernel(KernelBase):
 
             reply_content.update({
                 'traceback': shell._last_traceback or [],
-                'ename': unicode_type(type(err).__name__),
+                'ename': str(type(err).__name__),
                 'evalue': safe_unicode(err),
             })
 
@@ -505,7 +505,7 @@ class IPythonKernel(KernelBase):
             shell.showtraceback()
             reply_content = {
                 'traceback': shell._last_traceback or [],
-                'ename': unicode_type(type(e).__name__),
+                'ename': str(type(e).__name__),
                 'evalue': safe_unicode(e),
             }
             # FIXME: deprecated piece for ipyparallel (remove in 5.0):

--- a/ipykernel/ipkernel.py
+++ b/ipykernel/ipkernel.py
@@ -1,6 +1,7 @@
 """The IPython kernel implementation"""
 
 import asyncio
+import builtins
 from contextlib import contextmanager
 from functools import partial
 import getpass

--- a/ipykernel/ipkernel.py
+++ b/ipykernel/ipkernel.py
@@ -8,7 +8,7 @@ import signal
 import sys
 
 from IPython.core import release
-from ipython_genutils.py3compat import builtin_mod, PY3, safe_unicode
+from ipython_genutils.py3compat import builtin_mod, safe_unicode
 from IPython.utils.tokenutil import token_at_cursor, line_at_cursor
 from tornado import gen
 from traitlets import Instance, Type, Any, List, Bool
@@ -127,7 +127,7 @@ class IPythonKernel(KernelBase):
             'name': 'ipython',
             'version': sys.version_info[0]
         },
-        'pygments_lexer': 'ipython%d' % (3 if PY3 else 2),
+        'pygments_lexer': 'ipython%d' % 3,
         'nbconvert_exporter': 'python',
         'file_extension': '.py'
     }
@@ -181,24 +181,15 @@ class IPythonKernel(KernelBase):
         """
         self._allow_stdin = allow_stdin
 
-        if PY3:
-            self._sys_raw_input = builtin_mod.input
-            builtin_mod.input = self.raw_input
-        else:
-            self._sys_raw_input = builtin_mod.raw_input
-            self._sys_eval_input = builtin_mod.input
-            builtin_mod.raw_input = self.raw_input
-            builtin_mod.input = lambda prompt='': eval(self.raw_input(prompt))
+        self._sys_raw_input = builtin_mod.input
+        builtin_mod.input = self.raw_input
+
         self._save_getpass = getpass.getpass
         getpass.getpass = self.getpass
 
     def _restore_input(self):
         """Restore raw_input, getpass"""
-        if PY3:
-            builtin_mod.input = self._sys_raw_input
-        else:
-            builtin_mod.raw_input = self._sys_raw_input
-            builtin_mod.input = self._sys_eval_input
+        builtin_mod.input = self._sys_raw_input
 
         getpass.getpass = self._save_getpass
 

--- a/ipykernel/ipkernel.py
+++ b/ipykernel/ipkernel.py
@@ -8,7 +8,7 @@ import signal
 import sys
 
 from IPython.core import release
-from ipython_genutils.py3compat import builtin_mod, safe_unicode
+from ipython_genutils.py3compat import safe_unicode
 from IPython.utils.tokenutil import token_at_cursor, line_at_cursor
 from tornado import gen
 from traitlets import Instance, Type, Any, List, Bool
@@ -181,15 +181,15 @@ class IPythonKernel(KernelBase):
         """
         self._allow_stdin = allow_stdin
 
-        self._sys_raw_input = builtin_mod.input
-        builtin_mod.input = self.raw_input
+        self._sys_raw_input = builtins.input
+        builtins.input = self.raw_input
 
         self._save_getpass = getpass.getpass
         getpass.getpass = self.getpass
 
     def _restore_input(self):
         """Restore raw_input, getpass"""
-        builtin_mod.input = self._sys_raw_input
+        builtins.input = self._sys_raw_input
 
         getpass.getpass = self._save_getpass
 

--- a/ipykernel/jsonutil.py
+++ b/ipykernel/jsonutil.py
@@ -12,7 +12,6 @@ import numbers
 
 
 from ipython_genutils import py3compat
-from ipython_genutils.py3compat import iteritems
 from ipython_genutils.encoding import DEFAULT_ENCODING
 next_attr_name = '__next__' if py3compat.PY3 else 'next'
 
@@ -187,7 +186,7 @@ def json_clean(obj):
                              'key collision would lead to dropped values')
         # If all OK, proceed by making the new dict that will be json-safe
         out = {}
-        for k,v in iteritems(obj):
+        for k,v in obj.items():
             out[str(k)] = json_clean(v)
         return out
     if isinstance(obj, datetime):

--- a/ipykernel/jsonutil.py
+++ b/ipykernel/jsonutil.py
@@ -10,10 +10,8 @@ import types
 from datetime import datetime
 import numbers
 
-
-from ipython_genutils import py3compat
 from ipython_genutils.encoding import DEFAULT_ENCODING
-next_attr_name = '__next__' if py3compat.PY3 else 'next'
+next_attr_name = '__next__'
 
 #-----------------------------------------------------------------------------
 # Globals and constants
@@ -69,40 +67,7 @@ def encode_images(format_dict):
     # no need for handling of ambiguous bytestrings on Python 3,
     # where bytes objects always represent binary data and thus
     # base64-encoded.
-    if py3compat.PY3:
-        return format_dict
-
-    encoded = format_dict.copy()
-
-    pngdata = format_dict.get('image/png')
-    if isinstance(pngdata, bytes):
-        # make sure we don't double-encode
-        if not pngdata.startswith(PNG64):
-            pngdata = b2a_base64(pngdata)
-        encoded['image/png'] = pngdata.decode('ascii')
-
-    jpegdata = format_dict.get('image/jpeg')
-    if isinstance(jpegdata, bytes):
-        # make sure we don't double-encode
-        if not jpegdata.startswith(JPEG64):
-            jpegdata = b2a_base64(jpegdata)
-        encoded['image/jpeg'] = jpegdata.decode('ascii')
-        
-    gifdata = format_dict.get('image/gif')
-    if isinstance(gifdata, bytes):
-        # make sure we don't double-encode
-        if not gifdata.startswith((GIF_64, GIF89_64)):
-            gifdata = b2a_base64(gifdata)
-        encoded['image/gif'] = gifdata.decode('ascii')
-
-    pdfdata = format_dict.get('application/pdf')
-    if isinstance(pdfdata, bytes):
-        # make sure we don't double-encode
-        if not pdfdata.startswith(PDF64):
-            pdfdata = b2a_base64(pdfdata)
-        encoded['application/pdf'] = pdfdata.decode('ascii')
-
-    return encoded
+    return format_dict
 
 
 def json_clean(obj):
@@ -154,19 +119,9 @@ def json_clean(obj):
         return obj
     
     if isinstance(obj, bytes):
-        if py3compat.PY3:
-            # unanmbiguous binary data is base64-encoded
-            # (this probably should have happened upstream)
-            return b2a_base64(obj).decode('ascii')
-        else:
-            # Python 2 bytestr is ambiguous,
-            # needs special handling for possible binary bytestrings.
-            # imperfect workaround: if ascii, assume text.
-            # otherwise assume binary, base64-encode (py3 behavior).
-            try:
-                return obj.decode('ascii')
-            except UnicodeDecodeError:
-                return b2a_base64(obj).decode('ascii')
+        # unanmbiguous binary data is base64-encoded
+        # (this probably should have happened upstream)
+        return b2a_base64(obj).decode('ascii')
 
     if isinstance(obj, container_to_list) or (
         hasattr(obj, '__iter__') and hasattr(obj, next_attr_name)):

--- a/ipykernel/jsonutil.py
+++ b/ipykernel/jsonutil.py
@@ -12,7 +12,7 @@ import numbers
 
 
 from ipython_genutils import py3compat
-from ipython_genutils.py3compat import unicode_type, iteritems
+from ipython_genutils.py3compat import iteritems
 from ipython_genutils.encoding import DEFAULT_ENCODING
 next_attr_name = '__next__' if py3compat.PY3 else 'next'
 
@@ -130,7 +130,7 @@ def json_clean(obj):
 
     """
     # types that are 'atomic' and ok in json as-is.
-    atomic_ok = (unicode_type, type(None))
+    atomic_ok = (str, type(None))
 
     # containers that we need to convert into lists
     container_to_list = (tuple, set, types.GeneratorType)
@@ -181,14 +181,14 @@ def json_clean(obj):
         # key collisions after stringification.  This can happen with keys like
         # True and 'true' or 1 and '1', which collide in JSON.
         nkeys = len(obj)
-        nkeys_collapsed = len(set(map(unicode_type, obj)))
+        nkeys_collapsed = len(set(map(str, obj)))
         if nkeys != nkeys_collapsed:
             raise ValueError('dict cannot be safely converted to JSON: '
                              'key collision would lead to dropped values')
         # If all OK, proceed by making the new dict that will be json-safe
         out = {}
         for k,v in iteritems(obj):
-            out[unicode_type(k)] = json_clean(v)
+            out[str(k)] = json_clean(v)
         return out
     if isinstance(obj, datetime):
         return obj.strftime(ISO8601)

--- a/ipykernel/kernelapp.py
+++ b/ipykernel/kernelapp.py
@@ -3,8 +3,6 @@
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-from __future__ import print_function
-
 import atexit
 import os
 import sys

--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -516,7 +516,7 @@ class Kernel(SingletonConfigurable):
 
         try:
             content = parent['content']
-            code = py3compat.cast_unicode_py2(content['code'])
+            code = content['code']
             silent = content['silent']
             store_history = content.get('store_history', not silent)
             user_expressions = content.get('user_expressions', {})

--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -28,7 +28,7 @@ from zmq.eventloop.zmqstream import ZMQStream
 from traitlets.config.configurable import SingletonConfigurable
 from IPython.core.error import StdinNotImplementedError
 from ipython_genutils import py3compat
-from ipython_genutils.py3compat import unicode_type, string_types
+from ipython_genutils.py3compat import string_types
 from ipykernel.jsonutil import json_clean
 from traitlets import (
     Any, Instance, Float, Dict, List, Set, Integer, Unicode, Bool,
@@ -75,7 +75,7 @@ class Kernel(SingletonConfigurable):
 
     @default('ident')
     def _default_ident(self):
-        return unicode_type(uuid.uuid4())
+        return str(uuid.uuid4())
 
     # This should be overridden by wrapper kernels that implement any real
     # language.

--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -28,7 +28,6 @@ from zmq.eventloop.zmqstream import ZMQStream
 from traitlets.config.configurable import SingletonConfigurable
 from IPython.core.error import StdinNotImplementedError
 from ipython_genutils import py3compat
-from ipython_genutils.py3compat import string_types
 from ipykernel.jsonutil import json_clean
 from traitlets import (
     Any, Instance, Float, Dict, List, Set, Integer, Unicode, Bool,
@@ -752,7 +751,7 @@ class Kernel(SingletonConfigurable):
         """abort a specific msg by id"""
         self.log.warning("abort_request is deprecated in kernel_base. It is only part of IPython parallel")
         msg_ids = parent['content'].get('msg_ids', None)
-        if isinstance(msg_ids, string_types):
+        if isinstance(msg_ids, str):
             msg_ids = [msg_ids]
         if not msg_ids:
             self._abort_queues()

--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -3,8 +3,6 @@
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-from __future__ import print_function
-
 from datetime import datetime
 from functools import partial
 import itertools

--- a/ipykernel/kernelspec.py
+++ b/ipykernel/kernelspec.py
@@ -3,8 +3,6 @@
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-from __future__ import print_function
-
 import errno
 import json
 import os

--- a/ipykernel/parentpoller.py
+++ b/ipykernel/parentpoller.py
@@ -9,10 +9,7 @@ import os
 import platform
 import signal
 import time
-try:
-    from _thread import interrupt_main  # Py 3
-except ImportError:
-    from thread import interrupt_main  # Py 2
+from _thread import interrupt_main  # Py 3
 from threading import Thread
 
 from traitlets.log import get_logger

--- a/ipykernel/pickleutil.py
+++ b/ipykernel/pickleutil.py
@@ -13,7 +13,7 @@ from types import FunctionType
 
 from ipython_genutils import py3compat
 from ipython_genutils.importstring import import_item
-from ipython_genutils.py3compat import iteritems, buffer_to_bytes, buffer_to_bytes_py2
+from ipython_genutils.py3compat import buffer_to_bytes, buffer_to_bytes_py2
 
 # This registers a hook when it's imported
 try:
@@ -344,7 +344,7 @@ def can(obj):
     
     import_needed = False
     
-    for cls,canner in iteritems(can_map):
+    for cls,canner in can_map.items():
         if isinstance(cls, str):
             import_needed = True
             break
@@ -369,7 +369,7 @@ def can_dict(obj):
     """can the *values* of a dict"""
     if istype(obj, dict):
         newobj = {}
-        for k, v in iteritems(obj):
+        for k, v in obj.items():
             newobj[k] = can(v)
         return newobj
     else:
@@ -389,7 +389,7 @@ def uncan(obj, g=None):
     """invert canning"""
     
     import_needed = False
-    for cls,uncanner in iteritems(uncan_map):
+    for cls,uncanner in uncan_map.items():
         if isinstance(cls, str):
             import_needed = True
             break
@@ -407,7 +407,7 @@ def uncan(obj, g=None):
 def uncan_dict(obj, g=None):
     if istype(obj, dict):
         newobj = {}
-        for k, v in iteritems(obj):
+        for k, v in obj.items():
             newobj[k] = uncan(v,g)
         return newobj
     else:

--- a/ipykernel/pickleutil.py
+++ b/ipykernel/pickleutil.py
@@ -8,12 +8,8 @@ warnings.warn("ipykernel.pickleutil is deprecated. It has moved to ipyparallel."
 
 import copy
 import sys
+import pickle
 from types import FunctionType
-
-try:
-    import cPickle as pickle
-except ImportError:
-    import pickle
 
 from ipython_genutils import py3compat
 from ipython_genutils.importstring import import_item
@@ -36,10 +32,7 @@ else:
     from types import ClassType
     class_type = (type, ClassType)
 
-try:
-    PICKLE_PROTOCOL = pickle.DEFAULT_PROTOCOL
-except AttributeError:
-    PICKLE_PROTOCOL = pickle.HIGHEST_PROTOCOL
+PICKLE_PROTOCOL = pickle.DEFAULT_PROTOCOL
 
 def _get_cell_type(a=None):
     """the type of a closure cell doesn't seem to be importable,

--- a/ipykernel/pickleutil.py
+++ b/ipykernel/pickleutil.py
@@ -13,7 +13,7 @@ from types import FunctionType
 
 from ipython_genutils import py3compat
 from ipython_genutils.importstring import import_item
-from ipython_genutils.py3compat import string_types, iteritems, buffer_to_bytes, buffer_to_bytes_py2
+from ipython_genutils.py3compat import iteritems, buffer_to_bytes, buffer_to_bytes_py2
 
 # This registers a hook when it's imported
 try:
@@ -159,7 +159,7 @@ class CannedObject(object):
 class Reference(CannedObject):
     """object for wrapping a remote reference by name."""
     def __init__(self, name):
-        if not isinstance(name, string_types):
+        if not isinstance(name, str):
             raise TypeError("illegal name: %r"%name)
         self.name = name
         self.buffers = []
@@ -315,7 +315,7 @@ def _import_mapping(mapping, original=None):
     log = get_logger()
     log.debug("Importing canning map")
     for key,value in list(mapping.items()):
-        if isinstance(key, string_types):
+        if isinstance(key, str):
             try:
                 cls = import_item(key)
             except Exception:
@@ -345,7 +345,7 @@ def can(obj):
     import_needed = False
     
     for cls,canner in iteritems(can_map):
-        if isinstance(cls, string_types):
+        if isinstance(cls, str):
             import_needed = True
             break
         elif istype(obj, cls):
@@ -390,7 +390,7 @@ def uncan(obj, g=None):
     
     import_needed = False
     for cls,uncanner in iteritems(uncan_map):
-        if isinstance(cls, string_types):
+        if isinstance(cls, str):
             import_needed = True
             break
         elif isinstance(obj, cls):

--- a/ipykernel/pickleutil.py
+++ b/ipykernel/pickleutil.py
@@ -1,4 +1,3 @@
-# encoding: utf-8
 """Pickle related utilities. Perhaps this should be called 'can'."""
 
 # Copyright (c) IPython Development Team.

--- a/ipykernel/pickleutil.py
+++ b/ipykernel/pickleutil.py
@@ -25,12 +25,8 @@ except ImportError:
 
 from traitlets.log import get_logger
 
-if py3compat.PY3:
-    buffer = memoryview
-    class_type = type
-else:
-    from types import ClassType
-    class_type = (type, ClassType)
+buffer = memoryview
+class_type = type
 
 PICKLE_PROTOCOL = pickle.DEFAULT_PROTOCOL
 
@@ -281,10 +277,6 @@ class CannedArray(CannedObject):
             # we just pickled it
             return pickle.loads(buffer_to_bytes_py2(data))
         else:
-            if not py3compat.PY3 and isinstance(data, memoryview):
-                # frombuffer doesn't accept memoryviews on Python 2,
-                # so cast to old-style buffer
-                data = buffer(data.tobytes())
             return frombuffer(data, dtype=self.dtype).reshape(self.shape)
 
 

--- a/ipykernel/pickleutil.py
+++ b/ipykernel/pickleutil.py
@@ -12,7 +12,7 @@ import pickle
 from types import FunctionType
 
 from ipython_genutils.importstring import import_item
-from ipython_genutils.py3compat import buffer_to_bytes, buffer_to_bytes_py2
+from ipython_genutils.py3compat import buffer_to_bytes
 
 # This registers a hook when it's imported
 try:
@@ -274,7 +274,7 @@ class CannedArray(CannedObject):
         data = self.buffers[0]
         if self.pickled:
             # we just pickled it
-            return pickle.loads(buffer_to_bytes_py2(data))
+            return pickle.loads(data)
         else:
             return frombuffer(data, dtype=self.dtype).reshape(self.shape)
 

--- a/ipykernel/pickleutil.py
+++ b/ipykernel/pickleutil.py
@@ -11,7 +11,6 @@ import sys
 import pickle
 from types import FunctionType
 
-from ipython_genutils import py3compat
 from ipython_genutils.importstring import import_item
 from ipython_genutils.py3compat import buffer_to_bytes, buffer_to_bytes_py2
 
@@ -36,7 +35,7 @@ def _get_cell_type(a=None):
     """
     def inner():
         return a
-    return type(py3compat.get_closure(inner)[0])
+    return type(inner.__closure__[0])
 
 cell_type = _get_cell_type()
 
@@ -179,7 +178,7 @@ class CannedCell(CannedObject):
         cell_contents = uncan(self.cell_contents, g)
         def inner():
             return cell_contents
-        return py3compat.get_closure(inner)[0]
+        return inner.__closure__[0]
 
 
 class CannedFunction(CannedObject):
@@ -192,7 +191,7 @@ class CannedFunction(CannedObject):
         else:
             self.defaults = None
         
-        closure = py3compat.get_closure(f)
+        closure = f.__closure__
         if closure:
             self.closure = tuple( can(cell) for cell in closure )
         else:

--- a/ipykernel/pylab/backend_inline.py
+++ b/ipykernel/pylab/backend_inline.py
@@ -3,8 +3,6 @@
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-from __future__ import print_function
-
 import matplotlib
 from matplotlib.backends.backend_agg import (
     new_figure_manager,

--- a/ipykernel/tests/__init__.py
+++ b/ipykernel/tests/__init__.py
@@ -5,11 +5,7 @@ import os
 import shutil
 import sys
 import tempfile
-
-try:
-    from unittest.mock import patch
-except ImportError:
-    from mock import patch
+from unittest.mock import patch
 
 from jupyter_core import paths as jpaths
 from IPython import paths as ipaths

--- a/ipykernel/tests/test_embed_kernel.py
+++ b/ipykernel/tests/test_embed_kernel.py
@@ -15,7 +15,6 @@ from flaky import flaky
 from jupyter_client import BlockingKernelClient
 from jupyter_core import paths
 from ipython_genutils import py3compat
-from ipython_genutils.py3compat import unicode_type
 
 
 SETUP_TIMEOUT = 60
@@ -173,7 +172,7 @@ def test_embed_kernel_reentrant():
             content = msg['content']
             assert content['found']
             text = content['data']['text/plain']
-            assert unicode_type(i) in text
+            assert str(i) in text
 
             # exit from embed_kernel
             client.execute("get_ipython().exit_now = True")

--- a/ipykernel/tests/test_jsonutil.py
+++ b/ipykernel/tests/test_jsonutil.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 """Test suite for our JSON utilities."""
 
 # Copyright (c) IPython Development Team.

--- a/ipykernel/tests/test_kernel.py
+++ b/ipykernel/tests/test_kernel.py
@@ -90,7 +90,6 @@ def test_subprocess_print():
         flush_channels(kc)
         np = 5
         code = '\n'.join([
-            "from __future__ import print_function",
             "import time",
             "import multiprocessing as mp",
             "pool = [mp.Process(target=print, args=('hello', i,)) for i in range(%i)]" % np,

--- a/ipykernel/tests/test_kernel.py
+++ b/ipykernel/tests/test_kernel.py
@@ -16,7 +16,6 @@ from packaging import version
 
 from IPython.testing import decorators as dec, tools as tt
 import IPython
-from ipython_genutils import py3compat
 from IPython.paths import locate_profile
 from ipython_genutils.tempdir import TemporaryDirectory
 
@@ -155,11 +154,11 @@ def test_subprocess_error():
 # raw_input tests
 
 def test_raw_input():
-    """test [raw_]input"""
+    """test input"""
     with kernel() as kc:
         iopub = kc.iopub_channel
 
-        input_f = "input" if py3compat.PY3 else "raw_input"
+        input_f = "input"
         theprompt = "prompt> "
         code = 'print({input_f}("{theprompt}"))'.format(**locals())
         msg_id = kc.execute(code, allow_stdin=True)
@@ -173,27 +172,6 @@ def test_raw_input():
         assert reply['content']['status'] == 'ok'
         stdout, stderr = assemble_output(iopub)
         assert stdout == text + "\n"
-
-
-@dec.skipif(py3compat.PY3)
-def test_eval_input():
-    """test input() on Python 2"""
-    with kernel() as kc:
-        iopub = kc.iopub_channel
-
-        input_f = "input" if py3compat.PY3 else "raw_input"
-        theprompt = "prompt> "
-        code = 'print(input("{theprompt}"))'.format(**locals())
-        msg_id = kc.execute(code, allow_stdin=True)
-        msg = kc.get_stdin_msg(block=True, timeout=TIMEOUT)
-        assert msg['header']['msg_type'] == 'input_request'
-        content = msg['content']
-        assert content['prompt'] == theprompt
-        kc.input("1+1")
-        reply = kc.get_shell_msg(block=True, timeout=TIMEOUT)
-        assert reply['content']['status'] == 'ok'
-        stdout, stderr = assemble_output(iopub)
-        assert stdout == "2\n"
 
 
 def test_save_history():

--- a/ipykernel/tests/test_kernel.py
+++ b/ipykernel/tests/test_kernel.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 """test the IPython Kernel"""
 
 # Copyright (c) IPython Development Team.

--- a/ipykernel/tests/test_kernelspec.py
+++ b/ipykernel/tests/test_kernelspec.py
@@ -7,11 +7,7 @@ import os
 import shutil
 import sys
 import tempfile
-
-try:
-    from unittest import mock
-except ImportError:
-    import mock # py2
+from unittest import mock
 
 from jupyter_core.paths import jupyter_data_dir
 

--- a/ipykernel/tests/test_message_spec.py
+++ b/ipykernel/tests/test_message_spec.py
@@ -14,7 +14,7 @@ from nose.plugins.skip import SkipTest
 from traitlets import (
     HasTraits, TraitError, Bool, Unicode, Dict, Integer, List, Enum
 )
-from ipython_genutils.py3compat import string_types, iteritems
+from ipython_genutils.py3compat import iteritems
 
 from .utils import TIMEOUT, start_global_kernel, flush_channels, execute
 
@@ -98,7 +98,7 @@ class MimeBundle(Reference):
     def _data_changed(self, name, old, new):
         for k,v in iteritems(new):
             assert mime_pat.match(k)
-            assert isinstance(v, string_types)
+            assert isinstance(v, str)
 
 
 # shell replies

--- a/ipykernel/tests/test_message_spec.py
+++ b/ipykernel/tests/test_message_spec.py
@@ -14,7 +14,6 @@ from nose.plugins.skip import SkipTest
 from traitlets import (
     HasTraits, TraitError, Bool, Unicode, Dict, Integer, List, Enum
 )
-from ipython_genutils.py3compat import iteritems
 
 from .utils import TIMEOUT, start_global_kernel, flush_channels, execute
 
@@ -96,7 +95,7 @@ class MimeBundle(Reference):
     metadata = Dict()
     data = Dict()
     def _data_changed(self, name, old, new):
-        for k,v in iteritems(new):
+        for k,v in new.items():
             assert mime_pat.match(k)
             assert isinstance(v, str)
 

--- a/ipykernel/tests/test_message_spec.py
+++ b/ipykernel/tests/test_message_spec.py
@@ -6,10 +6,7 @@
 import re
 import sys
 from distutils.version import LooseVersion as V
-try:
-    from queue import Empty  # Py 3
-except ImportError:
-    from Queue import Empty  # Py 2
+from queue import Empty
 
 import nose.tools as nt
 from nose.plugins.skip import SkipTest

--- a/ipykernel/tests/test_zmq_shell.py
+++ b/ipykernel/tests/test_zmq_shell.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """ Tests for zmq shell / display publisher. """
 
 # Copyright (c) IPython Development Team.

--- a/ipykernel/tests/test_zmq_shell.py
+++ b/ipykernel/tests/test_zmq_shell.py
@@ -4,11 +4,7 @@
 # Distributed under the terms of the Modified BSD License.
 
 import os
-try:
-    from queue import Queue
-except ImportError:
-    # py2
-    from Queue import Queue
+from queue import Queue
 from threading import Thread
 import unittest
 

--- a/ipykernel/tests/utils.py
+++ b/ipykernel/tests/utils.py
@@ -3,8 +3,6 @@
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-from __future__ import print_function
-
 import atexit
 import os
 import sys

--- a/ipykernel/tests/utils.py
+++ b/ipykernel/tests/utils.py
@@ -8,11 +8,8 @@ import os
 import sys
 
 from contextlib import contextmanager
+from queue import Empty
 from subprocess import PIPE, STDOUT
-try:
-    from queue import Empty  # Py 3
-except ImportError:
-    from Queue import Empty  # Py 2
 
 import nose
 

--- a/ipykernel/zmqshell.py
+++ b/ipykernel/zmqshell.py
@@ -15,8 +15,6 @@ machinery.  This should thus be thought of as scaffolding.
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-from __future__ import print_function
-
 import os
 import sys
 import time

--- a/ipykernel/zmqshell.py
+++ b/ipykernel/zmqshell.py
@@ -41,7 +41,6 @@ from IPython.utils import openpy
 from ipykernel.jsonutil import json_clean, encode_images
 from IPython.utils.process import arg_split, system
 from ipython_genutils import py3compat
-from ipython_genutils.py3compat import unicode_type
 from traitlets import (
     Instance, Type, Dict, CBool, CBytes, Any, default, observe
 )
@@ -539,7 +538,7 @@ class ZMQInteractiveShell(InteractiveShell):
 
         exc_content = {
             'traceback' : stb,
-            'ename' : unicode_type(etype.__name__),
+            'ename' : str(etype.__name__),
             'evalue' : py3compat.safe_unicode(evalue),
         }
 

--- a/ipykernel/zmqshell.py
+++ b/ipykernel/zmqshell.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """A ZMQ-based subclass of InteractiveShell.
 
 This code is meant to ease the refactoring of the base InteractiveShell into

--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,6 @@
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-from __future__ import print_function
-
 # the name of the package
 name = 'ipykernel'
 

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# coding: utf-8
 
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.


### PR DESCRIPTION
Note to reviewer : I have tried making one and only one type of change in each of the commits so reviewing this PR commit-by-commit will be straightforward.

This PR removes most of the machinery in the codebase that supported python 2/3 compatibility.

- remove `__future__` import statements
- remove coding/encoding cookies from files
- remove try/except statements around imports that have changed between python 2 and 3
- use str instead of py3compat.unicode_type
- use str instead of py3compat.string_types
- use dict.items() instead of py3compat.iteriterms(dict)
- Remove a python 2 only test
- Remove py3compat.PY3 conditionals
- Use metaclass kwarg instead of py3compat.with_metaclass
- Use builtins instead of py3compat.builtin_mod
- Use `func.__closure__` instead of py3compat.get_closure(func)
- Remove py3compat.*_py2 functions which are no-op on python 3
