### PR TITLE
bump importlib-metadata limit for python<3.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -75,6 +75,7 @@ setup_args = dict(
     python_requires='>=3.7',
     install_requires=[
         'importlib-metadata<5;python_version<"3.8.0"',
+        'argcomplete>=1.12.3;python_version<"3.8.0"',
         'debugpy>=1.0.0,<2.0',
         'ipython>=7.23.1,<8.0',
         'traitlets>=4.1.0,<6.0',

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ setup_args = dict(
     keywords=['Interactive', 'Interpreter', 'Shell', 'Web'],
     python_requires='>=3.7',
     install_requires=[
-        'importlib-metadata<4;python_version<"3.8.0"',
+        'importlib-metadata<5;python_version<"3.8.0"',
         'debugpy>=1.0.0,<2.0',
         'ipython>=7.23.1,<8.0',
         'traitlets>=4.1.0,<6.0',


### PR DESCRIPTION
Related to #645

The importlib-metadata version was limited to <4 due to a corresponding restriction in the argcomplete package. 
The latest argcomplete patch release has bumped the limit to <5.

Note: ipykernel does not depend on argcomplete directly. 
I could also add an explicit dependency `argcomplete>=1.12.3` to select latest version if that is preferred