### PR TITLE
Import configure_inline_support from matplotlib_inline if available

### DIFF
--- a/ipykernel/zmqshell.py
+++ b/ipykernel/zmqshell.py
@@ -624,7 +624,10 @@ class ZMQInteractiveShell(InteractiveShell):
     def enable_matplotlib(self, gui=None):
         gui, backend = super(ZMQInteractiveShell, self).enable_matplotlib(gui)
 
-        from ipykernel.pylab.backend_inline import configure_inline_support
+        try:
+            from matplotlib_inline.backend_inline import configure_inline_support
+        except ImportError:
+            from ipykernel.pylab.backend_inline import configure_inline_support
 
         configure_inline_support(self, backend)
 


### PR DESCRIPTION
- This correctly applies the rcParams declared in the inline backend configuration when using `%matplotlib inline`.
- This is necessary for IPython 7.23+, which requires `matplotlib_inline` now.
- I also think a new release in the `5.5` series is required to work with that IPython version.

Pinging @SylvainCorlay and @blink1073 about this one.