### PR TITLE
Flush control stream upon shutdown

### DIFF
--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -937,4 +937,4 @@ class Kernel(SingletonConfigurable):
         if self._shutdown_message is not None:
             self.session.send(self.iopub_socket, self._shutdown_message, ident=self._topic('shutdown'))
             self.log.debug("%s", self._shutdown_message)
-        self.shell_stream.flush(zmq.POLLOUT)
+        self.control_stream.flush(zmq.POLLOUT)


### PR DESCRIPTION
The control stream was not properly flushed before shutting down the ZMQ context.

This fixes CI in `jupyter_client` with the pre-release.