### PR TITLE
Run control channel in separate thread

### DIFF
--- a/ipykernel/_version.py
+++ b/ipykernel/_version.py
@@ -1,4 +1,4 @@
-version_info = (5, 6, 0, 'dev0')
+version_info = (6, 0, 0, 'dev0')
 __version__ = '.'.join(map(str, version_info[:3]))
 
 # pep440 is annoying, beta/alpha/rc should _not_ have dots or pip/setuptools

--- a/ipykernel/control.py
+++ b/ipykernel/control.py
@@ -1,4 +1,3 @@
-
 from threading import Thread
 import zmq
 if zmq.pyzmq_version_info() >= (17, 0):

--- a/ipykernel/control.py
+++ b/ipykernel/control.py
@@ -1,0 +1,21 @@
+
+from threading import Thread
+import zmq
+if zmq.pyzmq_version_info() >= (17, 0):
+    from tornado.ioloop import IOLoop
+else:
+    # deprecated since pyzmq 17
+    from zmq.eventloop.ioloop import IOLoop
+
+
+class ControlThread(Thread):
+
+    def __init__(self, context):
+        Thread.__init__(self)
+        self.context = context
+        self.io_loop = IOLoop(make_current=False)
+
+    def run(self): 
+        self.io_loop.make_current()
+        self.io_loop.start()
+        self.io_loop.close(all_fds=True)

--- a/ipykernel/control.py
+++ b/ipykernel/control.py
@@ -10,9 +10,8 @@ else:
 
 class ControlThread(Thread):
 
-    def __init__(self, context):
-        Thread.__init__(self)
-        self.context = context
+    def __init__(self, **kwargs):
+        Thread.__init__(self, **kwargs)
         self.io_loop = IOLoop(make_current=False)
 
     def run(self): 

--- a/ipykernel/inprocess/client.py
+++ b/ipykernel/inprocess/client.py
@@ -12,7 +12,6 @@
 #-----------------------------------------------------------------------------
 
 # IPython imports
-from ipykernel.inprocess.socket import DummySocket
 from traitlets import Type, Instance, default
 from jupyter_client.clientabc import KernelClientABC
 from jupyter_client.client import KernelClient
@@ -171,10 +170,10 @@ class InProcessKernelClient(KernelClient):
         if kernel is None:
             raise RuntimeError('Cannot send request. No kernel exists.')
 
-        stream = DummySocket()
+        stream = kernel.shell_stream
         self.session.send(stream, msg)
         msg_parts = stream.recv_multipart()
-        kernel.dispatch_shell(stream, msg_parts)
+        kernel.dispatch_shell(msg_parts)
 
         idents, reply_msg = self.session.recv(stream, copy=False)
         self.shell_channel.call_handlers_later(reply_msg)

--- a/ipykernel/inprocess/ipkernel.py
+++ b/ipykernel/inprocess/ipkernel.py
@@ -49,10 +49,10 @@ class InProcessKernel(IPythonKernel):
     #-------------------------------------------------------------------------
 
     shell_class = Type(allow_none=True)
-    shell_streams = List()
-    control_stream = Any()
     _underlying_iopub_socket = Instance(DummySocket, ())
     iopub_thread = Instance(IOPubThread)
+
+    shell_stream = Instance(DummySocket, ())
 
     @default('iopub_thread')
     def _default_iopub_thread(self):

--- a/ipykernel/ipkernel.py
+++ b/ipykernel/ipkernel.py
@@ -145,11 +145,11 @@ class IPythonKernel(KernelBase):
         self.shell.exit_now = False
         super(IPythonKernel, self).start()
 
-    def set_parent(self, ident, parent):
+    def set_parent(self, ident, parent, channel='shell'):
         """Overridden from parent to tell the display hook and output streams
         about the parent message.
         """
-        super(IPythonKernel, self).set_parent(ident, parent)
+        super(IPythonKernel, self).set_parent(ident, parent, channel)
         self.shell.set_parent(parent)
 
     def init_metadata(self, parent):
@@ -509,7 +509,7 @@ class IPythonKernel(KernelBase):
             reply_content['engine_info'] = e_info
 
             self.send_response(self.iopub_socket, 'error', reply_content,
-                               ident=self._topic('error'))
+                               ident=self._topic('error'), channel='shell')
             self.log.info("Exception in apply request:\n%s", '\n'.join(reply_content['traceback']))
             result_buf = []
             reply_content['status'] = 'error'

--- a/ipykernel/kernelapp.py
+++ b/ipykernel/kernelapp.py
@@ -300,7 +300,7 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp,
             # see ipython/ipykernel#270 and zeromq/libzmq#2892
             self.control_socket.router_handover = 1
 
-        self.control_thread = ControlThread(self.control_socket)
+        self.control_thread = ControlThread(daemon=True)
         self.control_thread.start()
 
     def init_iopub(self, context):

--- a/ipykernel/kernelapp.py
+++ b/ipykernel/kernelapp.py
@@ -289,6 +289,7 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp,
         self.init_iopub(context)
 
     def init_control(self, context):
+        self.log.debug('IN INIT_CONTROL')
         self.control_socket = context.socket(zmq.ROUTER)
         self.control_socket.linger = 1000
         self.control_port = self._bind_socket(self.control_socket, self.control_port)
@@ -301,7 +302,6 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp,
             self.control_socket.router_handover = 1
 
         self.control_thread = ControlThread(daemon=True)
-        self.control_thread.start()
 
     def init_iopub(self, context):
         self.iopub_socket = context.socket(zmq.PUB)
@@ -448,9 +448,10 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp,
 
     def init_kernel(self):
         """Create the Kernel object itself"""
+        self.log.debug('IN INIT_KERNEL')
         shell_stream = ZMQStream(self.shell_socket)
         control_stream = ZMQStream(self.control_socket, self.control_thread.io_loop)
-
+        self.control_thread.start()
         kernel_factory = self.kernel_class.instance
 
         kernel = kernel_factory(parent=self, session=self.session,
@@ -569,6 +570,7 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp,
     def initialize(self, argv=None):
         self._init_asyncio_patch()
         super(IPKernelApp, self).initialize(argv)
+        self.log.debug('IN INITIALIZE')
         if self.subapp is not None:
             return
 
@@ -605,6 +607,7 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp,
         sys.stderr.flush()
 
     def start(self):
+        self.log.debug('IN START')
         if self.subapp is not None:
             return self.subapp.start()
         if self.poller is not None:

--- a/ipykernel/kernelapp.py
+++ b/ipykernel/kernelapp.py
@@ -289,7 +289,6 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp,
         self.init_iopub(context)
 
     def init_control(self, context):
-        self.log.debug('IN INIT_CONTROL')
         self.control_socket = context.socket(zmq.ROUTER)
         self.control_socket.linger = 1000
         self.control_port = self._bind_socket(self.control_socket, self.control_port)
@@ -448,7 +447,6 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp,
 
     def init_kernel(self):
         """Create the Kernel object itself"""
-        self.log.debug('IN INIT_KERNEL')
         shell_stream = ZMQStream(self.shell_socket)
         control_stream = ZMQStream(self.control_socket, self.control_thread.io_loop)
         self.control_thread.start()
@@ -570,7 +568,6 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp,
     def initialize(self, argv=None):
         self._init_asyncio_patch()
         super(IPKernelApp, self).initialize(argv)
-        self.log.debug('IN INITIALIZE')
         if self.subapp is not None:
             return
 
@@ -607,7 +604,6 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp,
         sys.stderr.flush()
 
     def start(self):
-        self.log.debug('IN START')
         if self.subapp is not None:
             return self.subapp.start()
         if self.poller is not None:

--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -11,6 +11,7 @@ from signal import signal, default_int_handler, SIGINT
 import sys
 import time
 import uuid
+import warnings
 
 try:
     # jupyter_client >= 5, use tz-aware now
@@ -58,6 +59,15 @@ class Kernel(SingletonConfigurable):
     session = Instance(Session, allow_none=True)
     profile_dir = Instance('IPython.core.profiledir.ProfileDir', allow_none=True)
     shell_stream = Instance(ZMQStream, allow_none=True)
+
+    @property
+    def shell_streams(self):
+        warnings.warn(
+            'Property shell_streams is deprecated in favor of shell_stream',
+            DeprecationWarning
+        )
+        return [shell_stream]
+
     control_stream = Instance(ZMQStream, allow_none=True)
     iopub_socket = Any()
     iopub_thread = Any()

--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -405,13 +405,7 @@ class Kernel(SingletonConfigurable):
         self.msg_queue = Queue()
         self.io_loop.add_callback(self.dispatch_queue)
 
-        self.control_stream.on_recv(
-            partial(
-                self.schedule_dispatch,
-                self.dispatch_control,
-            ),
-            copy=False,
-        )
+        self.control_stream.on_recv(self.dispatch_control, copy=False)
 
         self.shell_stream.on_recv(
             partial(

--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -366,12 +366,7 @@ class Kernel(SingletonConfigurable):
         Ensures that only one message is processing at a time,
         even when the handler is async
         """
-
         while True:
-            # ensure control stream is flushed before processing shell messages
-            if self.control_stream:
-                self.control_stream.flush()
-            # receive the next message and handle it
             try:
                 yield self.process_one()
             except Exception:
@@ -666,9 +661,6 @@ class Kernel(SingletonConfigurable):
         )
 
         self._at_shutdown()
-
-        # Flush to ensure reply is sent before stopping loop
-        self.control_stream.flush(zmq.POLLOUT)
 
         self.log.debug('Stopping control ioloop')
         control_io_loop = self.control_stream.io_loop


### PR DESCRIPTION
This makes the control channel run in a separate thread from the shell channel, so that control messages can be processed concurrently to shell requests.

 - this is now the recomended approach in the [Jupyter protocol](https://jupyter-client.readthedocs.io/en/stable/messaging.html#introduction).
 
    >  *For a smoother user experience, we recommend running the control channel in a separate thread from the shell channel, so that e.g. shutdown or debug messages can be processed immediately without waiting for a long-running shell message to be finished processing (such 
as an expensive execute request).*

 - this is required for ipykernel to support the Jupyter Debug Protocol in ipykernel: we need to be able to remove and add breakpoints while code is running (or even more importantly, process messages such as "continue", "step into", which are by nature to be called during execution.

Fixes #447