### PR TITLE
Travis-ci: added support for ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,5 +62,9 @@ matrix:
     - python: 3.8
       env:
         - IPYTHON=master
+    - python: 3.8
+      env:
+        - IPYTHON=master
+      arch: ppc64le
   allow_failures:
     - python: "nightly"


### PR DESCRIPTION
Hi,
I have added support for ppc64le build on travis-ci in the branch . The travis-ci build log can be tracked on the link :https://travis-ci.com/github/sanjaymsh/ipykernel/builds/191034110 . I believe it is ready for the final review and merge.
Please have a look on it.

Thanks !!