### PR TITLE
Add dependency on IPython genutils.

### DIFF
--- a/ipykernel/connect.py
+++ b/ipykernel/connect.py
@@ -7,7 +7,6 @@ import json
 import sys
 from subprocess import Popen, PIPE
 
-from ipython_genutils.path import filefind
 
 import jupyter_client
 from jupyter_client import write_connection_file
@@ -22,6 +21,7 @@ def get_connection_file(app=None):
     app : IPKernelApp instance [optional]
         If unspecified, the currently running app will be used
     """
+    from ipython_genutils.path import filefind
     if app is None:
         from ipykernel.kernelapp import IPKernelApp
         if not IPKernelApp.initialized():

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,7 @@ setup_args = dict(
     keywords=['Interactive', 'Interpreter', 'Shell', 'Web'],
     python_requires='>=3.7',
     install_requires=[
+        "ipython_genutils",
         'importlib-metadata<5;python_version<"3.8.0"',
         'argcomplete>=1.12.3;python_version<"3.8.0"',
         'debugpy>=1.0.0,<2.0',


### PR DESCRIPTION
this was an implicit dependency via IPython, which does not requires it
anymore and traitlets, which also does not requires it anymore since
today.

Closes #755