### PR TITLE
Import configure_inline_support from matplotlib_inline if available

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
     - name: Install the Python dependencies
       run: |
         pip install --pre --upgrade --upgrade-strategy=eager .[test] codecov
+        pip install jupyter_client==6.1.*
     - name: Install matplotlib
       if: ${{ matrix.os != 'macos' && matrix.python-version != 'pypy3' }}
       run: |

--- a/ipykernel/zmqshell.py
+++ b/ipykernel/zmqshell.py
@@ -600,7 +600,10 @@ class ZMQInteractiveShell(InteractiveShell):
     def enable_matplotlib(self, gui=None):
         gui, backend = super(ZMQInteractiveShell, self).enable_matplotlib(gui)
 
-        from ipykernel.pylab.backend_inline import configure_inline_support
+        try:
+            from matplotlib_inline.backend_inline import configure_inline_support
+        except ImportError:
+            from ipykernel.pylab.backend_inline import configure_inline_support
 
         configure_inline_support(self, backend)
 


### PR DESCRIPTION
This correctly applies the rcParams declared in the inline backend configuration when using "%matplotlib inline".

Pinging @blink1073 about it.