### PR TITLE
Stop using deprecated recv_multipart when using in-process socket.

### DIFF
--- a/ipykernel/inprocess/ipkernel.py
+++ b/ipykernel/inprocess/ipkernel.py
@@ -131,7 +131,7 @@ class InProcessKernel(IPythonKernel):
     def _io_dispatch(self, change):
         """ Called when a message is sent to the IO socket.
         """
-        ident, msg = self.session.recv(self.iopub_socket, copy=False)
+        ident, msg = self.session.recv(self.iopub_socket.io_thread.socket, copy=False)
         for frontend in self.frontends:
             frontend.iopub_channel.call_handlers(msg)
 


### PR DESCRIPTION
Found while working on https://github.com/napari/napari/issues/3314

I'm not too sure this is the right fix, as BackgroundSocket is used only
in inprocess kernel, and that in general io_pub socket looks like the
can be `Any()` and that therefore may not have a io_thread.

But if that's the case, then should we maybe un-deprecate recv_multipart on background socket ?

the recv in jupyter_client side (which is called by the line I change
here) is

    def recv(self, socket, mode=zmq.NOBLOCK, content=True, copy=True):
        """Receive and unpack a message.

        Parameters
        ----------
        socket : ZMQStream or Socket
            The socket or stream to use in receiving.

        Returns
        -------
        [idents], msg
            [idents] is a list of idents and msg is a nested message dict of
            same format as self.msg returns.
        """
        if isinstance(socket, ZMQStream):
            socket = socket.socket
        try:
            msg_list = socket.recv_multipart(mode, copy=copy) # this will trigger deprecation warning
        except zmq.ZMQError as e:
            ...

And I doubt we want to make that aware of background socket.