### PR TITLE
RFC: kernelapp: rename ports variable to avoid override

### DIFF
--- a/ipykernel/kernelapp.py
+++ b/ipykernel/kernelapp.py
@@ -129,7 +129,7 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp,
     iopub_thread = Any()
     control_thread = Any()
 
-    ports = Dict()
+    _ports = Dict()
 
     subcommands = {
         'install': (
@@ -390,7 +390,7 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp,
             for line in lines:
                 print(line, file=sys.__stdout__)
 
-        self.ports = dict(shell=self.shell_port, iopub=self.iopub_port,
+        self._ports = dict(shell=self.shell_port, iopub=self.iopub_port,
                                 stdin=self.stdin_port, hb=self.hb_port,
                                 control=self.control_port)
 
@@ -500,7 +500,7 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp,
                                 user_ns=self.user_ns,
         )
         kernel.record_ports({
-            name + '_port': port for name, port in self.ports.items()
+            name + '_port': port for name, port in self._ports.items()
         })
         self.kernel = kernel
 


### PR DESCRIPTION
As described in #730, it seems ConnectionFileMixin is expecting `ports` to be List[int].

https://github.com/jupyter/jupyter_client/blob/5742d84ca2162e21179d82e8b36e10baf0f8d978/jupyter_client/connect.py#L386

IPKernelApp is overriding such attribute and changing its type, which generates the error described.

This is the simplest fix I could come up with. Since I am not familiar with the project, please take this as a suggestion.

#Fixes 730

Signed-off-by: Adrian Moreno <amorenoz@redhat.com>