### PR TITLE
RF: Handle both asyncio.QueueEmpty and tornado.queues.QueueEmpty

### DIFF
--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -25,7 +25,7 @@ except ImportError:
     now = datetime.now
 
 from tornado import ioloop
-from tornado.queues import Queue
+from tornado.queues import Queue, QueueEmpty
 import zmq
 from zmq.eventloop.zmqstream import ZMQStream
 
@@ -441,7 +441,7 @@ class Kernel(SingletonConfigurable):
         else:
             try:
                 t, dispatch, args = self.msg_queue.get_nowait()
-            except asyncio.QueueEmpty:
+            except (asyncio.QueueEmpty, QueueEmpty):
                 return None
         await dispatch(*args)
 


### PR DESCRIPTION
Howdy, I just came across the error reported in #763. I believe that the fix is trivial. My guess is that using an ioloop from either `tornado` or `ioloop` is possible (or is a future possibility), so both exception types should be catered for.

Thanks!


