### PR TITLE
Back port of pull request #618 (Changed default timeout to 0.0 seconds for stop_on_error_timeout)

### DIFF
--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -110,7 +110,7 @@ class Kernel(SingletonConfigurable):
     _poll_interval = Float(0.01).tag(config=True)
 
     stop_on_error_timeout = Float(
-        0.1,
+        0.0,
         config=True,
         help="""time (in seconds) to wait for messages to arrive
         when aborting queued requests after an error.


### PR DESCRIPTION
Followed instructions from https://github.com/ipython/ipykernel/pull/618#issuecomment-809475636 to manually backport #618