### PR TITLE
Unpin IPython, and remove some dependencies on it.

### DIFF
--- a/ipykernel/inprocess/tests/test_kernel.py
+++ b/ipykernel/inprocess/tests/test_kernel.py
@@ -13,8 +13,8 @@ from ipykernel.inprocess.blocking import BlockingInProcessKernelClient
 from ipykernel.inprocess.manager import InProcessKernelManager
 from ipykernel.inprocess.ipkernel import InProcessKernel
 from ipykernel.tests.utils import assemble_output
-from IPython.testing.decorators import skipif_not_matplotlib
 from IPython.utils.io import capture_output
+
 
 
 def _init_asyncio_patch():
@@ -60,9 +60,9 @@ class InProcessKernelTestCase(unittest.TestCase):
         self.kc.start_channels()
         self.kc.wait_for_ready()
 
-    @skipif_not_matplotlib
     def test_pylab(self):
         """Does %pylab work in the in-process kernel?"""
+        matplotlib = pytest.importorskip('matplotlib', reason='This test requires matplotlib')
         kc = self.kc
         kc.execute('%pylab')
         out, err = assemble_output(kc.get_iopub_msg)

--- a/ipykernel/tests/test_kernel.py
+++ b/ipykernel/tests/test_kernel.py
@@ -14,7 +14,7 @@ from flaky import flaky
 import pytest
 from packaging import version
 
-from IPython.testing import decorators as dec, tools as tt
+from IPython.testing import tools as tt
 import IPython
 from IPython.paths import locate_profile
 
@@ -225,8 +225,8 @@ def test_save_history():
         assert 'b="abcþ"' in content
 
 
-@dec.skip_without('faulthandler')
 def test_smoke_faulthandler():
+    faulthadler = pytest.importorskip('faulthandler', reason='this test needs faulthandler')
     with kernel() as kc:
         # Note: faulthandler.register is not available on windows.
         code = '\n'.join([
@@ -296,8 +296,8 @@ def test_complete():
         assert completed.startswith(cell)
 
 
-@dec.skip_without('matplotlib')
 def test_matplotlib_inline_on_import():
+    pytest.importorskip('matplotlib', reason='this test requires matplotlib')
     with kernel() as kc:
         cell = '\n'.join([
             'import matplotlib, matplotlib.pyplot as plt',

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setup_args = dict(
         'importlib-metadata<5;python_version<"3.8.0"',
         'argcomplete>=1.12.3;python_version<"3.8.0"',
         'debugpy>=1.0.0,<2.0',
-        'ipython>=7.23.1,<8.0',
+        'ipython>=7.23.1',
         'traitlets>=5.1.0,<6.0',
         'jupyter_client<8.0',
         'tornado>=4.2,<7.0',


### PR DESCRIPTION
This makes it annoying to test whether IPython breaks IPykernel.
I'm almost always on IPython master branch and I'd like to know when/if
I break things.

Prompted by https://github.com/ipython/ipython/pull/13252,
which is not breaking ipykernel, but it's better to decouple where we
can.