### PR TITLE
Keep preferring SelectorEventLoop on Windows

### DIFF
--- a/ipykernel/kernelapp.py
+++ b/ipykernel/kernelapp.py
@@ -565,14 +565,21 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp,
         Pick the older SelectorEventLoopPolicy on Windows
         if the known-incompatible default policy is in use.
 
+        Support for Proactor via a background thread is available in tornado 6.1,
+        but it is still preferable to run the Selector in the main thread
+        instead of the background.
+
         do this as early as possible to make it a low priority and overrideable
 
         ref: https://github.com/tornadoweb/tornado/issues/2608
 
-        FIXME: if/when tornado supports the defaults in asyncio,
-               remove and bump tornado requirement for py38
+        FIXME: if/when tornado supports the defaults in asyncio without threads,
+               remove and bump tornado requirement for py38.
+               Most likely, this will mean a new Python version
+               where asyncio.ProactorEventLoop supports add_reader and friends.
+
         """
-        if sys.platform.startswith("win") and sys.version_info >= (3, 8) and tornado.version_info < (6, 1):
+        if sys.platform.startswith("win") and sys.version_info >= (3, 8):
             import asyncio
             try:
                 from asyncio import (


### PR DESCRIPTION
Selector is still preferable when ~all out events are on zmq sockets, which must use the add_reader methods missing from Proactor. Tornado 6.1 puts these events in a background thread when Proactor is used, which we can avoid by using Selector.

cf https://github.com/jupyter/notebook/pull/6052

reverts that part of #564

I don't understand the hang mentioned in #563 - if/where that happens and is caused by this patch, it is presumably multiple event loops with events, but only one running (waiting on async events scheduled on a non-running loop will never finish). That should be traceable and avoidable, though, if it can be reproduced.