### PR TITLE
Do not call setQuitOnLastWindowClosed() on a QCoreApplication

### DIFF
--- a/ipykernel/eventloops.py
+++ b/ipykernel/eventloops.py
@@ -111,9 +111,11 @@ def loop_qt4(kernel):
     """Start a kernel with PyQt4 event loop integration."""
 
     from IPython.lib.guisupport import get_app_qt4
+    from IPython.external.qt_for_kernel import QtGui
 
     kernel.app = get_app_qt4([" "])
-    kernel.app.setQuitOnLastWindowClosed(False)
+    if isinstance(kernel.app, QtGui.QApplication):
+        kernel.app.setQuitOnLastWindowClosed(False)
     _notify_stream_qt(kernel, kernel.shell_stream)
 
     _loop_qt(kernel.app)


### PR DESCRIPTION
Fixes the following error.

Notebook cell:
```python
%gui qt
from PyQt5 import QtCore
app = QtCore.QCoreApplication([''])
```
Kernel error:
```
Traceback (most recent call last):
  File "c:\users\astuk\appdata\local\programs\python\python38\lib\site-packages\tornado\ioloop.py", line 741, in _run_callback
    ret = callback()
  File "c:\users\astuk\appdata\local\programs\python\python38\lib\site-packages\ipykernel\kernelbase.py", line 402, in advance_eventloop
    eventloop(self)
  File "c:\users\astuk\appdata\local\programs\python\python38\lib\site-packages\ipykernel\eventloops.py", line 130, in loop_qt5
    return loop_qt4(kernel)
  File "c:\users\astuk\appdata\local\programs\python\python38\lib\site-packages\ipykernel\eventloops.py", line 120, in loop_qt4
    kernel.app.setQuitOnLastWindowClosed(False)
AttributeError: 'QCoreApplication' object has no attribute 'setQuitOnLastWindowClosed'
```

[loop_qt4()](https://github.com/ipython/ipykernel/blob/fdda069bba36cafcc25df4d2353b26fbdb9e4d15/ipykernel/eventloops.py#L110) currently expects the [get_app_qt4()](https://github.com/ipython/ipython/blob/967787ca35ad3e8731a34c26013ae32f875804a6/IPython/lib/guisupport.py#L112) function to always return a ``QApplication`` object (or a ``QGuiApplication`` in Qt5). This is not a valid assumption. The user may be creating just a ``QCoreApplication`` base class instance to run Qt event processing in the backend, never displaying any Qt windows/widgets. Non-UI Qt applications do not support the [setQuitOnLastWindowClosed()](https://doc.qt.io/qt-5/qguiapplication.html#quitOnLastWindowClosed-prop) method.