### PR TITLE
Test downstream projects

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install --upgrade pip
-          pip install pytest pytest-asyncio
+          pip install pytest pytest-asyncio pytest-tornado
           pip install nbclient[test]
           pip install --pre -U --upgrade-strategy=only-if-needed nbclient
           pip install ipyparallel[test]

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -28,5 +28,5 @@ jobs:
 
       - name: Run tests
         run: |
-          pytest --pyargs nbclient
+          #pytest --pyargs nbclient
           pytest --pyargs ipyparallel

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -25,11 +25,11 @@ jobs:
           pip install .
           pip install pytest "nbclient[test] @ git+git://github.com/jupyter/nbclient.git@master" \
                              "ipyparallel[test] @ git+git://github.com/ipython/ipyparallel.git@main" \
-                             "jupyter_client[test] @ git+git://github.com/jupyter/jupyter_client.git@master"
+                             jupyter_client[test]
           pip freeze
 
       - name: Run tests
         run: |
-          #IPYKERNEL_CELL_NAME="<IPY-INPUT>" pytest --pyargs nbclient
+          IPYKERNEL_CELL_NAME="<IPY-INPUT>" pytest --pyargs nbclient
           pytest --pyargs ipyparallel
           pytest --pyargs jupyter_client

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -25,7 +25,7 @@ jobs:
           pip install .
           pip install pytest "nbclient[test] @ git+git://github.com/jupyter/nbclient.git@master" \
                              "ipyparallel[test] @ git+git://github.com/ipython/ipyparallel.git@main" \
-                             jupyter_client[test]
+                             "jupyter_client[test] @ git+git://github.com/jupyter/jupyter_client.git@master"
           pip freeze
 
       - name: Run tests

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -25,7 +25,7 @@ jobs:
           pip install .
           pip install pytest "nbclient[test] @ git+git://github.com/jupyter/nbclient.git@master" \
                              "ipyparallel[test] @ git+git://github.com/ipython/ipyparallel.git@main" \
-                             "jupyter_client[test] @ git+git://github.com/jupyter/jupyter_client.git@master"
+                             jupyter_client[test] pytest-asyncio
           pip freeze
 
       - name: Run tests

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -23,9 +23,7 @@ jobs:
         run: |
           pip install --upgrade pip
           pip install .
-          pip install pytest "nbclient[test] @ git+git://github.com/jupyter/nbclient.git@master" \
-                             "ipyparallel[test] @ git+git://github.com/ipython/ipyparallel.git@main" \
-                             jupyter_client[test] pytest-asyncio
+          pip install pytest nbclient[test] ipyparallel[test] jupyter_client[test] pytest-asyncio
           pip freeze
 
       - name: Run tests

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -23,9 +23,12 @@ jobs:
         run: |
           pip install --upgrade pip
           pip install pytest pytest-asyncio
-          pip install nbclient[test]        --pre
-          pip install ipyparallel[test]     --pre
-          pip install jupyter_client[test]  --pre
+          pip install nbclient[test]
+          pip install --pre -U --upgrade-strategy=only-if-needed nbclient
+          pip install ipyparallel[test]
+          pip install --pre -U --upgrade-strategy=only-if-needed ipyparallel
+          pip install jupyter_client[test]
+          pip install --pre -U --upgrade-strategy=only-if-needed jupyter_client
           pip install . --force-reinstall
           pip freeze
           python -c 'import ipykernel; print("ipykernel", ipykernel.__version__)'

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -23,10 +23,13 @@ jobs:
         run: |
           pip install --upgrade pip
           pip install .
-          pip install pytest nbclient[test] "ipyparallel[test] @ git+git://github.com/ipython/ipyparallel.git@main"
+          pip install pytest "nbclient[test] @ git+git://github.com/jupyter/nbclient.git@master" \
+                             "ipyparallel[test] @ git+git://github.com/ipython/ipyparallel.git@main" \
+                             "jupyter_client[test] @ git+git://github.com/jupyter/jupyter_client.git@master"
           pip freeze
 
       - name: Run tests
         run: |
-          #pytest --pyargs nbclient
+          pytest --pyargs nbclient
           pytest --pyargs ipyparallel
+          pytest --pyargs jupyter_client

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -30,6 +30,6 @@ jobs:
 
       - name: Run tests
         run: |
-          IPYKERNEL_CELL_NAME="<IPY-INPUT>" pytest --pyargs nbclient
+          #IPYKERNEL_CELL_NAME="<IPY-INPUT>" pytest --pyargs nbclient
           pytest --pyargs ipyparallel
           pytest --pyargs jupyter_client

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -30,6 +30,6 @@ jobs:
 
       - name: Run tests
         run: |
-          pytest --pyargs nbclient
+          IPYKERNEL_CELL_NAME="<IPY-INPUT>" pytest --pyargs nbclient
           pytest --pyargs ipyparallel
           pytest --pyargs jupyter_client

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -22,15 +22,20 @@ jobs:
       - name: Install dependencies
         run: |
           pip install --upgrade pip
-          pip install .
-          pip install pytest "nbclient[test] @ git+git://github.com/jupyter/nbclient.git@master" \
-                             "ipyparallel[test] @ git+git://github.com/ipython/ipyparallel.git@main" \
-                             "jupyter_client[test] @ git+git://github.com/jupyter/jupyter_client.git@master" \
-                             pytest-asyncio
+          pip install pytest pytest-asyncio
+          pip install nbclient[test]        --pre
+          pip install ipyparallel[test]     --pre
+          pip install jupyter_client[test]  --pre
+          pip install . --force-reinstall
           pip freeze
+          python -c 'import ipykernel; print("ipykernel", ipykernel.__version__)'
 
-      - name: Run tests
-        run: |
-          IPYKERNEL_CELL_NAME="<IPY-INPUT>" pytest --pyargs nbclient
-          pytest --pyargs ipyparallel
-          pytest --pyargs jupyter_client
+      - name: Test nbclient
+        if: ${{ always() }}
+        run: IPYKERNEL_CELL_NAME="<IPY-INPUT>" pytest --pyargs nbclient
+      - name: Test ipyparallel
+        if: ${{ always() }}
+        run: pytest --pyargs ipyparallel
+      - name: Test jupyter_client
+        if: ${{ always() }}
+        run: pytest --pyargs jupyter_client

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -1,0 +1,32 @@
+name: Test downstream projects
+
+on:
+  push:
+    branches: "*"
+  pull_request:
+    branches: "*"
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+
+      - name: Install dependencies
+        run: |
+          pip install --upgrade pip
+          pip install .
+          pip install pytest nbclient[test] ipyparallel[test]
+          pip freeze
+
+      - name: Run tests
+        run: |
+          pytest --pyargs nbclient
+          pytest --pyargs ipyparallel

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -23,7 +23,10 @@ jobs:
         run: |
           pip install --upgrade pip
           pip install .
-          pip install pytest nbclient[test] ipyparallel[test] jupyter_client[test] pytest-asyncio
+          pip install pytest "nbclient[test] @ git+git://github.com/jupyter/nbclient.git@master" \
+                             "ipyparallel[test] @ git+git://github.com/ipython/ipyparallel.git@main" \
+                             "jupyter_client[test] @ git+git://github.com/jupyter/jupyter_client.git@master" \
+                             pytest-asyncio
           pip freeze
 
       - name: Run tests

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -23,7 +23,7 @@ jobs:
         run: |
           pip install --upgrade pip
           pip install .
-          pip install pytest nbclient[test] ipyparallel[test]
+          pip install pytest nbclient[test] "ipyparallel[test] @ git+git://github.com/ipython/ipyparallel.git@main"
           pip freeze
 
       - name: Run tests


### PR DESCRIPTION
It looks like ipykernel master breaks nbclient. I reproduced locally and I can see messages like:
```python
msg = {"shell": {...}, "control": {}}
```
where `...` is a regular message (with its `header` and so on).
Any idea where this could come from?