### PR TITLE
stop control thread before closing sockets on it

### DIFF
--- a/ipykernel/control.py
+++ b/ipykernel/control.py
@@ -15,7 +15,16 @@ class ControlThread(Thread):
         self.pydev_do_not_trace = True
         self.is_pydev_daemon_thread = True
 
-    def run(self): 
+    def run(self):
         self.io_loop.make_current()
-        self.io_loop.start()
-        self.io_loop.close(all_fds=True)
+        try:
+            self.io_loop.start()
+        finally:
+            self.io_loop.close()
+
+    def stop(self):
+        """Stop the thread.
+
+        This method is threadsafe.
+        """
+        self.io_loop.add_callback(self.io_loop.stop)

--- a/ipykernel/kernelapp.py
+++ b/ipykernel/kernelapp.py
@@ -346,6 +346,10 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp,
             self.log.debug("Closing iopub channel")
             self.iopub_thread.stop()
             self.iopub_thread.close()
+        if self.control_thread and self.control_thread.is_alive():
+            self.log.debug("Closing control thread")
+            self.control_thread.stop()
+            self.control_thread.join()
 
         if self.debugpy_socket and not self.debugpy_socket.closed:
             self.debugpy_socket.close()
@@ -487,7 +491,7 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp,
                                 control_stream=control_stream,
                                 debugpy_stream=debugpy_stream,
                                 debug_shell_socket=self.debug_shell_socket,
-                                shell_stream=shell_stream, 
+                                shell_stream=shell_stream,
                                 control_thread=self.control_thread,
                                 iopub_thread=self.iopub_thread,
                                 iopub_socket=self.iopub_socket,


### PR DESCRIPTION
closing sockets while they are still in use by another thread is a recipe for SIGABRT.

skip `close(all_fds=True)` in favor of explicit cleanup of sockets

I believe this fixes the nbclient failures in test_many_parallel_notebooks mentioned [here](https://github.com/ipython/ipykernel/pull/635#issuecomment-827826766).

I'm not sure why that test would have triggered it and not others, but it was readily reproducible for me and doesn't happen anymore after this.