### PR TITLE
Remove pin on Jedi because that was already fixed in IPython

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -89,7 +89,6 @@ setup_args = dict(
             "pytest-cov",
             "flaky",
             "nose",  # nose because there are still a few nose.tools imports hanging around
-            "jedi<=0.17.2",
             "ipyparallel",
         ],
     },


### PR DESCRIPTION
Just in case this is used by somebody.