### PR TITLE
Added missing excpeionPaths field to debugInfo reply

### DIFF
--- a/ipykernel/debugger.py
+++ b/ipykernel/debugger.py
@@ -496,7 +496,8 @@ class Debugger:
                 'tmpFileSuffix': '.py',
                 'breakpoints': breakpoint_list,
                 'stoppedThreads': self.stopped_threads,
-                'richRendering': True
+                'richRendering': True,
+                'exceptionPaths': ['Python Exceptions']
             }
         }
         return reply


### PR DESCRIPTION
This field is now mandatory in the [Jupyter Kernel Protocol](https://jupyter-client.readthedocs.io/en/stable/messaging.html#additions-to-the-dap) and is required in order to move https://github.com/jupyterlab/jupyterlab/pull/10298 forward.