### PR TITLE
Running next input as a part of the Shell protocol

### DIFF
--- a/ipykernel/zmqshell.py
+++ b/ipykernel/zmqshell.py
@@ -573,6 +573,16 @@ class ZMQInteractiveShell(InteractiveShell):
         )
         self.payload_manager.write_payload(payload)
 
+    def run_next_input(self, text, replace=False):
+        """Send the specified text to the frontend to be presented
+        and run at the next input cell."""
+        payload = dict(
+            source='run_next_input',
+            text=text,
+            replace=replace,
+        )
+        self.payload_manager.write_payload(payload)
+
     def set_parent(self, parent):
         """Set the parent header for associating output with its triggering input"""
         self.parent_header = parent


### PR DESCRIPTION
This is an attempt to fix this long running issue. Namely that there is no way to create cells programmatically. If there's a way to set the next input, I think it stands to reason there should be a way to run it.  Quite a people on StackOverflow have asked this question too.

https://github.com/ipython/ipython/issues/4983

This adds a new event type called `run_next_input` as an alternative to `set_next_input`.

I have also made a corresponding PR on the Jupyter notebook repository to handle this.

I am also looking into how I can add `run_next_input` to the base interactive shell class.

---

Thanks for looking at this. I appreciate I might not be going down the correct channels for this kind of change, but I'd love to know your thoughts.