### PR TITLE
Add env parameter to kernel installation

### DIFF
--- a/ipykernel/tests/test_kernelspec.py
+++ b/ipykernel/tests/test_kernelspec.py
@@ -150,12 +150,13 @@ def test_install_display_name_overrides_profile():
     dict(spam="spam", foo='bar')
 ])
 def test_install_env(tmp_path, env):
+    # python 3.5 // tmp_path must be converted to str
     with mock.patch('jupyter_client.kernelspec.SYSTEM_JUPYTER_PATH',
-            [tmp_path]):
+            [str(tmp_path)]):
         install(env=env)
 
     spec = tmp_path / 'kernels' / KERNEL_NAME / "kernel.json"
-    with open(spec) as f:
+    with spec.open() as f:
         spec = json.load(f)
 
     if env:

--- a/ipykernel/tests/test_kernelspec.py
+++ b/ipykernel/tests/test_kernelspec.py
@@ -21,6 +21,8 @@ from ipykernel.kernelspec import (
     RESOURCES,
 )
 
+import pytest
+
 import nose.tools as nt
 
 pjoin = os.path.join
@@ -140,3 +142,26 @@ def test_install_display_name_overrides_profile():
     with open(spec) as f:
         spec = json.load(f)
     assert spec["display_name"] == "Display"
+
+
+@pytest.mark.parametrize("env", [
+    None,
+    dict(spam="spam"),
+    dict(spam="spam", foo='bar')
+])
+def test_install_env(tmp_path, env):
+    with mock.patch('jupyter_client.kernelspec.SYSTEM_JUPYTER_PATH',
+            [tmp_path]):
+        install(env=env)
+
+    spec = tmp_path / 'kernels' / KERNEL_NAME / "kernel.json"
+    with open(spec) as f:
+        spec = json.load(f)
+
+    if env:
+        assert len(env) == len(spec['env'])
+        for k, v in env.items():
+            assert spec['env'][k] == v
+    else:
+        assert 'env' not in spec
+


### PR DESCRIPTION
This delivers a basic support of **env** parameter for setting kernel environment variables.

[Optional environment variables](https://jupyter-client.readthedocs.io/en/stable/kernels.html) can be set in kernels, this modification sets multiple environments variables on installation.

If the proposal is accepted, env. var. correctness can be added e.g. based on [Open Group Base Specifications](https://pubs.opengroup.org/onlinepubs/9699919799/)
 