### PR TITLE
Clean up workflows

### DIFF
--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -14,42 +14,23 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Install Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.9
-          architecture: "x64"
-      - name: Get pip cache dir
-        id: pip-cache
-        run: |
-          echo "::set-output name=dir::$(pip cache dir)"
-      - name: Cache pip
-        uses: actions/cache@v2
-        with:
-          path: ${{ steps.pip-cache.outputs.dir }}
-          key: ${{ runner.os }}-pip-${{ hashFiles('setup.cfg') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-            ${{ runner.os }}-pip-
-      - name: Cache checked links
-        if: ${{ matrix.group == 'link_check' }}
-        uses: actions/cache@v2
-        with:
-          path: ~/.cache/pytest-link-check
-          key: ${{ runner.os }}-linkcheck-${{ hashFiles('**/*.md', '**/*.rst') }}-md-links
-          restore-keys: |
-            ${{ runner.os }}-linkcheck-
-      - name: Upgrade packaging dependencies
-        run: |
-          pip install --upgrade pip setuptools wheel --user
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Base Setup
+        uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+
       - name: Install Dependencies
         run: |
           pip install -e .
+
       - name: Check Release
         if: ${{ matrix.group == 'check_release' }}
         uses: jupyter-server/jupyter_releaser/.github/actions/check-release@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Run Link Check
         if: ${{ matrix.group == 'link_check' }}
         uses: jupyter-server/jupyter_releaser/.github/actions/check-links@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: ipykernel tests
 
-on: [push, pull_request]
+on:
+  push:
+    branches: "master"
+  pull_request:
+    branches: "*"
 
 jobs:
   build:
@@ -9,67 +13,59 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, macos, windows]
-        python-version: [ '3.7', '3.8', '3.9' ]
+        python-version: [ '3.7', '3.8', '3.9', '3.10',  'pypy-3.7' ]
         exclude:
         - os: windows
-          python-version: pypy3
+          python-version: pypy-3.7
     steps:
     - name: Checkout
-      uses: actions/checkout@v1
-    - name: Install Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
-      with:
-        python-version: ${{ matrix.python-version }}
-        architecture: 'x64'
-    - name: Upgrade packaging dependencies
-      run: |
-        pip install --upgrade pip setuptools wheel --user
-    - name: Get pip cache dir
-      id: pip-cache
-      run: |
-        echo "::set-output name=dir::$(pip cache dir)"
-    - name: Cache pip
-      uses: actions/cache@v1
-      with:
-        path: ${{ steps.pip-cache.outputs.dir }}
-        key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('setup.py') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-${{ matrix.python-version }}-
-          ${{ runner.os }}-pip-
+      uses: actions/checkout@v2
+
+    - name: Base Setup
+      uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+
     - name: Install the Python dependencies
       run: |
         pip install --pre --upgrade --upgrade-strategy=eager .[test] codecov
+
     - name: Install matplotlib
       if: ${{ matrix.os != 'macos' && matrix.python-version != 'pypy3' }}
       run: |
-        pip install matplotlib || echo 'failed to install matplolib'
+        pip install matplotlib || echo 'failed to install matplotlib'
+
     - name: Install alternate event loops
       if: ${{ matrix.os != 'windows' }}
       run: |
         pip install curio || echo 'ignoring curio install failure'
         pip install trio || echo 'ignoring trio install failure'
+
     - name: List installed packages
       run: |
         pip freeze
         pip check
+
     - name: Run the tests
       timeout-minutes: 10
       run: |
         pytest ipykernel -vv -s --cov ipykernel --cov-branch --cov-report term-missing:skip-covered --durations 10
+
     - name: Build the docs
       if: ${{ matrix.os == 'ubuntu' &&  matrix.python-version == '3.9'}}
       run: |
         cd docs
         pip install -r requirements.txt
         make html
+
     - name: Build and check the dist files
       run: |
         pip install build twine
         python -m build .
         twine check dist/*
+
     - name: Coverage
       run: |
         codecov
+
   check_docstrings:
     runs-on: ${{ matrix.os }}-latest
     strategy:
@@ -82,34 +78,20 @@ jobs:
           python-version: pypy3
     steps:
     - name: Checkout
-      uses: actions/checkout@v1
-    - name: Install Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
-      with:
-        python-version: ${{ matrix.python-version }}
-        architecture: 'x64'
-    - name: Upgrade packaging dependencies
-      run: |
-        pip install --upgrade pip setuptools wheel --user
-    - name: Get pip cache dir
-      id: pip-cache
-      run: |
-        echo "::set-output name=dir::$(pip cache dir)"
-    - name: Cache pip
-      uses: actions/cache@v1
-      with:
-        path: ${{ steps.pip-cache.outputs.dir }}
-        key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('setup.py') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-${{ matrix.python-version }}-
-          ${{ runner.os }}-pip-
+      uses: actions/checkout@v2
+
+    - name: Base Setup
+      uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+
     - name: Install the Python dependencies
       run: |
         pip install --pre --upgrade --upgrade-strategy=eager .
         pip install velin
+
     - name: Check Docstrings
       run: |
         velin . --check --compact
+
   test_without_debugpy:
     runs-on: ${{ matrix.os }}-latest
     strategy:
@@ -119,34 +101,20 @@ jobs:
         python-version: [ '3.9' ]
     steps:
     - name: Checkout
-      uses: actions/checkout@v1
-    - name: Install Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
-      with:
-        python-version: ${{ matrix.python-version }}
-        architecture: 'x64'
-    - name: Upgrade packaging dependencies
-      run: |
-        pip install --upgrade pip setuptools wheel --user
-    - name: Get pip cache dir
-      id: pip-cache
-      run: |
-        echo "::set-output name=dir::$(pip cache dir)"
-    - name: Cache pip
-      uses: actions/cache@v1
-      with:
-        path: ${{ steps.pip-cache.outputs.dir }}
-        key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('setup.py') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-${{ matrix.python-version }}-
-          ${{ runner.os }}-pip-
+      uses: actions/checkout@v2
+
+    - name: Base Setup
+      uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+
     - name: Install the Python dependencies without debugpy
       run: |
         pip install --pre --upgrade --upgrade-strategy=eager .[test]
         pip uninstall --yes debugpy
+
     - name: List installed packages
       run: |
         pip freeze
+
     - name: Run the tests
       timeout-minutes: 10
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,8 +46,17 @@ jobs:
 
     - name: Run the tests
       timeout-minutes: 10
+      if: ${{ !startsWith( matrix.python-version, 'pypy' ) }}
       run: |
         pytest ipykernel -vv -s --cov ipykernel --cov-branch --cov-report term-missing:skip-covered --durations 10
+
+              - name: Run the tests
+
+    - name: Run the tests on pypy
+      timeout-minutes: 15
+      if: ${{ startsWith( matrix.python-version, 'pypy' ) }}
+      run: |
+        pytest -vv ipykernel
 
     - name: Build the docs
       if: ${{ matrix.os == 'ubuntu' &&  matrix.python-version == '3.9'}}
@@ -55,12 +64,6 @@ jobs:
         cd docs
         pip install -r requirements.txt
         make html
-
-    - name: Build and check the dist files
-      run: |
-        pip install build twine
-        python -m build .
-        twine check dist/*
 
     - name: Coverage
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,8 +50,6 @@ jobs:
       run: |
         pytest ipykernel -vv -s --cov ipykernel --cov-branch --cov-report term-missing:skip-covered --durations 10
 
-              - name: Run the tests
-
     - name: Run the tests on pypy
       timeout-minutes: 15
       if: ${{ startsWith( matrix.python-version, 'pypy' ) }}

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -2,7 +2,7 @@ name: Test downstream projects
 
 on:
   push:
-    branches: "*"
+    branches: "master"
   pull_request:
     branches: "*"
 
@@ -14,34 +14,25 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Set up Python 3.9
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.9
-
-      - name: Install dependencies
-        run: |
-          pip install --upgrade pip
-          pip install pytest pytest-asyncio pytest-tornado
-          pip install nbclient[test]
-          pip install --pre -U --upgrade-strategy=only-if-needed nbclient
-          pip install ipyparallel[test]
-          pip install --pre -U --upgrade-strategy=only-if-needed ipyparallel
-          pip install jupyter_client[test]
-          pip install --pre -U --upgrade-strategy=only-if-needed jupyter_client
-          pip install . --force-reinstall
-          pip freeze
-          python -c 'import ipykernel; print("ipykernel", ipykernel.__version__)'
+      - name: Base Setup
+        uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
 
       - name: Test nbclient
-        if: ${{ always() }}
-        run: IPYKERNEL_CELL_NAME="<IPY-INPUT>" pytest --pyargs nbclient
+        uses: jupyterlab/maintainer-tools/.github/actions/downstream-test@v1
+        with:
+          package_name: nbclient
+          env_values: IPYKERNEL_CELL_NAME=\<IPY-INPUT\>
+
       - name: Test ipyparallel
-        if: ${{ always() }}
-        run: pytest --pyargs ipyparallel
+        uses: jupyterlab/maintainer-tools/.github/actions/downstream-test@v1
+        with:
+          package_name: ipyparallel
+
       - name: Test jupyter_client
-        if: ${{ always() }}
-        run: pytest --pyargs jupyter_client
+        uses: jupyterlab/maintainer-tools/.github/actions/downstream-test@v1
+        with:
+          package_name: jupyter_client
+
       - name: Test jupyter_kernel_test
         run: |
           git clone https://github.com/jupyter/jupyter_kernel_test.git

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -7,7 +7,7 @@ on:
     branches: "*"
 
 jobs:
-  tests:
+  downstream1:
     runs-on: ubuntu-latest
 
     steps:
@@ -23,15 +23,25 @@ jobs:
           package_name: nbclient
           env_values: IPYKERNEL_CELL_NAME=\<IPY-INPUT\>
 
-      - name: Test ipyparallel
-        uses: jupyterlab/maintainer-tools/.github/actions/downstream-test@v1
-        with:
-          package_name: ipyparallel
-
       - name: Test jupyter_client
         uses: jupyterlab/maintainer-tools/.github/actions/downstream-test@v1
         with:
           package_name: jupyter_client
+
+  downstream2:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Base Setup
+        uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+
+      - name: Test ipyparallel
+        uses: jupyterlab/maintainer-tools/.github/actions/downstream-test@v1
+        with:
+          package_name: ipyparallel
 
       - name: Test jupyter_kernel_test
         run: |

--- a/ipykernel/tests/test_kernel.py
+++ b/ipykernel/tests/test_kernel.py
@@ -6,6 +6,7 @@
 import ast
 import io
 import os.path
+import platform
 import subprocess
 import sys
 import time
@@ -367,6 +368,10 @@ def test_unc_paths():
         assert reply['content']['status'] == 'ok'
 
 
+@pytest.mark.skipif(
+    platform.python_implementation() == "PyPy",
+    reason="does not work on PyPy",
+)
 def test_shutdown():
     """Kernel exits after polite shutdown_request"""
     with new_kernel() as kc:

--- a/ipykernel/tests/utils.py
+++ b/ipykernel/tests/utils.py
@@ -5,6 +5,7 @@
 
 import atexit
 import os
+import platform
 import sys
 from tempfile import TemporaryDirectory
 from time import time
@@ -17,7 +18,7 @@ from jupyter_client import manager
 
 
 STARTUP_TIMEOUT = 60
-TIMEOUT = 60
+TIMEOUT = 100
 
 KM = None
 KC = None


### PR DESCRIPTION
- Use `base-setup` and `downstream-test` actions from `jupyterlab/maintainer-tools` to clean up the workflows.
- Add testing for Python 3.10 and pypy