### PR TITLE
bump Python to 3.8 in readthedocs.yml

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,4 +1,4 @@
 python:
-  version: 3.5
+  version: 3.8
   pip_install: true
 requirements_file: docs/requirements.txt


### PR DESCRIPTION
3.5 is EOL and docs builds have been failing.