### PR TITLE
Set debugOptions for breakpoints in python standard library source

### DIFF
--- a/ipykernel/debugger.py
+++ b/ipykernel/debugger.py
@@ -462,6 +462,8 @@ class Debugger:
             'port': port
         }
         message['arguments']['logToFile'] = True
+        # Set debugOptions for breakpoints in python standard library source.
+        message['arguments']['debugOptions'] = [ 'DebugStdLib' ]
         return await self._forward_message(message)
 
     async def configurationDone(self, message):


### PR DESCRIPTION
Users need to be able to add breakpoints in python standard library source.

For this, the needed flag `DebugStdLib` needs to be added in the `debugOptions` when attaching the debug session.
