### PR TITLE
Make ipykernel work without debugpy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,3 +110,44 @@ jobs:
     - name: Check Docstrings
       run: |
         velin . --check --compact
+  test_without_debugpy:
+    runs-on: ${{ matrix.os }}-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu]
+        python-version: [ '3.9' ]
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v1
+    - name: Install Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+        architecture: 'x64'
+    - name: Upgrade packaging dependencies
+      run: |
+        pip install --upgrade pip setuptools wheel --user
+    - name: Get pip cache dir
+      id: pip-cache
+      run: |
+        echo "::set-output name=dir::$(pip cache dir)"
+    - name: Cache pip
+      uses: actions/cache@v1
+      with:
+        path: ${{ steps.pip-cache.outputs.dir }}
+        key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('setup.py') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-${{ matrix.python-version }}-
+          ${{ runner.os }}-pip-
+    - name: Install the Python dependencies without debugpy
+      run: |
+        pip install --pre --upgrade --upgrade-strategy=eager .[test]
+        pip uninstall --yes debugpy
+    - name: List installed packages
+      run: |
+        pip freeze
+    - name: Run the tests
+      timeout-minutes: 10
+      run: |
+        pytest ipykernel -vv -s --durations 10

--- a/ipykernel/kernelspec.py
+++ b/ipykernel/kernelspec.py
@@ -13,6 +13,8 @@ import tempfile
 
 from jupyter_client.kernelspec import KernelSpecManager
 
+from .ipkernel import _is_debugpy_available
+
 pjoin = os.path.join
 
 KERNEL_NAME = 'python%i' % sys.version_info[0]
@@ -52,7 +54,7 @@ def get_kernel_dict(extra_arguments=None):
         'argv': make_ipkernel_cmd(extra_arguments=extra_arguments),
         'display_name': 'Python %i (ipykernel)' % sys.version_info[0],
         'language': 'python',
-        'metadata': { 'debugger': True}
+        'metadata': { 'debugger': _is_debugpy_available}
     }
 
 


### PR DESCRIPTION
debugpy is an optional dependency because only frontends with
debugging support (Jupyter lab) can really use its features.

Fixes: https://github.com/ipython/ipykernel/issues/712

There is also one new test in the CI to check that all tests are passing when debugpy is not installed.