### PR TITLE
Update Trio mode for compatibility with Trio >= 0.18.0

### DIFF
--- a/ipykernel/trio_runner.py
+++ b/ipykernel/trio_runner.py
@@ -39,7 +39,7 @@ class TrioRunner:
                 exc)
 
         async def trio_main():
-            self._trio_token = trio.hazmat.current_trio_token()
+            self._trio_token = trio.lowlevel.current_trio_token()
             async with trio.open_nursery() as nursery:
                 # TODO This hack prevents the nursery from cancelling all child
                 # tasks when an uncaught exception occurs, but it's ugly.


### PR DESCRIPTION
The Trio package renamed their trio.hazmat module to trio.lowlevel.