### PR TITLE
Changed default timeout to 0.0 seconds for stop_on_error_timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changes in IPython kernel
 
+* Set `stop_on_error_timeout` default to 0.0 matching pre 5.5.0 default behavior with correctly working flag from 5.5.0.
+
 ## 5.5
 
 ### 5.5.0

--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -120,7 +120,7 @@ class Kernel(SingletonConfigurable):
     _poll_interval = Float(0.01).tag(config=True)
 
     stop_on_error_timeout = Float(
-        0.1,
+        0.0,
         config=True,
         help="""time (in seconds) to wait for messages to arrive
         when aborting queued requests after an error.


### PR DESCRIPTION
Resolves https://github.com/ipython/ipykernel/issues/609

Tested on classic, lab, papermill, testbook, and nteract. The behavior matches 5.4 kernel behavior by default now, with the ability for each interface to set the default abort time if they wish. Testing this with a higher value override worked as expected with requests aborting within the given window of time, though none of the interfaces showed that an abort occurred, they simple show no result. Also `stop_on_error: false` works to ignore the setting (nteract has this on by default for some reason).

@glentakahashi I implemented the suggested change, but when testing if you short circuit the abort future, the run-all in classic and lab will no properly abort already queued cells that were sent with `Run All Cells`. It does work appropriately for papermill/nbclient/testbook since those interfaces wait for each cell completion to send the next cell to execute. Unlike the headless libraries, the browser notebook interfaces will send all the cells at once (in back-to-back `execute_request`s) when told to `Run All`, relying on the kernel queue to handle execution. If the abort isn't fired with an immediate delay the queue will not be dropped.

The reason for headed interfaces to do this is to partially protect users from not executing those cells if they lose network connection to the server. The ideal solution would be for the notebook server to do the queuing so that A) latency between kernel and request is minimized and B) the server can control continued execution when clients disconnect rather than relying on the kernel to know caller intent. But that's beyond the scope of the change here.