### PR TITLE
Minimal flake8 config

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -8,4 +8,34 @@ license_file = COPYING.md
 warningfilters= default   |.*             |DeprecationWarning |ipykernel.*
                 error     |.*invalid.*    |DeprecationWarning |matplotlib.*
                 
-                
+[flake8]
+# References:
+# https://flake8.readthedocs.io/en/latest/user/configuration.html
+# https://flake8.readthedocs.io/en/latest/user/error-codes.html
+# https://pycodestyle.pycqa.org/en/latest/intro.html#error-codes
+exclude = __init__.py,versioneer.py
+ignore =
+    E20,   # Extra space in brackets
+    E122,  # continuation line missing indentation or outdented
+    E124,  # closing bracket does not match visual indentation
+    E128,E127,E126  # continuation line over/under-indented for visual indent
+    E121,E125,  # continuation line with same indent as next logical line
+    E226,  # missing whitespace around arithmetic operator
+    E231,E241,  # Multiple spaces around ","
+    E211,  # whitespace before '('
+    E221,E225,E228  # missing whitespace around operator
+    E271,  # multiple spaces after keyword
+    E301,E303,E305,E306 # expected X blank lines
+    E26,   # Comments
+    E251   # unexpected spaces around keyword / parameter equals
+    E302   # expected 2 blank lines, found 1
+    E4,    # Import formatting
+    E721,  # Comparing types instead of isinstance
+    E731,  # Assigning lambda expression
+    E741,  # Ambiguous variable names
+    W293,  # blank line contains whitespace
+    W503,  # line break before binary operator
+    W504,  # line break after binary operator
+    F811,  # redefinition of unused 'loop' from line 10
+max-line-length = 120
+ 


### PR DESCRIPTION
This disable most common issues that are not critical like whitespace,
at least for now, so that we can fix all the issues and put flake8 in
CI with an exist status.

Then we can decide to renable (or not) those checks.