### PR TITLE
Replace import item from ipython_genutils to traitlets.

### DIFF
--- a/ipykernel/comm/manager.py
+++ b/ipykernel/comm/manager.py
@@ -8,7 +8,7 @@ import logging
 
 from traitlets.config import LoggingConfigurable
 
-from ipython_genutils.importstring import import_item
+from traitlets.utils.importstring import import_item
 from traitlets import Instance, Unicode, Dict, Any, default
 
 from .comm import Comm

--- a/ipykernel/kernelapp.py
+++ b/ipykernel/kernelapp.py
@@ -29,7 +29,7 @@ from ipython_genutils.path import filefind, ensure_dir_exists
 from traitlets import (
     Any, Instance, Dict, Unicode, Integer, Bool, DottedObjectName, Type, default
 )
-from ipython_genutils.importstring import import_item
+from traitlets.utils.importstring import import_item
 from jupyter_core.paths import jupyter_runtime_dir
 from jupyter_client import write_connection_file
 from jupyter_client.connect import ConnectionFileMixin

--- a/ipykernel/pickleutil.py
+++ b/ipykernel/pickleutil.py
@@ -14,7 +14,7 @@ import sys
 import pickle
 from types import FunctionType
 
-from ipython_genutils.importstring import import_item
+from traitlets.utils.importstring import import_item
 from ipython_genutils.py3compat import buffer_to_bytes
 
 # This registers a hook when it's imported


### PR DESCRIPTION
This is to start removing ipython_genutils dependency,
the functionality is identical except this one checks its parameter is a
str.