### PR TITLE
Remove unused variables

### DIFF
--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -1024,7 +1024,7 @@ class Kernel(SingletonConfigurable):
             except KeyboardInterrupt:
                 # re-raise KeyboardInterrupt, to truncate traceback
                 raise KeyboardInterrupt("Interrupted by user") from None
-            except Exception as e:
+            except Exception:
                 self.log.warning("Invalid Message:", exc_info=True)
 
         try:

--- a/ipykernel/tests/test_embed_kernel.py
+++ b/ipykernel/tests/test_embed_kernel.py
@@ -94,18 +94,18 @@ def test_embed_kernel_basic():
 
     with setup_kernel(cmd) as client:
         # oinfo a (int)
-        msg_id = client.inspect('a')
+        client.inspect("a")
         msg = client.get_shell_msg(block=True, timeout=TIMEOUT)
         content = msg['content']
         assert content['found']
 
-        msg_id = client.execute("c=a*2")
+        client.execute("c=a*2")
         msg = client.get_shell_msg(block=True, timeout=TIMEOUT)
         content = msg['content']
         assert content['status'] == 'ok'
 
         # oinfo c (should be 10)
-        msg_id = client.inspect('c')
+        client.inspect("c")
         msg = client.get_shell_msg(block=True, timeout=TIMEOUT)
         content = msg['content']
         assert content['found']
@@ -128,7 +128,7 @@ def test_embed_kernel_namespace():
 
     with setup_kernel(cmd) as client:
         # oinfo a (int)
-        msg_id = client.inspect('a')
+        client.inspect("a")
         msg = client.get_shell_msg(block=True, timeout=TIMEOUT)
         content = msg['content']
         assert content['found']
@@ -136,7 +136,7 @@ def test_embed_kernel_namespace():
         assert '5' in text
 
         # oinfo b (str)
-        msg_id = client.inspect('b')
+        client.inspect("b")
         msg = client.get_shell_msg(block=True, timeout=TIMEOUT)
         content = msg['content']
         assert content['found']
@@ -144,7 +144,7 @@ def test_embed_kernel_namespace():
         assert 'hi there' in text
 
         # oinfo c (undefined)
-        msg_id = client.inspect('c')
+        client.inspect("c")
         msg = client.get_shell_msg(block=True, timeout=TIMEOUT)
         content = msg['content']
         assert not content['found']
@@ -167,7 +167,7 @@ def test_embed_kernel_reentrant():
 
     with setup_kernel(cmd) as client:
         for i in range(5):
-            msg_id = client.inspect('count')
+            client.inspect("count")
             msg = client.get_shell_msg(block=True, timeout=TIMEOUT)
             content = msg['content']
             assert content['found']

--- a/ipykernel/tests/test_kernel.py
+++ b/ipykernel/tests/test_kernel.py
@@ -447,7 +447,7 @@ def test_control_thread_priority():
             control_msg_ids.append(msg["header"]["msg_id"])
 
         # finally, collect the replies on both channels for comparison
-        sleep_reply = get_reply(kc, sleep_msg_id)
+        get_reply(kc, sleep_msg_id)
         shell_replies = []
         for msg_id in shell_msg_ids:
             shell_replies.append(get_reply(kc, msg_id))

--- a/ipykernel/tests/test_kernelspec.py
+++ b/ipykernel/tests/test_kernelspec.py
@@ -89,10 +89,9 @@ def test_write_kernel_spec_path():
 def test_install_kernelspec():
 
     path = tempfile.mkdtemp()
-    try: 
-        test = InstallIPythonKernelSpecApp.launch_instance(argv=['--prefix', path])
-        assert_is_spec(os.path.join(
-            path, 'share', 'jupyter', 'kernels', KERNEL_NAME))
+    try:
+        InstallIPythonKernelSpecApp.launch_instance(argv=["--prefix", path])
+        assert_is_spec(os.path.join(path, "share", "jupyter", "kernels", KERNEL_NAME))
     finally:
         shutil.rmtree(path)
 

--- a/ipykernel/tests/test_message_spec.py
+++ b/ipykernel/tests/test_message_spec.py
@@ -322,14 +322,15 @@ def test_execute_inc():
     """execute request should increment execution_count"""
     flush_channels()
 
-    msg_id, reply = execute(code='x=1')
-    count = reply['execution_count']
+    _, reply = execute(code="x=1")
+    count = reply["execution_count"]
 
     flush_channels()
 
-    msg_id, reply = execute(code='x=2')
-    count_2 = reply['execution_count']
-    assert count_2 == count+1
+    _, reply = execute(code="x=2")
+    count_2 = reply["execution_count"]
+    assert count_2 == count + 1
+
 
 def test_execute_stop_on_error():
     """execute request should not abort execution queue with stop_on_error False"""
@@ -342,7 +343,7 @@ def test_execute_stop_on_error():
         'raise ValueError',
     ])
     KC.execute(code=fail)
-    msg_id = KC.execute(code='print("Hello")')
+    KC.execute(code='print("Hello")')
     KC.get_shell_msg(timeout=TIMEOUT)
     reply = KC.get_shell_msg(timeout=TIMEOUT)
     assert reply['content']['status'] == 'aborted'
@@ -350,7 +351,7 @@ def test_execute_stop_on_error():
     flush_channels()
 
     KC.execute(code=fail, stop_on_error=False)
-    msg_id = KC.execute(code='print("Hello")')
+    KC.execute(code='print("Hello")')
     KC.get_shell_msg(timeout=TIMEOUT)
     reply = KC.get_shell_msg(timeout=TIMEOUT)
     assert reply['content']['status'] == 'ok'
@@ -519,8 +520,8 @@ def test_is_complete():
 def test_history_range():
     flush_channels()
 
-    msg_id_exec = KC.execute(code='x=1', store_history = True)
-    reply_exec = KC.get_shell_msg(timeout=TIMEOUT)
+    KC.execute(code="x=1", store_history=True)
+    KC.get_shell_msg(timeout=TIMEOUT)
 
     msg_id = KC.history(hist_access_type = 'range', raw = True, output = True, start = 1, stop = 2, session = 0)
     reply = get_reply(KC, msg_id, TIMEOUT)
@@ -531,8 +532,8 @@ def test_history_range():
 def test_history_tail():
     flush_channels()
 
-    msg_id_exec = KC.execute(code='x=1', store_history = True)
-    reply_exec = KC.get_shell_msg(timeout=TIMEOUT)
+    KC.execute(code="x=1", store_history=True)
+    KC.get_shell_msg(timeout=TIMEOUT)
 
     msg_id = KC.history(hist_access_type = 'tail', raw = True, output = True, n = 1, session = 0)
     reply = get_reply(KC, msg_id, TIMEOUT)
@@ -543,8 +544,8 @@ def test_history_tail():
 def test_history_search():
     flush_channels()
 
-    msg_id_exec = KC.execute(code='x=1', store_history = True)
-    reply_exec = KC.get_shell_msg(timeout=TIMEOUT)
+    KC.execute(code="x=1", store_history=True)
+    KC.get_shell_msg(timeout=TIMEOUT)
 
     msg_id = KC.history(hist_access_type = 'search', raw = True, output = True, n = 1, pattern = '*', session = 0)
     reply = get_reply(KC, msg_id, TIMEOUT)

--- a/ipykernel/tests/test_start_kernel.py
+++ b/ipykernel/tests/test_start_kernel.py
@@ -11,7 +11,7 @@ def test_ipython_start_kernel_userns():
            'start_kernel(user_ns=ns)')
 
     with setup_kernel(cmd) as client:
-        msg_id = client.inspect('tre')
+        client.inspect("tre")
         msg = client.get_shell_msg(block=True, timeout=TIMEOUT)
         content = msg['content']
         assert content['found']
@@ -19,11 +19,11 @@ def test_ipython_start_kernel_userns():
         assert '123' in text
 
         # user_module should be an instance of DummyMod
-        msg_id = client.execute("usermod = get_ipython().user_module")
+        client.execute("usermod = get_ipython().user_module")
         msg = client.get_shell_msg(block=True, timeout=TIMEOUT)
-        content = msg['content']
-        assert content['status'] == 'ok'
-        msg_id = client.inspect('usermod')
+        content = msg["content"]
+        assert content["status"] == "ok"
+        client.inspect("usermod")
         msg = client.get_shell_msg(block=True, timeout=TIMEOUT)
         content = msg['content']
         assert content['found']
@@ -39,11 +39,11 @@ def test_ipython_start_kernel_no_userns():
 
     with setup_kernel(cmd) as client:
         # user_module should not be an instance of DummyMod
-        msg_id = client.execute("usermod = get_ipython().user_module")
+        client.execute("usermod = get_ipython().user_module")
         msg = client.get_shell_msg(block=True, timeout=TIMEOUT)
-        content = msg['content']
-        assert content['status'] == 'ok'
-        msg_id = client.inspect('usermod')
+        content = msg["content"]
+        assert content["status"] == "ok"
+        client.inspect("usermod")
         msg = client.get_shell_msg(block=True, timeout=TIMEOUT)
         content = msg['content']
         assert content['found']


### PR DESCRIPTION
Unused variables are a code smell.
Removing them make it clearer we expect the functions called to be
called for their side-effects.

Part of the #717 PR-group.