### PR TITLE
Fix stop_on_error_timeout blocking other messages in queue

### DIFF
--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -43,7 +43,6 @@ from ._version import kernel_protocol_version
 
 CONTROL_PRIORITY = 1
 SHELL_PRIORITY = 10
-ABORT_PRIORITY = 20
 
 
 class Kernel(SingletonConfigurable):

--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -795,6 +795,7 @@ class Kernel(SingletonConfigurable):
         self._aborting = True
 
         def stop_aborting(f):
+            self.log.info("Finishing abort")
             self._aborting = False
 
         self.io_loop.add_future(gen.sleep(self.stop_on_error_timeout), stop_aborting)

--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -795,16 +795,10 @@ class Kernel(SingletonConfigurable):
             stream.flush()
         self._aborting = True
 
-        self.schedule_dispatch(
-            ABORT_PRIORITY,
-            self._dispatch_abort,
-        )
+        def stop_aborting(f):
+            self._aborting = False
 
-    @gen.coroutine
-    def _dispatch_abort(self):
-        self.log.info("Finishing abort")
-        yield gen.sleep(self.stop_on_error_timeout)
-        self._aborting = False
+        self.io_loop.add_future(gen.sleep(self.stop_on_error_timeout), stop_aborting)
 
     def _send_abort_reply(self, stream, msg, idents):
         """Send a reply to an aborted request"""


### PR DESCRIPTION
In the current implementation, `stop_on_error_timeout` doesn't work as expected and instead completely blocks the message queue rather than operating as an async callback as intended.

Explanation:
`stop_on_error_timeout = 0.1`
If we send 100 requests at 1 per 0.01 second, and an error occurs after 0.3 seconds (request 30), this is what is expected to happen:
* requests 1-30 should be queued as normal
* requests 31-40 should be aborted
* requests 41-100 will be queued as normal

What actually happens:
* requests 1-30 are queued as normal
* the message queue blocks for 0.1 seconds
* requests 31-100 are queued as normal


A more extreme case can be seen if you bump this up to `stop_on_error_timeout = 15`. What happens in this case is:
* requests 1-30 are queued as normal
* the message queue blocks for 15 seconds! - No communication happens at this time, from the outside it appears as if the kernel is stalled.
* requests 31-100 are queued as normal



this PR fixes this by moving the "finish abort" callback to the event loop instead of using the existing message queue