### PR TITLE
Make the isatty method of OutStream return True

### DIFF
--- a/ipykernel/iostream.py
+++ b/ipykernel/iostream.py
@@ -383,11 +383,11 @@ class OutStream(TextIOBase):
 
     def isatty(self):
         """Return a bool indicating whether this is an 'interactive' stream.
-        
+
         The standard ipykernel streams are assumed to be interactive.
         """
         return True
-    
+
     def _setup_stream_redirects(self, name):
         pr, pw = os.pipe()
         fno = getattr(sys, name).fileno()

--- a/ipykernel/iostream.py
+++ b/ipykernel/iostream.py
@@ -333,7 +333,7 @@ class OutStream(TextIOBase):
             the file descriptor by its number. It will spawn a watching thread,
             that will swap the give file descriptor for a pipe, read from the
             pipe, and insert this into the current Stream.
-        isatty: bool (default, False)
+        isatty : bool (default, False)
             Indication of whether this stream has termimal capabilities (e.g. can handle colors)
 
         """

--- a/ipykernel/iostream.py
+++ b/ipykernel/iostream.py
@@ -320,7 +320,7 @@ class OutStream(TextIOBase):
             self._exc = sys.exc_info()
 
     def __init__(
-        self, session, pub_thread, name, pipe=None, echo=None, *, watchfd=True, isatty=True,
+        self, session, pub_thread, name, pipe=None, echo=None, *, watchfd=True, isatty=False,
     ):
         """
         Parameters
@@ -333,7 +333,7 @@ class OutStream(TextIOBase):
             the file descriptor by its number. It will spawn a watching thread,
             that will swap the give file descriptor for a pipe, read from the
             pipe, and insert this into the current Stream.
-        isatty: bool (default, True)
+        isatty: bool (default, False)
             Indication of whether this stream has termimal capabilities (e.g. can handle colors)
 
         """

--- a/ipykernel/iostream.py
+++ b/ipykernel/iostream.py
@@ -381,6 +381,13 @@ class OutStream(TextIOBase):
             else:
                 raise ValueError("echo argument must be a file like object")
 
+    def isatty(self):
+        """Return a bool indicating whether this is an 'interactive' stream.
+        
+        The standard ipykernel streams are assumed to be interactive.
+        """
+        return True
+    
     def _setup_stream_redirects(self, name):
         pr, pw = os.pipe()
         fno = getattr(sys, name).fileno()

--- a/ipykernel/iostream.py
+++ b/ipykernel/iostream.py
@@ -320,7 +320,7 @@ class OutStream(TextIOBase):
             self._exc = sys.exc_info()
 
     def __init__(
-        self, session, pub_thread, name, pipe=None, echo=None, *, watchfd=True
+        self, session, pub_thread, name, pipe=None, echo=None, *, watchfd=True, isatty=True,
     ):
         """
         Parameters
@@ -333,6 +333,8 @@ class OutStream(TextIOBase):
             the file descriptor by its number. It will spawn a watching thread,
             that will swap the give file descriptor for a pipe, read from the
             pipe, and insert this into the current Stream.
+        isatty: bool (default, True)
+            Indication of whether this stream has termimal capabilities (e.g. can handle colors)
 
         """
         if pipe is not None:
@@ -364,6 +366,7 @@ class OutStream(TextIOBase):
         self._io_loop = pub_thread.io_loop
         self._new_buffer()
         self.echo = None
+        self._isatty = bool(isatty)
 
         if (
             watchfd
@@ -384,9 +387,10 @@ class OutStream(TextIOBase):
     def isatty(self):
         """Return a bool indicating whether this is an 'interactive' stream.
 
-        The standard ipykernel streams are assumed to be interactive.
+        Returns:
+            Boolean
         """
-        return True
+        return self._isatty
 
     def _setup_stream_redirects(self, name):
         pr, pw = os.pipe()

--- a/ipykernel/tests/test_io.py
+++ b/ipykernel/tests/test_io.py
@@ -17,7 +17,7 @@ def test_io_api():
     thread = IOPubThread(pub)
     thread.start()
 
-    stream = OutStream(session, thread, 'stdout', isatty=True)
+    stream = OutStream(session, thread, 'stdout')
 
     # cleanup unused zmq objects before we start testing
     thread.stop()

--- a/ipykernel/tests/test_io.py
+++ b/ipykernel/tests/test_io.py
@@ -25,7 +25,7 @@ def test_io_api():
     ctx.term()
 
     assert stream.errors is None
-    assert not stream.isatty()
+    assert stream.isatty()
     with nt.assert_raises(io.UnsupportedOperation):
         stream.detach()
     with nt.assert_raises(io.UnsupportedOperation):

--- a/ipykernel/tests/test_io.py
+++ b/ipykernel/tests/test_io.py
@@ -17,7 +17,7 @@ def test_io_api():
     thread = IOPubThread(pub)
     thread.start()
 
-    stream = OutStream(session, thread, 'stdout')
+    stream = OutStream(session, thread, 'stdout', isatty=True)
 
     # cleanup unused zmq objects before we start testing
     thread.stop()
@@ -38,3 +38,13 @@ def test_io_api():
         stream.seek(0)
     with nt.assert_raises(io.UnsupportedOperation):
         stream.tell()
+
+def test_io_isatty():
+    session = Session()
+    ctx = zmq.Context()
+    pub = ctx.socket(zmq.PUB)
+    thread = IOPubThread(pub)
+    thread.start()
+
+    stream = OutStream(session, thread, 'stdout', isatty=False)
+    assert not stream.isatty()

--- a/ipykernel/tests/test_io.py
+++ b/ipykernel/tests/test_io.py
@@ -25,7 +25,7 @@ def test_io_api():
     ctx.term()
 
     assert stream.errors is None
-    assert stream.isatty()
+    assert not stream.isatty()
     with nt.assert_raises(io.UnsupportedOperation):
         stream.detach()
     with nt.assert_raises(io.UnsupportedOperation):
@@ -46,5 +46,5 @@ def test_io_isatty():
     thread = IOPubThread(pub)
     thread.start()
 
-    stream = OutStream(session, thread, 'stdout', isatty=False)
-    assert not stream.isatty()
+    stream = OutStream(session, thread, 'stdout', isatty=True)
+    assert stream.isatty()


### PR DESCRIPTION
The ` ipykernel.iostream.OutStream` represents an interactive stream and should there have a `isatty` method returning `True`.
Also see https://github.com/ipython/ipykernel/issues/268, https://github.com/ipython/ipykernel/issues/680, https://github.com/willmcgugan/rich/pull/1221

Fixes #680 
Fixes #268 
