### PR TITLE
Specify ipykernel in kernelspec

### DIFF
--- a/ipykernel/kernelspec.py
+++ b/ipykernel/kernelspec.py
@@ -53,7 +53,7 @@ def get_kernel_dict(extra_arguments=None):
     """Construct dict for kernel.json"""
     return {
         'argv': make_ipkernel_cmd(extra_arguments=extra_arguments),
-        'display_name': 'Python %i' % sys.version_info[0],
+        'display_name': 'Python %i (ipykernel)' % sys.version_info[0],
         'language': 'python',
         'metadata': { 'debugger': True}
     }

--- a/ipykernel/tests/test_kernelspec.py
+++ b/ipykernel/tests/test_kernelspec.py
@@ -41,7 +41,7 @@ def test_make_ipkernel_cmd():
 
 def assert_kernel_dict(d):
     assert d['argv'] == make_ipkernel_cmd()
-    assert d['display_name'] == 'Python %i' % sys.version_info[0]
+    assert d['display_name'] == 'Python %i (ipykernel)' % sys.version_info[0]
     assert d['language'] == 'python'
 
 
@@ -53,7 +53,7 @@ def test_get_kernel_dict():
 def assert_kernel_dict_with_profile(d):
     nt.assert_equal(d['argv'], make_ipkernel_cmd(
         extra_arguments=["--profile", "test"]))
-    assert d['display_name'] == 'Python %i' % sys.version_info[0]
+    assert d['display_name'] == 'Python %i (ipykernel)' % sys.version_info[0]
     assert d['language'] == 'python'
 
 


### PR DESCRIPTION
I think that it makes sense to specify (ipykernel) in the kernelspec to differentiate from xeus-python, or other potential python kernels (such as Slicer).

Eventually I would also like to use the proper Python logo for xeus-python.

![Screenshot from 2021-03-25 16-24-25](https://user-images.githubusercontent.com/2397974/112498416-cd093980-8d86-11eb-91e8-d6bc98c39145.png)

