### PR TITLE
Use native coroutines instead of tornado coroutines

### DIFF
--- a/ipykernel/inprocess/client.py
+++ b/ipykernel/inprocess/client.py
@@ -11,6 +11,8 @@
 # Imports
 #-----------------------------------------------------------------------------
 
+import asyncio
+
 # IPython imports
 from traitlets import Type, Instance, default
 from jupyter_client.clientabc import KernelClientABC
@@ -173,8 +175,8 @@ class InProcessKernelClient(KernelClient):
         stream = kernel.shell_stream
         self.session.send(stream, msg)
         msg_parts = stream.recv_multipart()
-        kernel.dispatch_shell(msg_parts)
-
+        loop = asyncio.get_event_loop()
+        loop.run_until_complete(kernel.dispatch_shell(msg_parts))
         idents, reply_msg = self.session.recv(stream, copy=False)
         self.shell_channel.call_handlers_later(reply_msg)
 

--- a/ipykernel/inprocess/ipkernel.py
+++ b/ipykernel/inprocess/ipkernel.py
@@ -74,16 +74,16 @@ class InProcessKernel(IPythonKernel):
         self._underlying_iopub_socket.observe(self._io_dispatch, names=['message_sent'])
         self.shell.kernel = self
 
-    def execute_request(self, stream, ident, parent):
+    async def execute_request(self, stream, ident, parent):
         """ Override for temporary IO redirection. """
         with self._redirected_io():
-            super(InProcessKernel, self).execute_request(stream, ident, parent)
+            await super(InProcessKernel, self).execute_request(stream, ident, parent)
 
     def start(self):
         """ Override registration of dispatchers for streams. """
         self.shell.exit_now = False
 
-    def _abort_queues(self):
+    async def _abort_queues(self):
         """ The in-process kernel doesn't abort requests. """
         pass
 

--- a/ipykernel/ipkernel.py
+++ b/ipykernel/ipkernel.py
@@ -384,7 +384,7 @@ class IPythonKernel(KernelBase):
 
         return reply_content
 
-    async def do_complete(self, code, cursor_pos):
+    def do_complete(self, code, cursor_pos):
         if _use_experimental_60_completion and self.use_experimental_completions:
             return self._experimental_do_complete(code, cursor_pos)
 
@@ -404,7 +404,7 @@ class IPythonKernel(KernelBase):
                 'status' : 'ok'}
 
     async def do_debug_request(self, msg):
-        return self.debugger.process_request(msg)
+        return await self.debugger.process_request(msg)
 
     def _experimental_do_complete(self, code, cursor_pos):
         """
@@ -440,7 +440,7 @@ class IPythonKernel(KernelBase):
                 'metadata': {_EXPERIMENTAL_KEY_NAME: comps},
                 'status': 'ok'}
 
-    async def do_inspect(self, code, cursor_pos, detail_level=0):
+    def do_inspect(self, code, cursor_pos, detail_level=0):
         name = token_at_cursor(code, cursor_pos)
 
         reply_content = {'status' : 'ok'}
@@ -461,7 +461,7 @@ class IPythonKernel(KernelBase):
 
         return reply_content
 
-    async def do_history(self, hist_access_type, output, raw, session=0, start=0,
+    def do_history(self, hist_access_type, output, raw, session=0, start=0,
                    stop=None, n=None, pattern=None, unique=False):
         if hist_access_type == 'tail':
             hist = self.shell.history_manager.get_tail(n, raw=raw, output=output,
@@ -482,11 +482,11 @@ class IPythonKernel(KernelBase):
             'history' : list(hist),
         }
 
-    async def do_shutdown(self, restart):
+    def do_shutdown(self, restart):
         self.shell.exit_now = True
         return dict(status='ok', restart=restart)
 
-    async def do_is_complete(self, code):
+    def do_is_complete(self, code):
         transformer_manager = getattr(self.shell, 'input_transformer_manager', None)
         if transformer_manager is None:
             # input_splitter attribute is deprecated
@@ -497,7 +497,7 @@ class IPythonKernel(KernelBase):
             r['indent'] = ' ' * indent_spaces
         return r
 
-    async def do_apply(self, content, bufs, msg_id, reply_metadata):
+    def do_apply(self, content, bufs, msg_id, reply_metadata):
         from .serialize import serialize_object, unpack_apply_message
         shell = self.shell
         try:
@@ -552,7 +552,7 @@ class IPythonKernel(KernelBase):
 
         return reply_content, result_buf
 
-    async def do_clear(self):
+    def do_clear(self):
         self.shell.reset(False)
         return dict(status='ok')
 

--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -8,6 +8,7 @@ from datetime import datetime
 from functools import partial
 import itertools
 import logging
+import inspect
 from signal import signal, default_int_handler, SIGINT
 import sys
 import time
@@ -237,7 +238,9 @@ class Kernel(SingletonConfigurable):
             self.log.error("UNKNOWN CONTROL MESSAGE TYPE: %r", msg_type)
         else:
             try:
-                await handler(self.control_stream, idents, msg)
+                result = handler(self.control_stream, idents, msg)
+                if inspect.isawaitable(result):
+                    await result
             except Exception:
                 self.log.error("Exception in control handler:", exc_info=True)
 
@@ -303,7 +306,9 @@ class Kernel(SingletonConfigurable):
             except Exception:
                 self.log.debug("Unable to signal in pre_handler_hook:", exc_info=True)
             try:
-                await handler(self.shell_stream, idents, msg)
+                result = handler(self.shell_stream, idents, msg)
+                if inspect.isawaitable(result):
+                    await result
             except Exception:
                 self.log.error("Exception in message handler:", exc_info=True)
             finally:


### PR DESCRIPTION
- This fixes https://github.com/ipython/ipython/issues/11565 because tornado's wrapping of asyncio is a bit aggressive with creating Task objects which causes them to have a different `contextvars.Context`.
- However, this is a major change. I think this deserves a careful review - and be considered a backward incompatible change.
- If/when this goes in, we should also consider completely getting rid of tornado in ipykernel.

cc @afshin @minrk @Carreau.

Note: tests are passing except for the in-process kernel tests, for which we will need to make more functions async.