### PR TITLE
Some removal of ipython_genutils.py3compat.

### DIFF
--- a/ipykernel/connect.py
+++ b/ipykernel/connect.py
@@ -11,7 +11,6 @@ import warnings
 from IPython.core.profiledir import ProfileDir
 from IPython.paths import get_ipython_dir
 from ipython_genutils.path import filefind
-from ipython_genutils.py3compat import str_to_bytes
 
 import jupyter_client
 from jupyter_client import write_connection_file
@@ -131,7 +130,7 @@ def get_connection_info(connection_file=None, unpack=False, profile=None):
     if unpack:
         info = json.loads(info)
         # ensure key is bytes:
-        info['key'] = str_to_bytes(info.get('key', ''))
+        info["key"] = info.get("key", "").encode()
     return info
 
 

--- a/ipykernel/iostream.py
+++ b/ipykernel/iostream.py
@@ -24,7 +24,6 @@ from zmq.eventloop.zmqstream import ZMQStream
 
 from jupyter_client.session import extract_header
 
-from ipython_genutils import py3compat
 
 #-----------------------------------------------------------------------------
 # Globals
@@ -288,8 +287,12 @@ class OutStream(TextIOBase):
 
     def __init__(self, session, pub_thread, name, pipe=None, echo=None):
         if pipe is not None:
-            warnings.warn("pipe argument to OutStream is deprecated and ignored",
-                DeprecationWarning)
+            warnings.warn(
+                "pipe argument to OutStream is deprecated and ignored",
+                " since ipykernel 4.2.3.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         # This is necessary for compatibility with Python built-in streams
         self.session = session
         if not isinstance(pub_thread, IOPubThread):
@@ -300,7 +303,7 @@ class OutStream(TextIOBase):
             pub_thread.start()
         self.pub_thread = pub_thread
         self.name = name
-        self.topic = b'stream.' + py3compat.cast_bytes(name)
+        self.topic = b"stream." + name.encode()
         self.parent_header = {}
         self._master_pid = os.getpid()
         self._flush_pending = False

--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -29,7 +29,6 @@ from zmq.eventloop.zmqstream import ZMQStream
 
 from traitlets.config.configurable import SingletonConfigurable
 from IPython.core.error import StdinNotImplementedError
-from ipython_genutils import py3compat
 from ipykernel.jsonutil import json_clean
 from traitlets import (
     Any, Instance, Float, Dict, List, Set, Integer, Unicode, Bool,
@@ -824,7 +823,7 @@ class Kernel(SingletonConfigurable):
         """prefixed topic for IOPub messages"""
         base = "kernel.%s" % self.ident
 
-        return py3compat.cast_bytes("%s.%s" % (base, topic))
+        return ("%s.%s" % (base, topic)).encode()
 
     _aborting = Bool(False)
 
@@ -939,8 +938,8 @@ class Kernel(SingletonConfigurable):
                 self.log.warning("Invalid Message:", exc_info=True)
         
         try:
-            value = py3compat.unicode_to_str(reply['content']['value'])
-        except:
+            value = reply["content"]["value"]
+        except Exception:
             self.log.error("Bad input_reply: %s", parent)
             value = ''
         if value == '\x04':

--- a/ipykernel/tests/test_jsonutil.py
+++ b/ipykernel/tests/test_jsonutil.py
@@ -13,7 +13,6 @@ import nose.tools as nt
 
 from .. import jsonutil
 from ..jsonutil import json_clean, encode_images
-from ipython_genutils.py3compat import unicode_to_str
 
 class MyInt(object):
     def __int__(self):
@@ -80,14 +79,8 @@ def test_encode_images():
     encoded2 = json_clean(encode_images(encoded))
     assert encoded == encoded2
     
-    # test that we don't double-encode base64 str
-    b64_str = {}
-    for key, encoded in encoded.items():
-        b64_str[key] = unicode_to_str(encoded)
-    encoded3 = json_clean(encode_images(b64_str))
-    assert encoded3 == b64_str
     for key, value in fmt.items():
-        decoded = a2b_base64(encoded3[key])
+        decoded = a2b_base64(encoded[key])
         assert decoded == value
 
 def test_lambda():


### PR DESCRIPTION
As in some of the other Jupyter Repositories; this start to remove
ipython_genutils because of packaging problem in linux distribution
(getting rid of nose).

This is a step toward that.

Note that this changes is slightly stricter in some area where function
would previously accept string/bytes and now only accept one; but as far
as I can tell are generally only used with one of those since we are
Python 3 only.