### PR TITLE
Clean up QTimer/QSocketNotifier when exiting Qt event loop

### DIFF
--- a/ipykernel/eventloops.py
+++ b/ipykernel/eventloops.py
@@ -39,6 +39,7 @@ def _notify_stream_qt(kernel, stream):
     fd = stream.getsockopt(zmq.FD)
     notifier = QtCore.QSocketNotifier(fd, QtCore.QSocketNotifier.Read, kernel.app)
     notifier.activated.connect(process_stream_events)
+    notifier.activated.connect(notifier.deleteLater)
     # there may already be unprocessed events waiting.
     # these events will not wake zmq's edge-triggered FD
     # since edge-triggered notification only occurs on new i/o activity.
@@ -49,6 +50,7 @@ def _notify_stream_qt(kernel, stream):
     timer = QtCore.QTimer(kernel.app)
     timer.setSingleShot(True)
     timer.timeout.connect(process_stream_events)
+    timer.timeout.connect(timer.deleteLater)
     timer.start(0)
 
 # mapping of keys to loop functions


### PR DESCRIPTION
The ``QTimer`` and ``QSocketNotifier`` helper objects, created by the ``_notify_stream_qt()`` function as child objects of the global ``QApplication``, need to be discarded after use when leaving the Qt event loop. Otherwise they keep piling up with each roundtrip between the Qt and the kernel event loop. This code change makes sure that these Qt objects destroy themselves at an appropriate time.