### PR TITLE
Add Kernel.get_parent_header

### DIFF
--- a/ipykernel/comm/comm.py
+++ b/ipykernel/comm/comm.py
@@ -66,7 +66,7 @@ class Comm(LoggingConfigurable):
         self.kernel.session.send(self.kernel.iopub_socket, msg_type,
             content,
             metadata=json_clean(metadata),
-            parent=self.kernel._parent_header.get('shell', {}),
+            parent=self.kernel.get_parent_header("shell"),
             ident=self.topic,
             buffers=buffers,
         )


### PR DESCRIPTION
and deprecate instead of break `Kernel._parent_header`.

While testing the 6.0 alpha, I noticed an issue with the OutputWidget, which references the parent header [here](https://github.com/jupyter-widgets/ipywidgets/blob/e0d41f6f02324596a282bc9e4650fd7ba63c0004/ipywidgets/widgets/widget_output.py#L112). #585 changes `_parent_header` to be a nested dict of headers, now that two channels may have different parents, causing the output widget to fail with a KeyError on 'msg_id'.

This is ~understandable because widgets are using a private API, but at the same time there isn't a public API for getting the current parent header, which the output widget needs.

I went with:

- keep `Kernel._parent_header` to mean shell, but with a deprecation
- rename new still-private nested headers trait to `_parent_headers`
- add `Kernel.get_parent_header(channel="shell")` API with clearer stability expectations

This way the Output widget doesn't break, and has a clearer path to using a non-private non-deprecated API, which wasn't available before.

related to #635