### PR TITLE
debugpy is now a build requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ build-backend = "setuptools.build_meta"
 requires=[
   "setuptools",
   "wheel",
+  "debugpy",
   "ipython>=5",
   "jupyter_core>=4.2",
   "jupyter_client",


### PR DESCRIPTION
to get the right debugger metadata in the wheel kernelspec

due to the runtime check added [here](https://github.com/ipython/ipykernel/pull/767/files#diff-c4f6702e977e08e5d1aee47d489ef372ff37913e7e282dbaf269d050f58d56a7R57). The wheel kernelspec currently has an inaccurate `debugger: false` in its metadata, so should probably do a 6.4.1

closes #770