### PR TITLE
Add configure_inline_support and call it in the shell

### DIFF
--- a/ipykernel/zmqshell.py
+++ b/ipykernel/zmqshell.py
@@ -597,6 +597,15 @@ class ZMQInteractiveShell(InteractiveShell):
         self.register_magics(KernelMagics)
         self.magics_manager.register_alias('ed', 'edit')
 
+    def enable_matplotlib(self, gui=None):
+        gui, backend = super(ZMQInteractiveShell, self).enable_matplotlib(gui)
+
+        from ipykernel.pylab.backend_inline import configure_inline_support
+
+        configure_inline_support(self, backend)
+
+        return gui, backend
+
     def init_virtualenv(self):
         # Overridden not to do virtualenv detection, because it's probably
         # not appropriate in a kernel. To use a kernel in a virtualenv, install


### PR DESCRIPTION
This removes a circular dependency between ipykernel and IPython. See https://github.com/ipython/ipython/pull/12814