### PR TITLE
Invalid syntax in ipykernel/log.py

### DIFF
--- a/ipykernel/log.py
+++ b/ipykernel/log.py
@@ -4,7 +4,7 @@ from zmq.log.handlers import PUBHandler
 
 import warnings
 warnings.warn("ipykernel.log is deprecated. It has moved to ipyparallel.engine.log",
-    DeprecationWarning
+    DeprecationWarning,
     stacklevel=2
 )
 


### PR DESCRIPTION
The `DeprecationWarning` in this file is missing a comma, so the file can't be loaded. Not used in the normal configuration (since it's deprecated, but while the file is present it should probably be importable).

Found while packaging for Debian since all files get byte-compiled on install, which picked this up.