### PR TITLE
Update some warnings with instructions and version number.

### DIFF
--- a/ipykernel/iostream.py
+++ b/ipykernel/iostream.py
@@ -252,8 +252,13 @@ class BackgroundSocket(object):
             # don't wrap magic methods
             super(BackgroundSocket, self).__getattr__(attr)
         if hasattr(self.io_thread.socket, attr):
-            warnings.warn("Accessing zmq Socket attribute %s on BackgroundSocket" % attr,
-                DeprecationWarning, stacklevel=2)
+            warnings.warn(
+                "Accessing zmq Socket attribute {attr} on BackgroundSocket"
+                " is deprecated since ipykernel 4.3.0"
+                " use .io_thread.socket.{attr}".format(attr=attr),
+                DeprecationWarning,
+                stacklevel=2,
+            )
             return getattr(self.io_thread.socket, attr)
         super(BackgroundSocket, self).__getattr__(attr)
 
@@ -261,8 +266,13 @@ class BackgroundSocket(object):
         if attr == 'io_thread' or (attr.startswith('__' and attr.endswith('__'))):
             super(BackgroundSocket, self).__setattr__(attr, value)
         else:
-            warnings.warn("Setting zmq Socket attribute %s on BackgroundSocket" % attr,
-                DeprecationWarning, stacklevel=2)
+            warnings.warn(
+                "Setting zmq Socket attribute {attr} on BackgroundSocket"
+                " is deprecated since ipykernel 4.3.0"
+                " use .io_thread.socket.{attr}".format(attr=attr),
+                DeprecationWarning,
+                stacklevel=2,
+            )
             setattr(self.io_thread.socket, attr, value)
 
     def send(self, msg, *args, **kwargs):


### PR DESCRIPTION
I came across this when trying to reproduce an unrelated bug with
someone in an outdated environment, but at least having the version
number will make us more confident when e remove the conditional branch
later.