### PR TITLE
Turn IPython CLI into a kernel. 

### DIFF
--- a/ipykernel/ipkernel.py
+++ b/ipykernel/ipkernel.py
@@ -62,9 +62,8 @@ class IPythonKernel(KernelBase):
 
         # Initialize the InteractiveShell subclass
         self._existing_shell = False
-        assert "shell" in kwargs
-        if kwargs.get("shell"):
-            self.shell = kwargs["shell"]
+        if kwargs.get('shell'):
+            self.shell = kwargs['shell']
             self._existing_shell = True
         else:
             self.shell = self.shell_class.instance(parent=self,

--- a/ipykernel/ipkernel.py
+++ b/ipykernel/ipkernel.py
@@ -62,8 +62,9 @@ class IPythonKernel(KernelBase):
 
         # Initialize the InteractiveShell subclass
         self._existing_shell = False
-        if kwargs.get('shell'):
-            self.shell = kwargs['shell']
+        assert "shell" in kwargs
+        if kwargs.get("shell"):
+            self.shell = kwargs["shell"]
             self._existing_shell = True
         else:
             self.shell = self.shell_class.instance(parent=self,

--- a/ipykernel/ipkernel.py
+++ b/ipykernel/ipkernel.py
@@ -58,6 +58,8 @@ class IPythonKernel(KernelBase):
     _sys_eval_input = Any()
 
     def __init__(self, **kwargs):
+        if kwargs.get("user_ns", None) is None:
+            kwargs.pop("user_ns")
         super(IPythonKernel, self).__init__(**kwargs)
 
         # Initialize the InteractiveShell subclass

--- a/ipykernel/ipkernel.py
+++ b/ipykernel/ipkernel.py
@@ -92,6 +92,12 @@ class IPythonKernel(KernelBase):
             self.shell.display_pub = ZMQDisplayPublisher(parent=self.shell, shell=self.shell)
             self.shell.configurables.append(self.shell.display_pub)
 
+            from ipykernel.datapub import ZMQDataPublisher
+            self.shell.data_pub = ZMQDataPublisher(parent=self.shell)
+            import types
+            meth = types.MethodType(ZMQInteractiveShell.system_piped, self.shell)
+            self.shell.system = meth
+
 
         self.shell.displayhook.session = self.session
         self.shell.displayhook.pub_socket = self.iopub_socket

--- a/ipykernel/kernelapp.py
+++ b/ipykernel/kernelapp.py
@@ -382,9 +382,9 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp,
             e_stdout = None if self.quiet else sys.__stdout__
             e_stderr = None if self.quiet else sys.__stderr__
 
-            sys.stdout = outstream_factory(
-                self.session, self.iopub_thread, u"stdout", echo=e_stdout
-            )
+            # sys.stdout = outstream_factory(self.session, self.iopub_thread,
+            #                               u'stdout',
+            #                               echo=e_stdout)
             if sys.stderr is not None:
                 sys.stderr.flush()
             sys.stderr = outstream_factory(
@@ -442,23 +442,16 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp,
 
         kernel_factory = self.kernel_class.instance
 
-        if shell is not None:
-            user_ns = self.user_ns
-        else:
-            user_ns = None
-
-        kernel = kernel_factory(
-            parent=self,
-            session=self.session,
-            control_stream=control_stream,
-            shell_streams=[shell_stream, control_stream],
-            iopub_thread=self.iopub_thread,
-            iopub_socket=self.iopub_socket,
-            stdin_socket=self.stdin_socket,
-            log=self.log,ü
-            profile_dir=self.profile_dir,
-            user_ns=user_ns,
-            shell=shell,
+        kernel = kernel_factory(parent=self, session=self.session,
+                                control_stream=control_stream,
+                                shell_streams=[shell_stream, control_stream],
+                                iopub_thread=self.iopub_thread,
+                                iopub_socket=self.iopub_socket,
+                                stdin_socket=self.stdin_socket,
+                                log=self.log,
+                                profile_dir=self.profile_dir,
+                                #user_ns=self.user_ns,
+                                shell=shell
         )
         kernel.record_ports({
             name + '_port': port for name, port in self.ports.items()
@@ -592,10 +585,10 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp,
         # shell init steps
         self.init_path()
         self.init_shell()
-        if self.shell:
-            self.init_gui_pylab()
-            self.init_extensions()
-            self.init_code()
+        #if self.shell:
+        #    self.init_gui_pylab()
+        #    self.init_extensions()
+        #    self.init_code()
         # flush stdout/stderr, so that anything written to these streams during
         # initialization do not get associated with the first execution request
         sys.stdout.flush()

--- a/ipykernel/kernelapp.py
+++ b/ipykernel/kernelapp.py
@@ -580,14 +580,14 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp,
             # kernel on a separate thread
             if self.log_level < logging.CRITICAL:
                 self.log.error("Unable to initialize signal:", exc_info=True)
-        self.init_kernel()
+        self.init_kernel(shell=shell)
         # shell init steps
         self.init_path()
         self.init_shell()
-        if self.shell:
-            self.init_gui_pylab()
-            self.init_extensions()
-            self.init_code()
+        #if self.shell:
+        #    self.init_gui_pylab()
+        #    self.init_extensions()
+        #    self.init_code()
         # flush stdout/stderr, so that anything written to these streams during
         # initialization do not get associated with the first execution request
         sys.stdout.flush()

--- a/ipykernel/kernelapp.py
+++ b/ipykernel/kernelapp.py
@@ -587,10 +587,10 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp,
         # shell init steps
         self.init_path()
         self.init_shell()
-        #if self.shell:
-        #    self.init_gui_pylab()
-        #    self.init_extensions()
-        #    self.init_code()
+        if self.shell and not shell:
+            self.init_gui_pylab()
+            self.init_extensions()
+            self.init_code()
         # flush stdout/stderr, so that anything written to these streams during
         # initialization do not get associated with the first execution request
         sys.stdout.flush()

--- a/ipykernel/kernelapp.py
+++ b/ipykernel/kernelapp.py
@@ -382,9 +382,9 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp,
             e_stdout = None if self.quiet else sys.__stdout__
             e_stderr = None if self.quiet else sys.__stderr__
 
-            # sys.stdout = outstream_factory(self.session, self.iopub_thread,
-            #                               u'stdout',
-            #                               echo=e_stdout)
+            sys.stdout = outstream_factory(
+                self.session, self.iopub_thread, u"stdout", echo=e_stdout
+            )
             if sys.stderr is not None:
                 sys.stderr.flush()
             sys.stderr = outstream_factory(

--- a/ipykernel/kernelapp.py
+++ b/ipykernel/kernelapp.py
@@ -442,16 +442,18 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp,
 
         kernel_factory = self.kernel_class.instance
 
-        kernel = kernel_factory(parent=self, session=self.session,
-                                control_stream=control_stream,
-                                shell_streams=[shell_stream, control_stream],
-                                iopub_thread=self.iopub_thread,
-                                iopub_socket=self.iopub_socket,
-                                stdin_socket=self.stdin_socket,
-                                log=self.log,
-                                profile_dir=self.profile_dir,
-                                #user_ns=self.user_ns,
-                                shell=shell
+        kernel = kernel_factory(
+            parent=self,
+            session=self.session,
+            control_stream=control_stream,
+            shell_streams=[shell_stream, control_stream],
+            iopub_thread=self.iopub_thread,
+            iopub_socket=self.iopub_socket,
+            stdin_socket=self.stdin_socket,
+            log=self.log,
+            profile_dir=self.profile_dir,
+            user_ns=self.user_ns,
+            shell=shell,
         )
         kernel.record_ports({
             name + '_port': port for name, port in self.ports.items()

--- a/ipykernel/kernelapp.py
+++ b/ipykernel/kernelapp.py
@@ -434,7 +434,7 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp,
     def init_signal(self):
         signal.signal(signal.SIGINT, signal.SIG_IGN)
 
-    def init_kernel(self):
+    def init_kernel(self, shell=None):
         """Create the Kernel object itself"""
         shell_stream = ZMQStream(self.shell_socket)
         control_stream = ZMQStream(self.control_socket)
@@ -449,7 +449,8 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp,
                                 stdin_socket=self.stdin_socket,
                                 log=self.log,
                                 profile_dir=self.profile_dir,
-                                user_ns=self.user_ns,
+                                #user_ns=self.user_ns,
+                                shell=shell
         )
         kernel.record_ports({
             name + '_port': port for name, port in self.ports.items()
@@ -554,7 +555,7 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp,
             pdb.set_trace = debugger.set_trace
 
     @catch_config_error
-    def initialize(self, argv=None):
+    def initialize(self, argv=None, shell=None):
         self._init_asyncio_patch()
         super(IPKernelApp, self).initialize(argv)
         if self.subapp is not None:

--- a/ipykernel/kernelapp.py
+++ b/ipykernel/kernelapp.py
@@ -382,14 +382,15 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp,
             e_stdout = None if self.quiet else sys.__stdout__
             e_stderr = None if self.quiet else sys.__stderr__
 
-            sys.stdout = outstream_factory(self.session, self.iopub_thread,
-                                           u'stdout',
-                                           echo=e_stdout)
+            # sys.stdout = outstream_factory(self.session, self.iopub_thread,
+            #                               u'stdout',
+            #                               echo=e_stdout)
             if sys.stderr is not None:
                 sys.stderr.flush()
-            sys.stderr = outstream_factory(self.session, self.iopub_thread,
-                                           u'stderr',
-                                           echo=e_stderr)
+            sys.stderr = outstream_factory(
+                self.session, self.iopub_thread, u"stderr", echo=e_stderr
+            )
+
         if self.displayhook_class:
             displayhook_factory = import_item(str(self.displayhook_class))
             self.displayhook = displayhook_factory(self.session, self.iopub_socket)

--- a/ipykernel/kernelapp.py
+++ b/ipykernel/kernelapp.py
@@ -382,9 +382,9 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp,
             e_stdout = None if self.quiet else sys.__stdout__
             e_stderr = None if self.quiet else sys.__stderr__
 
-            # sys.stdout = outstream_factory(self.session, self.iopub_thread,
-            #                               u'stdout',
-            #                               echo=e_stdout)
+            sys.stdout = outstream_factory(
+                self.session, self.iopub_thread, u"stdout", echo=e_stdout
+            )
             if sys.stderr is not None:
                 sys.stderr.flush()
             sys.stderr = outstream_factory(
@@ -442,16 +442,23 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp,
 
         kernel_factory = self.kernel_class.instance
 
-        kernel = kernel_factory(parent=self, session=self.session,
-                                control_stream=control_stream,
-                                shell_streams=[shell_stream, control_stream],
-                                iopub_thread=self.iopub_thread,
-                                iopub_socket=self.iopub_socket,
-                                stdin_socket=self.stdin_socket,
-                                log=self.log,
-                                profile_dir=self.profile_dir,
-                                #user_ns=self.user_ns,
-                                shell=shell
+        if shell is not None:
+            user_ns = self.user_ns
+        else:
+            user_ns = None
+
+        kernel = kernel_factory(
+            parent=self,
+            session=self.session,
+            control_stream=control_stream,
+            shell_streams=[shell_stream, control_stream],
+            iopub_thread=self.iopub_thread,
+            iopub_socket=self.iopub_socket,
+            stdin_socket=self.stdin_socket,
+            log=self.log,ü
+            profile_dir=self.profile_dir,
+            user_ns=user_ns,
+            shell=shell,
         )
         kernel.record_ports({
             name + '_port': port for name, port in self.ports.items()
@@ -585,10 +592,10 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp,
         # shell init steps
         self.init_path()
         self.init_shell()
-        #if self.shell:
-        #    self.init_gui_pylab()
-        #    self.init_extensions()
-        #    self.init_code()
+        if self.shell:
+            self.init_gui_pylab()
+            self.init_extensions()
+            self.init_code()
         # flush stdout/stderr, so that anything written to these streams during
         # initialization do not get associated with the first execution request
         sys.stdout.flush()

--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -395,6 +395,7 @@ class Kernel(SingletonConfigurable):
     def schedule_dispatch(self, priority, dispatch, *args):
         """schedule a message for dispatch"""
         idx = next(self._message_counter)
+        print('ho got message scheduled', now(), dispatch)
 
         self.msg_queue.put_nowait(
             (
@@ -423,7 +424,7 @@ class Kernel(SingletonConfigurable):
                 ),
                 copy=False,
             )
-
+        print('will register dispathc shell')
         for s in self.shell_streams:
             if s is self.control_stream:
                 continue

--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -395,7 +395,6 @@ class Kernel(SingletonConfigurable):
     def schedule_dispatch(self, priority, dispatch, *args):
         """schedule a message for dispatch"""
         idx = next(self._message_counter)
-        print('ho got message scheduled', now(), dispatch)
 
         self.msg_queue.put_nowait(
             (
@@ -424,7 +423,6 @@ class Kernel(SingletonConfigurable):
                 ),
                 copy=False,
             )
-        print('will register dispathc shell')
         for s in self.shell_streams:
             if s is self.control_stream:
                 continue


### PR DESCRIPTION
This allow some modification to create an IPykernel from an existing shell, and is a first draft step toward turning a running ipython CLI into an IPykernel, with the righ infrastructure this woudl allow a notebook to connect to an existing IPython session. 