### PR TITLE
Replace non-existing function.

### DIFF
--- a/ipykernel/ipkernel.py
+++ b/ipykernel/ipkernel.py
@@ -534,9 +534,9 @@ class IPythonKernel(KernelBase):
             # invoke IPython traceback formatting
             shell.showtraceback()
             reply_content = {
-                'traceback': shell._last_traceback or [],
-                'ename': str(type(e).__name__),
-                'evalue': safe_unicode(e),
+                "traceback": shell._last_traceback or [],
+                "ename": str(type(e).__name__),
+                "evalue": str(e),
             }
             # FIXME: deprecated piece for ipyparallel (remove in 5.0):
             e_info = dict(engine_uuid=self.ident, engine_id=self.int_id, method='apply')


### PR DESCRIPTION
This was forgotten as part of an earlier pass, when safe_unicode (py2
compat) was removed. safe_unicode is undefiled now and would lead to
crash.

Part of the #717 PR-group.