### PR TITLE
Don't assume kernels have loops.

### DIFF
--- a/ipykernel/zmqshell.py
+++ b/ipykernel/zmqshell.py
@@ -464,8 +464,9 @@ class ZMQInteractiveShell(InteractiveShell):
     def _update_exit_now(self, change):
         """stop eventloop when exit_now fires"""
         if change['new']:
-            loop = self.kernel.io_loop
-            loop.call_later(0.1, loop.stop)
+            if hasattr(self.kernel, 'io_loop'):
+                loop = self.kernel.io_loop
+                loop.call_later(0.1, loop.stop)
             if self.kernel.eventloop:
                 exit_hook = getattr(self.kernel.eventloop, 'exit_hook', None)
                 if exit_hook:


### PR DESCRIPTION
In particular the in-process kernels don't.

This does not fix all the issues in particular the quit() and exit()
autocaller that become no-op, but that's another story