### PR TITLE
Fix stack levels for ipykernel's deprecation warnings and stop using some deprecated APIs

### DIFF
--- a/ipykernel/codeutil.py
+++ b/ipykernel/codeutil.py
@@ -12,7 +12,10 @@ Reference: A. Tremols, P Cogolo, "Python Cookbook," p 302-305
 # Distributed under the terms of the Modified BSD License.
 
 import warnings
-warnings.warn("ipykernel.codeutil is deprecated since IPykernel 4.3.1. It has moved to ipyparallel.serialize", DeprecationWarning)
+warnings.warn("ipykernel.codeutil is deprecated since IPykernel 4.3.1. It has moved to ipyparallel.serialize",
+    DeprecationWarning,
+    stacklevel=2
+)
 
 import copyreg
 import sys

--- a/ipykernel/datapub.py
+++ b/ipykernel/datapub.py
@@ -13,7 +13,12 @@ warnings.warn("ipykernel.datapub is deprecated. It has moved to ipyparallel.data
 from traitlets.config import Configurable
 from traitlets import Instance, Dict, CBytes, Any
 from ipykernel.jsonutil import json_clean
-from ipykernel.serialize import serialize_object
+try:
+    # available since ipyparallel 5.0.0
+    from ipyparallel.serialize import serialize_object
+except ImportError:
+    # Deprecated since ipykernel 4.3.0
+    from ipykernel.serialize import serialize_object
 from jupyter_client.session import Session, extract_header
 
 

--- a/ipykernel/datapub.py
+++ b/ipykernel/datapub.py
@@ -2,7 +2,10 @@
 """
 
 import warnings
-warnings.warn("ipykernel.datapub is deprecated. It has moved to ipyparallel.datapub", DeprecationWarning)
+warnings.warn("ipykernel.datapub is deprecated. It has moved to ipyparallel.datapub",
+    DeprecationWarning,
+    stacklevel=2
+)
 
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
@@ -56,7 +59,10 @@ def publish_data(data):
     data : dict
         The data to be published. Think of it as a namespace.
     """
-    warnings.warn("ipykernel.datapub is deprecated. It has moved to ipyparallel.datapub", DeprecationWarning)
+    warnings.warn("ipykernel.datapub is deprecated. It has moved to ipyparallel.datapub",
+        DeprecationWarning,
+        stacklevel=2
+    )
     
     from ipykernel.zmqshell import ZMQInteractiveShell
     ZMQInteractiveShell.instance().data_pub.publish_data(data)

--- a/ipykernel/iostream.py
+++ b/ipykernel/iostream.py
@@ -14,7 +14,11 @@ import warnings
 from io import StringIO, TextIOBase
 
 import zmq
-from zmq.eventloop.ioloop import IOLoop
+if zmq.pyzmq_version_info() >= (17, 0):
+    from tornado.ioloop import IOLoop
+else:
+    # deprecated since pyzmq 17
+    from zmq.eventloop.ioloop import IOLoop
 from zmq.eventloop.zmqstream import ZMQStream
 
 from jupyter_client.session import extract_header

--- a/ipykernel/ipkernel.py
+++ b/ipykernel/ipkernel.py
@@ -12,7 +12,7 @@ from IPython.core import release
 from ipython_genutils.py3compat import safe_unicode
 from IPython.utils.tokenutil import token_at_cursor, line_at_cursor
 from tornado import gen
-from traitlets import Instance, Type, Any, List, Bool
+from traitlets import Instance, Type, Any, List, Bool, observe, observe_compat
 
 from .comm import CommManager
 from .kernelbase import Kernel as KernelBase
@@ -43,14 +43,18 @@ class IPythonKernel(KernelBase):
     ).tag(config=True)
 
     user_module = Any()
-    def _user_module_changed(self, name, old, new):
+    @observe('user_module')
+    @observe_compat
+    def _user_module_changed(self, change):
         if self.shell is not None:
-            self.shell.user_module = new
+            self.shell.user_module = change['new']
 
     user_ns = Instance(dict, args=None, allow_none=True)
-    def _user_ns_changed(self, name, old, new):
+    @observe('user_ns')
+    @observe_compat
+    def _user_ns_changed(self, change):
         if self.shell is not None:
-            self.shell.user_ns = new
+            self.shell.user_ns = change['new']
             self.shell.init_user_ns()
 
     # A reference to the Python builtin 'raw_input' function.

--- a/ipykernel/log.py
+++ b/ipykernel/log.py
@@ -3,7 +3,10 @@ from logging import INFO, DEBUG, WARN, ERROR, FATAL
 from zmq.log.handlers import PUBHandler
 
 import warnings
-warnings.warn("ipykernel.log is deprecated. It has moved to ipyparallel.engine.log", DeprecationWarning)
+warnings.warn("ipykernel.log is deprecated. It has moved to ipyparallel.engine.log",
+    DeprecationWarning
+    stacklevel=2
+)
 
 class EnginePUBHandler(PUBHandler):
     """A simple PUBHandler subclass that sets root_topic"""

--- a/ipykernel/pickleutil.py
+++ b/ipykernel/pickleutil.py
@@ -4,7 +4,10 @@
 # Distributed under the terms of the Modified BSD License.
 
 import warnings
-warnings.warn("ipykernel.pickleutil is deprecated. It has moved to ipyparallel.", DeprecationWarning)
+warnings.warn("ipykernel.pickleutil is deprecated. It has moved to ipyparallel.",
+    DeprecationWarning,
+    stacklevel=2
+)
 
 import copy
 import sys

--- a/ipykernel/serialize.py
+++ b/ipykernel/serialize.py
@@ -4,7 +4,10 @@
 # Distributed under the terms of the Modified BSD License.
 
 import warnings
-warnings.warn("ipykernel.serialize is deprecated. It has moved to ipyparallel.serialize", DeprecationWarning)
+warnings.warn("ipykernel.serialize is deprecated. It has moved to ipyparallel.serialize",
+    DeprecationWarning,
+    stacklevel=2
+)
 
 import pickle
 

--- a/ipykernel/serialize.py
+++ b/ipykernel/serialize.py
@@ -13,10 +13,19 @@ import pickle
 
 from itertools import chain
 
-from ipykernel.pickleutil import (
-    can, uncan, can_sequence, uncan_sequence, CannedObject,
-    istype, sequence_types, PICKLE_PROTOCOL,
-)
+try:
+    # available since ipyparallel 5.0.0
+    from ipyparallel.serialize.canning import (
+        can, uncan, can_sequence, uncan_sequence, CannedObject,
+        istype, sequence_types,
+    )
+    from ipyparallel.serialize.serialize import PICKLE_PROTOCOL
+except ImportError:
+    # Deprecated since ipykernel 4.3.0
+    from ipykernel.pickleutil import (
+        can, uncan, can_sequence, uncan_sequence, CannedObject,
+        istype, sequence_types, PICKLE_PROTOCOL,
+    )
 from jupyter_client.session import MAX_ITEMS, MAX_BYTES
 
 

--- a/ipykernel/zmqshell.py
+++ b/ipykernel/zmqshell.py
@@ -49,6 +49,13 @@ from ipykernel.displayhook import ZMQShellDisplayHook
 from jupyter_core.paths import jupyter_runtime_dir
 from jupyter_client.session import extract_header, Session
 
+try:
+    # available since ipyparallel 5.0.0
+    from ipyparallel.engine.datapub import ZMQDataPublisher
+except ImportError:
+    # Deprecated since ipykernel 4.3.0
+    from ipykernel.datapub import ZMQDataPublisher
+
 #-----------------------------------------------------------------------------
 # Functions and classes
 #-----------------------------------------------------------------------------
@@ -438,7 +445,7 @@ class ZMQInteractiveShell(InteractiveShell):
 
     displayhook_class = Type(ZMQShellDisplayHook)
     display_pub_class = Type(ZMQDisplayPublisher)
-    data_pub_class = Type('ipykernel.datapub.ZMQDataPublisher')
+    data_pub_class = Type(ZMQDataPublisher)
     kernel = Any()
     parent_header = Any()
 


### PR DESCRIPTION
This PR:
- fixes stack levels for ipykernel's deprecation warnings
- stops using deprecated traitlets api for observing
- uses the ipyparallel interfaces over the deprecated ipykernel variants when available
- uses tornado's IOLoop when pyzmq version is 17 or greater

This greatly minimizes the amount of deprecation warnings from ipykernel.