### PR TITLE
Issue #12786: Create hook for dispatching GUI messages asynchronously 

### DIFF
--- a/ipykernel/inprocess/client.py
+++ b/ipykernel/inprocess/client.py
@@ -173,10 +173,8 @@ class InProcessKernelClient(KernelClient):
             raise RuntimeError('Cannot send request. No kernel exists.')
 
         stream = kernel.shell_stream
-        self.session.send(stream, msg)
-        msg_parts = stream.recv_multipart()
         loop = asyncio.get_event_loop()
-        loop.run_until_complete(kernel.dispatch_shell(msg_parts))
+        loop.run_until_complete(kernel.dispatch_shell(msg))
         idents, reply_msg = self.session.recv(stream, copy=False)
         self.shell_channel.call_handlers_later(reply_msg)
 

--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -302,18 +302,14 @@ class Kernel(SingletonConfigurable):
             return False
         return True
 
-    async def dispatch_shell(self, msg):
+    async def dispatch_shell(self, msg, idents=None):
         """dispatch shell requests"""
 
         # flush control queue before handling shell requests
         await self._flush_control_queue()
 
-        idents, msg = self.session.feed_identities(msg, copy=False)
-        try:
-            msg = self.session.deserialize(msg, content=True, copy=False)
-        except Exception:
-            self.log.error("Invalid Message", exc_info=True)
-            return
+        if idents is None:
+            idents = []
 
         # Set the parent message for side effects.
         self.set_parent(idents, msg, channel='shell')
@@ -467,15 +463,38 @@ class Kernel(SingletonConfigurable):
     def _message_counter_default(self):
         return itertools.count()
 
-    def schedule_dispatch(self, dispatch, *args):
+    def should_dispatch_immediately(self, msg):
+        """
+        This provides a hook for dispatching incoming messages
+        from the frontend immediately, and out of order.
+
+        It could be used to allow asynchronous messages from
+        GUIs to be processed.
+        """
+        return False
+
+    def schedule_dispatch(self, msg, dispatch):
         """schedule a message for dispatch"""
+
+        idents, msg = self.session.feed_identities(msg, copy=False)
+        try:
+            msg = self.session.deserialize(msg, content=True, copy=False)
+        except:
+            self.log.error("Invalid shell message", exc_info=True)
+            return
+
+        new_args = (msg, idents)
+
+        if self.should_dispatch_immediately(msg):
+            return self.io_loop.add_callback(dispatch, *new_args)
+
         idx = next(self._message_counter)
 
         self.msg_queue.put_nowait(
             (
                 idx,
                 dispatch,
-                args,
+                new_args,
             )
         )
         # ensure the eventloop wakes up
@@ -499,7 +518,7 @@ class Kernel(SingletonConfigurable):
         self.shell_stream.on_recv(
             partial(
                 self.schedule_dispatch,
-                self.dispatch_shell,
+                dispatch=self.dispatch_shell,
             ),
             copy=False,
         )


### PR DESCRIPTION
This fixes this issue I raised: https://github.com/ipython/ipython/issues/12786

And allows you to use async and await on GUI events. Like `await button.click()`

![image](https://gist.githubusercontent.com/sonthonaxrk/01a0428bd318e477686d21a8b3135534/raw/7dcd0601bab46f291821023bbe3c69fdc4477407/asnyc_widget.gif)


-----

It's just experimental so far. But I haven't found any major issues yet. The only possible problem is where the output from Comm messages gets posted to. If you have a Comm.on_msg callback, that has a print statement, it will probably print to the last modified cell, and not the Cell which the comm was created in.

I don't think this will introduce any regressions.

I've split this into two commits, one introduces the hook. The other implements it. I'd personally be happy merging fist the first commit as it makes doing this in a subclass easier.

This changes the method signatures of the dispatch_shell and dispatch_control method. I hope that's okay.