### PR TITLE
Build docs only on ubuntu : add jobs to check docstring formatting.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,10 +53,11 @@ jobs:
         pip freeze
         pip check
     - name: Run the tests
-      timeout-minutes: 30
+      timeout-minutes: 10
       run: |
         pytest ipykernel -vv -s --cov ipykernel --cov-branch --cov-report term-missing:skip-covered --durations 10
     - name: Build the docs
+      if: ${{ matrix.os == 'ubuntu' &&  matrix.python-version == '3.9'}}
       run: |
         cd docs
         pip install -r requirements.txt
@@ -69,3 +70,43 @@ jobs:
     - name: Coverage
       run: |
         codecov
+  check_docstrings:
+    runs-on: ${{ matrix.os }}-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu]
+        python-version: [ '3.9' ]
+        exclude:
+        - os: windows
+          python-version: pypy3
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v1
+    - name: Install Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+        architecture: 'x64'
+    - name: Upgrade packaging dependencies
+      run: |
+        pip install --upgrade pip setuptools wheel --user
+    - name: Get pip cache dir
+      id: pip-cache
+      run: |
+        echo "::set-output name=dir::$(pip cache dir)"
+    - name: Cache pip
+      uses: actions/cache@v1
+      with:
+        path: ${{ steps.pip-cache.outputs.dir }}
+        key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('setup.py') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-${{ matrix.python-version }}-
+          ${{ runner.os }}-pip-
+    - name: Install the Python dependencies
+      run: |
+        pip install --pre --upgrade --upgrade-strategy=eager .
+        pip install velin
+    - name: Check Docstrings
+      run: |
+        velin . --check --compact

--- a/ipykernel/kernelspec.py
+++ b/ipykernel/kernelspec.py
@@ -21,7 +21,7 @@ KERNEL_NAME = 'python%i' % sys.version_info[0]
 RESOURCES = pjoin(os.path.dirname(__file__), 'resources')
 
 
-def make_ipkernel_cmd(mod='ipykernel_launcher', executable=None, extra_arguments=None, **kw):
+def make_ipkernel_cmd(mod="ipykernel_launcher", executable=None, extra_arguments=None):
     """Build Popen command list for launching an IPython kernel.
 
     Parameters

--- a/ipykernel/pickleutil.py
+++ b/ipykernel/pickleutil.py
@@ -128,6 +128,9 @@ class CannedObject(object):
         hook : callable (optional)
             An optional extra callable,
             which can do additional processing of the uncanned object.
+
+        Notes
+        -----
         large data may be offloaded into the buffers list,
         used for zero-copy transfers.
         """


### PR DESCRIPTION
This makes sure that docstring auto formatting won't change anything. Runs only on ubuntu + 3.9