### PR TITLE
[bugfix] fix in setup.py (comma before appnope)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ setup_args = dict(
         'traitlets>=4.1.0',
         'jupyter_client',
         'tornado>=4.2',
-        'matplotlib-inline>=0.1.0,<0.2.0'
+        'matplotlib-inline>=0.1.0,<0.2.0',
         'appnope;platform_system=="Darwin"',
     ],
     extras_require={


### PR DESCRIPTION
The two dependency-strings for `matplotlib-inline` and `appnope` were merged which lead to errors such as `Invalid constraint (matplotlib-inline (<0.2.0appnope,>=0.1.0) ; platform_system == "Darwin") found in ipykernel-6.0.0rc0 dependencies`.