### PR TITLE
Add watchfd keyword to InProcessKernel OutStream initialization

### DIFF
--- a/ipykernel/inprocess/ipkernel.py
+++ b/ipykernel/inprocess/ipkernel.py
@@ -152,11 +152,13 @@ class InProcessKernel(IPythonKernel):
 
     @default('stdout')
     def _default_stdout(self):
-        return OutStream(self.session, self.iopub_thread, 'stdout')
+        return OutStream(self.session, self.iopub_thread, 'stdout', 
+                         watchfd=False)
 
     @default('stderr')
     def _default_stderr(self):
-        return OutStream(self.session, self.iopub_thread, 'stderr')
+        return OutStream(self.session, self.iopub_thread, 'stderr', 
+                         watchfd=False)
 
 #-----------------------------------------------------------------------------
 # Interactive shell subclass


### PR DESCRIPTION
On some systems, the creation of OutStream instances to handle `stdout` and `stderr` triggers an exception when using the InProcessKernel. This is because the default keyword arguments creating the stream assume there is a file descriptor and calls `fileno`, which triggers an `io.UnsupportedOperation("fileno")` exception. The problem is new to v6. This PR adds `watchfd=False` to the default OutStreams for both `stdout` and `stderr` in the InProcessKernel. This fixes #724.