### PR TITLE
Deacrease lag time for eventloop

### DIFF
--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -318,7 +318,7 @@ class Kernel(SingletonConfigurable):
             # flush the eventloop every so often,
             # giving us a chance to handle messages in the meantime
             self.log.debug("Scheduling eventloop advance")
-            self.io_loop.call_later(1, advance_eventloop)
+            self.io_loop.call_later(0.001, advance_eventloop)
 
         # begin polling the eventloop
         schedule_next()


### PR DESCRIPTION
While using interactive matplotlib figure, the figure will freeze for 1 seconds very often. This get rid of this freeze.