### PR TITLE
Send omit_sections to IPython to choose which sections of documentation you don't want

### DIFF
--- a/ipykernel/ipkernel.py
+++ b/ipykernel/ipkernel.py
@@ -5,7 +5,6 @@ import builtins
 from contextlib import contextmanager
 from functools import partial
 import getpass
-import re
 import signal
 import sys
 

--- a/ipykernel/ipkernel.py
+++ b/ipykernel/ipkernel.py
@@ -459,7 +459,7 @@ class IPythonKernel(KernelBase):
                 'metadata': {_EXPERIMENTAL_KEY_NAME: comps},
                 'status': 'ok'}
 
-    def do_inspect(self, code, cursor_pos, detail_level=0):
+    def do_inspect(self, code, cursor_pos, detail_level=0, omit_sections=()):
         name = token_at_cursor(code, cursor_pos)
 
         reply_content = {'status' : 'ok'}
@@ -469,7 +469,8 @@ class IPythonKernel(KernelBase):
             reply_content['data'].update(
                 self.shell.object_inspect_mime(
                     name,
-                    detail_level=detail_level
+                    detail_level=detail_level,
+                    omit_sections=omit_sections,
                 )
             )
             if not self.shell.enable_html_pager:

--- a/ipykernel/ipkernel.py
+++ b/ipykernel/ipkernel.py
@@ -5,6 +5,7 @@ import builtins
 from contextlib import contextmanager
 from functools import partial
 import getpass
+import re
 import signal
 import sys
 
@@ -466,13 +467,20 @@ class IPythonKernel(KernelBase):
         reply_content['data'] = {}
         reply_content['metadata'] = {}
         try:
-            reply_content['data'].update(
-                self.shell.object_inspect_mime(
+            if release.version_info >= (8,):
+                # `omit_sections` keyword will be available in IPython 8, see
+                # https://github.com/ipython/ipython/pull/13343
+                bundle = self.shell.object_inspect_mime(
                     name,
                     detail_level=detail_level,
                     omit_sections=omit_sections,
                 )
-            )
+            else:
+                bundle = self.shell.object_inspect_mime(
+                    name,
+                    detail_level=detail_level
+                )
+            reply_content['data'].update(bundle)
             if not self.shell.enable_html_pager:
                 reply_content['data'].pop('text/html')
             reply_content['found'] = True

--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -702,6 +702,7 @@ class Kernel(SingletonConfigurable):
         reply_content = self.do_inspect(
             content['code'], content['cursor_pos'],
             content.get('detail_level', 0),
+            set(content.get('omit_sections', [])),
         )
         if inspect.isawaitable(reply_content):
             reply_content = await reply_content
@@ -712,7 +713,7 @@ class Kernel(SingletonConfigurable):
                                 reply_content, parent, ident)
         self.log.debug("%s", msg)
 
-    def do_inspect(self, code, cursor_pos, detail_level=0):
+    def do_inspect(self, code, cursor_pos, detail_level=0, omit_sections=()):
         """Override in subclasses to allow introspection.
         """
         return {'status': 'ok', 'data': {}, 'metadata': {}, 'found': False}


### PR DESCRIPTION
This PR brings to ipykernel a recent IPython PR https://github.com/ipython/ipython/pull/13343 which allows us to customize IPython's responses to `info` and `inspect` messages by specifying which documentation sections we *don't* want. For example, `numpy.sin` returns the following sections:
- Call signature
- Type
- String form
- File
- Docstring
- Class docstring

and with the new `omit_sections` keyword argument, we can for example specify that we are not interested in the `File`, `String form`, and `Type` sections, thereby saving runtime and bandwidth by not generating those documentation sections.

In this present PR, we enable ipykernel's `inspect` message to take advantage of `omit_sections`. If the client provides `omit_sections` in its request, we'll pass it on to IPython.

**Nota bene** if merged, this PR should be released with an ipykernel that depends on IPython 8.0, the milestone @Carreau has set in https://github.com/ipython/ipython/pull/13343.

---

To test this using JupyterLab for example:
1. install ipython master
2. install this PR's branch of ipykernel (https://github.com/fasiha/ipykernel/tree/blocklist-for-inspector)
3. install https://github.com/fasiha/jupyterlab/tree/use-omit_sections branch of jupyterlab and start it: this branch has [configured](https://github.com/fasiha/jupyterlab/blob/6c20cefe215f28f54ad8d9b1405c544773fce2aa/packages/inspector/src/kernelconnector.ts#L45) its inspector to omit all sections except docstrings
4. run the following in a notebook cell:
```py
import numpy
numpy.sin
numpy.exp
```
5. open JupyterLab's contextual help menu and click on "exp" and "sin", etc.

Original ipykernel:

<img width="1365" alt="Screen Shot 2021-11-26 at 7 19 14 PM" src="https://user-images.githubusercontent.com/37649/143666387-6454567e-70df-4191-86fc-a96a15574e3e.png">

This PR with customized JupyterLab to omit numerous sections:

<img width="1365" alt="Screen Shot 2021-11-26 at 7 19 48 PM" src="https://user-images.githubusercontent.com/37649/143666591-c8431dd1-fea7-48d6-8799-ae201fe5cc4c.png">

---

Recommended triage: `enhancement`?