### PR TITLE
Clean up release process and add tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,11 @@ jobs:
       timeout-minutes: 30
       run: |
         pytest ipykernel -vv -s --cov ipykernel --cov-branch --cov-report term-missing:skip-covered --durations 10
+    - name: Build and check the dist files
+      run: |
+        pip install build twine
+        python -m build .
+        twine check dist/*
     - name: Coverage
       run: |
         codecov

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -11,8 +11,8 @@ git tag $version; true;
 git push --all
 git push --tags
 rm -rf dist build
-python setup.py sdist
-python setup.py bdist_wheel
+pip install build twine
+python -m build .
 pip install twine
 twine check dist/* 
 twine upload dist/*

--- a/ipykernel/_version.py
+++ b/ipykernel/_version.py
@@ -1,4 +1,4 @@
-version_info = (5, 5, 0)
+version_info = (5, 6, 0, 'dev0')
 __version__ = '.'.join(map(str, version_info[:3]))
 
 # pep440 is annoying, beta/alpha/rc should _not_ have dots or pip/setuptools

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,5 @@
 [build-system]
+build-backend = "setuptools.build_meta"
 requires=[
   "setuptools",
   "wheel",

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,9 @@ if not loose_pep440re.match(current_version):
     raise ValueError("Version number '%s' is not valid (should match [N!]N(.N)*[{a|b|rc}N][.postN][.devN])" % current_version)
 
 
+with open(pjoin(here, 'README.md')) as fid:
+    LONG_DESCRIPTION = fid.read()
+
 setup_args = dict(
     name=name,
     version=current_version,
@@ -76,11 +79,12 @@ setup_args = dict(
     py_modules=['ipykernel_launcher'],
     package_data=package_data,
     description="IPython Kernel for Jupyter",
+    long_description_content_type="text/markdown",
     author='IPython Development Team',
     author_email='ipython-dev@scipy.org',
     url='https://ipython.org',
     license='BSD',
-    long_description="The IPython kernel for Jupyter",
+    long_description=LONG_DESCRIPTION,
     platforms="Linux, Mac OS X, Windows",
     keywords=['Interactive', 'Interpreter', 'Shell', 'Web'],
     python_requires='>=3.5',
@@ -112,6 +116,7 @@ setup_args = dict(
 
 
 if any(a.startswith(('bdist', 'install')) for a in sys.argv):
+    sys.path.insert(0, here)
     from ipykernel.kernelspec import write_kernel_spec, make_ipkernel_cmd, KERNEL_NAME
 
     # When building a wheel, the executable specified in the kernelspec is simply 'python'.


### PR DESCRIPTION
- Use PEP517 compliant build tool
- Add CI tests for the release process
- Clean up `setup.py`
- Back to `dev` version