### PR TITLE
Added 'type' field to variables returned by inspectVariables request

### DIFF
--- a/ipykernel/debugger.py
+++ b/ipykernel/debugger.py
@@ -413,6 +413,7 @@ class Debugger:
                 var_list.append({
                     'name': k,
                     'value': v,
+                    'type': str(type(v))[8:-2],
                     'variablesReference': 0
                 })
         reply = {


### PR DESCRIPTION
This fixes the issue in JupyterLab where variables of complex types define d in the notebook are not displayed in the variable panel when the debugger has started.