### PR TITLE
Fix Tk and asyncio event loops

### DIFF
--- a/ipykernel/eventloops.py
+++ b/ipykernel/eventloops.py
@@ -232,10 +232,10 @@ def loop_tk(kernel):
         # For Tkinter, we create a Tk object and call its withdraw method.
         kernel.app_wrapper = BasicAppWrapper(app)
 
-        notifier = partial(process_stream_events, shell_stream)
+        notifier = partial(process_stream_events, kernel.shell_stream)
         # seems to be needed for tk
         notifier.__name__ = "notifier"
-        app.tk.createfilehandler(shell_stream.getsockopt(zmq.FD), READABLE, notifier)
+        app.tk.createfilehandler(kernel.shell_stream.getsockopt(zmq.FD), READABLE, notifier)
         # schedule initial call after start
         app.after(0, notifier)
 
@@ -364,8 +364,8 @@ def loop_asyncio(kernel):
         if stream.flush(limit=1):
             loop.stop()
 
-    notifier = partial(process_stream_events, shell_stream)
-    loop.add_reader(shell_stream.getsockopt(zmq.FD), notifier)
+    notifier = partial(process_stream_events, kernel.shell_stream)
+    loop.add_reader(kernel.shell_stream.getsockopt(zmq.FD), notifier)
     loop.call_soon(notifier)
 
     while True:


### PR DESCRIPTION
I noticed this when running the Spyder test suite against the newly released ipykernel 6.