### PR TITLE
test vs pypy3 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, macos, windows]
-        python-version: [ '3.7', '3.8', '3.9' ]
+        python-version: [ '3.7', '3.8', '3.9', 'pypy3' ]
         exclude:
         - os: windows
           python-version: pypy3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,15 +9,15 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, macos, windows]
-        python-version: [ '3.7', '3.8', '3.9', 'pypy3' ]
+        python-version: [ '3.7', '3.8', '3.9', 'pypy-3.7' ]
         exclude:
         - os: windows
-          python-version: pypy3
+          python-version: pypy-3.7
     steps:
     - name: Checkout
       uses: actions/checkout@v1
     - name: Install Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
         architecture: 'x64'
@@ -84,7 +84,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v1
     - name: Install Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
         architecture: 'x64'


### PR DESCRIPTION
Hooray ipykernel 6! Boo pypy fails. Seeing if this test fail is spurious/azure/cosmic rays: 

```
=================================== FAILURES ===================================
________________________________ test_shutdown _________________________________

    def test_shutdown():
        """Kernel exits after polite shutdown_request"""
        with new_kernel() as kc:
            km = kc.parent
            execute('a = 1', kc=kc)
            wait_for_idle(kc)
            kc.shutdown()
            for i in range(300): # 30s timeout
                if km.is_alive():
                    time.sleep(.1)
                else:
                    break
>           assert not km.is_alive()
E           assert not True
E            +  where True = <bound method KernelManager.is_alive of <jupyter_client.manager.KernelManager object at 0x000055773df9b0c0>>()
E            +    where <bound method KernelManager.is_alive of <jupyter_client.manager.KernelManager object at 0x000055773df9b0c0>> = <jupyter_client.manager.KernelManager object at 0x000055773df9b0c0>.is_alive

../_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placeh/site-packages/ipykernel/tests/test_kernel.py:373: AssertionError

```

> from https://github.com/conda-forge/ipykernel-feedstock/pull/84#issuecomment-871402127

