### PR TITLE
Remove setting of the eventloop function in the InProcessKernel

### DIFF
--- a/ipykernel/inprocess/ipkernel.py
+++ b/ipykernel/inprocess/ipkernel.py
@@ -175,12 +175,9 @@ class InProcessInteractiveShell(ZMQInteractiveShell):
 
     def enable_gui(self, gui=None):
         """Enable GUI integration for the kernel."""
-        from ipykernel.eventloops import enable_gui
         if not gui:
             gui = self.kernel.gui
-        enable_gui(gui, kernel=self.kernel)
         self.active_eventloop = gui
-
 
     def enable_matplotlib(self, gui=None):
         """Enable matplotlib integration for the kernel."""


### PR DESCRIPTION
The `enable_gui` function of the InProcessInteractiveShell calls a function of the same name in 'eventloops.py', which sets `kernel.eventloop` to a function defined by the requested GUI. For the InProcessKernel, `kernel.eventloop` should always be set to `None`. Otherwise, commands typed in the shell trigger a call to the parent kernel class's `enter_eventloop` function, which causes an exception because attributes like `io_loop` and `msg_queue` are not defined by the InProcessKernel.

This PR removes the call to the `enable_gui` function in 'eventloops.py' since the Qt event loop should already be running in the InProcessKernel.

This is designed to fix #780 and is possibly related to #775 and #319.