### PR TITLE
Add python version classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -89,6 +89,9 @@ setup_args = dict(
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9'
     ],
 )
 


### PR DESCRIPTION
Expand classifiers list to specify capability with python versions 3.7, 3.8, and 3.9