### PR TITLE
Allow setting cell name

### DIFF
--- a/ipykernel/compiler.py
+++ b/ipykernel/compiler.py
@@ -44,8 +44,11 @@ def get_tmp_hash_seed():
     return hash_seed
 
 def get_file_name(code):
-    name = murmur2_x86(code, get_tmp_hash_seed())
-    return get_tmp_directory() + '/' + str(name) + '.py'
+    cell_name = os.environ.get("IPYKERNEL_CELL_NAME")
+    if cell_name is None:
+        name = murmur2_x86(code, get_tmp_hash_seed())
+        cell_name = get_tmp_directory() + '/' + str(name) + '.py'
+    return cell_name
 
 class XCachingCompiler(CachingCompiler):
 


### PR DESCRIPTION
The cell name is now of the form `/tmp/ipykernel_1789/2216019953.py`, which makes it hard to compare error outputs with a traceback, because the cell name is embedded in it:
```python-traceback
---------------------------------------------------------------------------
NameError                                 Traceback (most recent call last)
/tmp/ipykernel_1789/2216019953.py in <module>
----> 1 foo

NameError: name 'foo' is not defined
```
For instance in nbclient, the new ipykernel will require rewriting our tests because we check strict output equality.
It would be nice to allow setting the cell name by passing it in an environment variable, e.g.:
```
export IPYKERNEL_CELL_NAME="<IPY-INPUT>"
```
This should be enough for tests not involving the debugger.