### PR TITLE
[WIP] Fix exception raised by `OutStream.write`

### DIFF
--- a/ipykernel/iostream.py
+++ b/ipykernel/iostream.py
@@ -498,7 +498,7 @@ class OutStream(TextIOBase):
         """
 
         if not isinstance(string, str):
-            raise ValueError(
+            raise TypeError(
                 "TypeError: write() argument must be str, not {type(string)}"
             )
 

--- a/ipykernel/iostream.py
+++ b/ipykernel/iostream.py
@@ -499,7 +499,7 @@ class OutStream(TextIOBase):
 
         if not isinstance(string, str):
             raise TypeError(
-                "TypeError: write() argument must be str, not {type(string)}"
+                f"write() argument must be str, not {type(string)}"
             )
 
         if self.echo is not None:

--- a/ipykernel/tests/test_io.py
+++ b/ipykernel/tests/test_io.py
@@ -38,6 +38,8 @@ def test_io_api():
         stream.seek(0)
     with nt.assert_raises(io.UnsupportedOperation):
         stream.tell()
+    with nt.assert_raises(TypeError):
+        stream.write(b'')
 
 def test_io_isatty():
     session = Session()


### PR DESCRIPTION
In order to conform with the behavior of `sys.stdout.write` this method should return a `TypeError` rather than a `ValueError`.  This PR also adds an 'f' to the to make the f-string evaluate the `type(string)` and return more helpful information in the exception message.

After some fiddling, I was not able to get the nosetests to pass on my local machine by following the instructions in the READM.md for this repo.  The contributing docs indicated that a pass in actions would be sufficient, but I'm open to suggestions for what I might be doing wrong.

The PR is intended to fix #725