### PR TITLE
Fix typo in eventloops.py

### DIFF
--- a/ipykernel/eventloops.py
+++ b/ipykernel/eventloops.py
@@ -324,7 +324,7 @@ def loop_cocoa(kernel):
                 # don't let interrupts during mainloop invoke crash_handler:
                 sys.excepthook = handle_int
                 mainloop(kernel._poll_interval)
-                if kernel_shell_stream.flush(limit=1):
+                if kernel.shell_stream.flush(limit=1):
                     # events to process, return control to kernel
                     return
             except:


### PR DESCRIPTION
Possible typo in eventloops.py : Changing kernel_shell_stream to kernel.shell_stream fixes this NameError with the MacOSX backend

Using matplotlib backend: MacOSX
ERROR:tornado.application:Exception in callback functools.partial(<function Kernel.enter_eventloop.<locals>.advance_eventloop at 0x108aefe50>)
Traceback (most recent call last):
  File "/Users/selasley/venvs/py39/lib/python3.9/site-packages/tornado/ioloop.py", line 741, in _run_callback
    ret = callback()
  File "/Users/selasley/venvs/py39/lib/python3.9/site-packages/ipykernel/kernelbase.py", line 401, in advance_eventloop
    eventloop(self)
  File "/Users/selasley/venvs/py39/lib/python3.9/site-packages/ipykernel/eventloops.py", line 327, in loop_cocoa
    if kernel_shell_stream.flush(limit=1):
NameError: name 'kernel_shell_stream' is not defined