### PR TITLE
Clean python 2 artifacts. Fix #826

### DIFF
--- a/examples/embedding/internal_ipkernel.py
+++ b/examples/embedding/internal_ipkernel.py
@@ -20,7 +20,7 @@ def mpl_kernel(gui):
     return kernel
 
 
-class InternalIPKernel(object):
+class InternalIPKernel:
 
     def init_ipkernel(self, backend):
         # Start IPython kernel with GUI event loop and mpl support

--- a/ipykernel/comm/comm.py
+++ b/ipykernel/comm/comm.py
@@ -50,7 +50,7 @@ class Comm(LoggingConfigurable):
     def __init__(self, target_name='', data=None, metadata=None, buffers=None, **kwargs):
         if target_name:
             kwargs['target_name'] = target_name
-        super(Comm, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         if self.kernel:
             if self.primary:
                 # I am primary, open my peer.

--- a/ipykernel/compiler.py
+++ b/ipykernel/compiler.py
@@ -59,7 +59,7 @@ def get_file_name(code):
 class XCachingCompiler(CachingCompiler):
 
     def __init__(self, *args, **kwargs):
-        super(XCachingCompiler, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.log = None
 
     def get_code_name(self, raw_code, code, number):

--- a/ipykernel/debugger.py
+++ b/ipykernel/debugger.py
@@ -540,7 +540,7 @@ class Debugger:
         else:
             # The code has stopped on a breakpoint, we use the setExpression
             # request to get the rich representation of the variable
-            code = "get_ipython().display_formatter.format(" + var_name + ")"
+            code = f"get_ipython().display_formatter.format({var_name})"
             frame_id = message["arguments"]["frameId"]
             seq = message["seq"]
             reply = await self._forward_message(

--- a/ipykernel/displayhook.py
+++ b/ipykernel/displayhook.py
@@ -12,7 +12,7 @@ from traitlets import Instance, Dict, Any
 from jupyter_client.session import extract_header, Session
 
 
-class ZMQDisplayHook(object):
+class ZMQDisplayHook:
     """A simple displayhook that publishes the object's repr over a ZeroMQ
     socket."""
     topic = b'execute_result'

--- a/ipykernel/eventloops.py
+++ b/ipykernel/eventloops.py
@@ -229,7 +229,7 @@ def loop_tk(kernel):
     # file handlers are not available on Windows
     if hasattr(app, 'createfilehandler'):
         # A basic wrapper for structural similarity with the Windows version
-        class BasicAppWrapper(object):
+        class BasicAppWrapper:
             def __init__(self, app):
                 self.app = app
                 self.app.withdraw()
@@ -257,7 +257,7 @@ def loop_tk(kernel):
         # Tk uses milliseconds
         poll_interval = int(1000 * kernel._poll_interval)
 
-        class TimedAppWrapper(object):
+        class TimedAppWrapper:
             def __init__(self, app, func):
                 self.app = app
                 self.app.withdraw()

--- a/ipykernel/gui/gtk3embed.py
+++ b/ipykernel/gui/gtk3embed.py
@@ -23,7 +23,7 @@ from gi.repository import GObject, Gtk
 # Classes and functions
 #-----------------------------------------------------------------------------
 
-class GTKEmbed(object):
+class GTKEmbed:
     """A class to embed a kernel into the GTK main event loop.
     """
     def __init__(self, kernel):

--- a/ipykernel/gui/gtkembed.py
+++ b/ipykernel/gui/gtkembed.py
@@ -21,7 +21,7 @@ import gtk
 # Classes and functions
 #-----------------------------------------------------------------------------
 
-class GTKEmbed(object):
+class GTKEmbed:
     """A class to embed a kernel into the GTK main event loop.
     """
     def __init__(self, kernel):

--- a/ipykernel/inprocess/blocking.py
+++ b/ipykernel/inprocess/blocking.py
@@ -23,7 +23,7 @@ from .client import InProcessKernelClient
 class BlockingInProcessChannel(InProcessChannel):
 
     def __init__(self, *args, **kwds):
-        super(BlockingInProcessChannel, self).__init__(*args, **kwds)
+        super().__init__(*args, **kwds)
         self._in_queue = Queue()
 
     def call_handlers(self, msg):

--- a/ipykernel/inprocess/channels.py
+++ b/ipykernel/inprocess/channels.py
@@ -9,12 +9,12 @@ from jupyter_client.channelsabc import HBChannelABC
 # Channel classes
 #-----------------------------------------------------------------------------
 
-class InProcessChannel(object):
+class InProcessChannel:
     """Base class for in-process channels."""
     proxy_methods = []
 
     def __init__(self, client=None):
-        super(InProcessChannel, self).__init__()
+        super().__init__()
         self.client = client
         self._is_alive = False
 
@@ -57,7 +57,7 @@ class InProcessChannel(object):
 
 
 
-class InProcessHBChannel(object):
+class InProcessHBChannel:
     """A dummy heartbeat channel interface for in-process kernels.
 
     Normally we use the heartbeat to check that the kernel process is alive.
@@ -68,7 +68,7 @@ class InProcessHBChannel(object):
     time_to_dead = 3.0
 
     def __init__(self, client=None):
-        super(InProcessHBChannel, self).__init__()
+        super().__init__()
         self.client = client
         self._is_alive = False
         self._pause = True

--- a/ipykernel/inprocess/client.py
+++ b/ipykernel/inprocess/client.py
@@ -58,12 +58,12 @@ class InProcessKernelClient(KernelClient):
         return BlockingInProcessKernelClient
 
     def get_connection_info(self):
-        d = super(InProcessKernelClient, self).get_connection_info()
+        d = super().get_connection_info()
         d['kernel'] = self.kernel
         return d
 
     def start_channels(self, *args, **kwargs):
-        super(InProcessKernelClient, self).start_channels()
+        super().start_channels()
         self.kernel.frontends.append(self)
 
     @property

--- a/ipykernel/inprocess/ipkernel.py
+++ b/ipykernel/inprocess/ipkernel.py
@@ -69,7 +69,7 @@ class InProcessKernel(IPythonKernel):
     stdin_socket = Instance(DummySocket, ())
 
     def __init__(self, **traits):
-        super(InProcessKernel, self).__init__(**traits)
+        super().__init__(**traits)
 
         self._underlying_iopub_socket.observe(self._io_dispatch, names=['message_sent'])
         self.shell.kernel = self
@@ -77,7 +77,7 @@ class InProcessKernel(IPythonKernel):
     async def execute_request(self, stream, ident, parent):
         """ Override for temporary IO redirection. """
         with self._redirected_io():
-            await super(InProcessKernel, self).execute_request(stream, ident, parent)
+            await super().execute_request(stream, ident, parent)
 
     def start(self):
         """ Override registration of dispatchers for streams. """
@@ -106,7 +106,7 @@ class InProcessKernel(IPythonKernel):
                 break
         else:
             logging.error('No frontend found for raw_input request')
-            return str()
+            return ''
 
         # Await a response.
         while self.raw_input_str is None:
@@ -183,13 +183,13 @@ class InProcessInteractiveShell(ZMQInteractiveShell):
         """Enable matplotlib integration for the kernel."""
         if not gui:
             gui = self.kernel.gui
-        return super(InProcessInteractiveShell, self).enable_matplotlib(gui)
+        return super().enable_matplotlib(gui)
 
     def enable_pylab(self, gui=None, import_all=True, welcome_message=False):
         """Activate pylab support at runtime."""
         if not gui:
             gui = self.kernel.gui
-        return super(InProcessInteractiveShell, self).enable_pylab(gui, import_all,
+        return super().enable_pylab(gui, import_all,
                                                             welcome_message)
 
 InteractiveShellABC.register(InProcessInteractiveShell)

--- a/ipykernel/inprocess/manager.py
+++ b/ipykernel/inprocess/manager.py
@@ -71,7 +71,7 @@ class InProcessKernelManager(KernelManager):
 
     def client(self, **kwargs):
         kwargs['kernel'] = self.kernel
-        return super(InProcessKernelManager, self).client(**kwargs)
+        return super().client(**kwargs)
 
 
 #-----------------------------------------------------------------------------

--- a/ipykernel/iostream.py
+++ b/ipykernel/iostream.py
@@ -253,9 +253,9 @@ class BackgroundSocket:
             super().__getattr__(attr)
         if hasattr(self.io_thread.socket, attr):
             warnings.warn(
-                "Accessing zmq Socket attribute {attr} on BackgroundSocket"
-                " is deprecated since ipykernel 4.3.0"
-                " use .io_thread.socket.{attr}".format(attr=attr),
+                f"Accessing zmq Socket attribute {attr} on BackgroundSocket"
+                f" is deprecated since ipykernel 4.3.0"
+                f" use .io_thread.socket.{attr}",
                 DeprecationWarning,
                 stacklevel=2,
             )
@@ -267,9 +267,9 @@ class BackgroundSocket:
             super().__setattr__(attr, value)
         else:
             warnings.warn(
-                "Setting zmq Socket attribute {attr} on BackgroundSocket"
-                " is deprecated since ipykernel 4.3.0"
-                " use .io_thread.socket.{attr}".format(attr=attr),
+                f"Setting zmq Socket attribute {attr} on BackgroundSocket"
+                f" is deprecated since ipykernel 4.3.0"
+                f" use .io_thread.socket.{attr}",
                 DeprecationWarning,
                 stacklevel=2,
             )

--- a/ipykernel/iostream.py
+++ b/ipykernel/iostream.py
@@ -39,7 +39,7 @@ CHILD = 1
 #-----------------------------------------------------------------------------
 
 
-class IOPubThread(object):
+class IOPubThread:
     """An object for sending IOPub messages in a background thread
 
     Prevents a blocking main thread from delaying output from threads.
@@ -239,7 +239,7 @@ class IOPubThread(object):
             ctx.term()
 
 
-class BackgroundSocket(object):
+class BackgroundSocket:
     """Wrapper around IOPub thread that provides zmq send[_multipart]"""
     io_thread = None
 
@@ -250,7 +250,7 @@ class BackgroundSocket(object):
         """Wrap socket attr access for backward-compatibility"""
         if attr.startswith('__') and attr.endswith('__'):
             # don't wrap magic methods
-            super(BackgroundSocket, self).__getattr__(attr)
+            super().__getattr__(attr)
         if hasattr(self.io_thread.socket, attr):
             warnings.warn(
                 "Accessing zmq Socket attribute {attr} on BackgroundSocket"
@@ -260,11 +260,11 @@ class BackgroundSocket(object):
                 stacklevel=2,
             )
             return getattr(self.io_thread.socket, attr)
-        super(BackgroundSocket, self).__getattr__(attr)
+        super().__getattr__(attr)
 
     def __setattr__(self, attr, value):
         if attr == 'io_thread' or (attr.startswith('__' and attr.endswith('__'))):
-            super(BackgroundSocket, self).__setattr__(attr, value)
+            super().__setattr__(attr, value)
         else:
             warnings.warn(
                 "Setting zmq Socket attribute {attr} on BackgroundSocket"
@@ -484,7 +484,7 @@ class OutStream(TextIOBase):
                 self.echo.flush()
             except OSError as e:
                 if self.echo is not sys.__stderr__:
-                    print("Flush failed: {}".format(e),
+                    print(f"Flush failed: {e}",
                           file=sys.__stderr__)
 
         data = self._flush_buffer()
@@ -517,7 +517,7 @@ class OutStream(TextIOBase):
                 self.echo.write(string)
             except OSError as e:
                 if self.echo is not sys.__stderr__:
-                    print("Write failed: {}".format(e),
+                    print(f"Write failed: {e}",
                           file=sys.__stderr__)
 
         if self.pub_thread is None:

--- a/ipykernel/ipkernel.py
+++ b/ipykernel/ipkernel.py
@@ -75,7 +75,7 @@ class IPythonKernel(KernelBase):
     _sys_eval_input = Any()
 
     def __init__(self, **kwargs):
-        super(IPythonKernel, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
         # Initialize the Debugger
         if _is_debugpy_available:
@@ -175,13 +175,13 @@ class IPythonKernel(KernelBase):
             self.log.warning("debugpy_stream undefined, debugging will not be enabled")
         else:
             self.debugpy_stream.on_recv(self.dispatch_debugpy, copy=False)
-        super(IPythonKernel, self).start()
+        super().start()
 
     def set_parent(self, ident, parent, channel='shell'):
         """Overridden from parent to tell the display hook and output streams
         about the parent message.
         """
-        super(IPythonKernel, self).set_parent(ident, parent, channel)
+        super().set_parent(ident, parent, channel)
         if channel == 'shell':
             self.shell.set_parent(parent)
 
@@ -190,7 +190,7 @@ class IPythonKernel(KernelBase):
 
         Run at the beginning of each execution request.
         """
-        md = super(IPythonKernel, self).init_metadata(parent)
+        md = super().init_metadata(parent)
         # FIXME: remove deprecated ipyparallel-specific code
         # This is required for ipyparallel < 5.0
         md.update({
@@ -591,4 +591,4 @@ class Kernel(IPythonKernel):
         import warnings
         warnings.warn('Kernel is a deprecated alias of ipykernel.ipkernel.IPythonKernel',
                       DeprecationWarning)
-        super(Kernel, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)

--- a/ipykernel/kernelapp.py
+++ b/ipykernel/kernelapp.py
@@ -247,7 +247,7 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp,
         self.log.debug("Cleaning up connection file: %s", cf)
         try:
             os.remove(cf)
-        except (IOError, OSError):
+        except OSError:
             pass
 
         self.cleanup_ipc_files()
@@ -257,7 +257,7 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp,
             self.connection_file = "kernel-%s.json"%os.getpid()
         try:
             self.connection_file = filefind(self.connection_file, ['.', self.connection_dir])
-        except IOError:
+        except OSError:
             self.log.debug("Connection file not found: %s", self.connection_file)
             # This means I own it, and I'll create it in this directory:
             os.makedirs(os.path.dirname(self.abs_connection_file), mode=0o700, exist_ok=True)
@@ -621,7 +621,7 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp,
     @catch_config_error
     def initialize(self, argv=None):
         self._init_asyncio_patch()
-        super(IPKernelApp, self).initialize(argv)
+        super().initialize(argv)
         if self.subapp is not None:
             return
 

--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -207,7 +207,7 @@ class Kernel(SingletonConfigurable):
     control_msg_types = msg_types + ['clear_request', 'abort_request', 'debug_request']
 
     def __init__(self, **kwargs):
-        super(Kernel, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         # Build dict of handlers for message types
         self.shell_handlers = {}
         for msg_type in self.msg_types:

--- a/ipykernel/parentpoller.py
+++ b/ipykernel/parentpoller.py
@@ -22,7 +22,7 @@ class ParentPollerUnix(Thread):
     """
 
     def __init__(self):
-        super(ParentPollerUnix, self).__init__()
+        super().__init__()
         self.daemon = True
 
     def run(self):
@@ -60,7 +60,7 @@ class ParentPollerWindows(Thread):
             handle is signaled.
         """
         assert(interrupt_handle or parent_handle)
-        super(ParentPollerWindows, self).__init__()
+        super().__init__()
         if ctypes is None:
             raise ImportError("ParentPollerWindows requires ctypes")
         self.daemon = True

--- a/ipykernel/pickleutil.py
+++ b/ipykernel/pickleutil.py
@@ -110,7 +110,7 @@ def use_cloudpickle():
 #-------------------------------------------------------------------------------
 
 
-class CannedObject(object):
+class CannedObject:
     def __init__(self, obj, keys=[], hook=None):
         """can an object for safe pickling
 

--- a/ipykernel/tests/__init__.py
+++ b/ipykernel/tests/__init__.py
@@ -40,6 +40,6 @@ def teardown():
 
     try:
         shutil.rmtree(tmp)
-    except (OSError, IOError):
+    except OSError:
         # no such file
         pass

--- a/ipykernel/tests/test_async.py
+++ b/ipykernel/tests/test_async.py
@@ -54,7 +54,7 @@ def test_async_interrupt(asynclib, request):
 
     flush_channels(KC)
     msg_id = KC.execute(
-        "print('begin'); import {0}; await {0}.sleep(5)".format(asynclib)
+        f"print('begin'); import {asynclib}; await {asynclib}.sleep(5)"
     )
     busy = KC.get_iopub_msg(timeout=TIMEOUT)
     validate_message(busy, "status", msg_id)

--- a/ipykernel/tests/test_debugger.py
+++ b/ipykernel/tests/test_debugger.py
@@ -146,7 +146,7 @@ print({0})
         {"variableName": var_name},
     )
 
-    assert reply["body"]["data"] == {"text/plain": "'{}'".format(value)}
+    assert reply["body"]["data"] == {"text/plain": f"'{value}'"}
 
 
 def test_rich_inspect_at_breakpoint(kernel_with_debug):

--- a/ipykernel/tests/test_debugger.py
+++ b/ipykernel/tests/test_debugger.py
@@ -130,9 +130,9 @@ f(2, 3)"""
 def test_rich_inspect_not_at_breakpoint(kernel_with_debug):
     var_name = "text"
     value = "Hello the world"
-    code = """{0}='{1}'
-print({0})
-""".format(var_name, value)
+    code = f"""{var_name}='{value}'
+print({var_name})
+"""
 
     msg_id = kernel_with_debug.execute(code)
     get_reply(kernel_with_debug, msg_id)

--- a/ipykernel/tests/test_embed_kernel.py
+++ b/ipykernel/tests/test_embed_kernel.py
@@ -58,12 +58,12 @@ def setup_kernel(cmd):
 
         if kernel.poll() is not None:
             o, e = kernel.communicate()
-            raise IOError("Kernel failed to start:\n%s" % e)
+            raise OSError("Kernel failed to start:\n%s" % e)
 
         if not os.path.exists(connection_file):
             if kernel.poll() is None:
                 kernel.terminate()
-            raise IOError("Connection file %r never arrived" % connection_file)
+            raise OSError("Connection file %r never arrived" % connection_file)
 
         client = BlockingKernelClient(connection_file=connection_file)
         client.load_connection_file()

--- a/ipykernel/tests/test_jsonutil.py
+++ b/ipykernel/tests/test_jsonutil.py
@@ -20,13 +20,13 @@ from ..jsonutil import json_clean, encode_images
 JUPYTER_CLIENT_MAJOR_VERSION = jupyter_client_version[0]
 
 
-class MyInt(object):
+class MyInt:
     def __int__(self):
         return 389
 numbers.Integral.register(MyInt)
 
 
-class MyFloat(object):
+class MyFloat:
     def __float__(self):
         return 3.14
 numbers.Real.register(MyFloat)
@@ -45,7 +45,7 @@ def test():
              # Containers
              ([1, 2], None),
              ((1, 2), [1, 2]),
-             (set([1, 2]), [1, 2]),
+             ({1, 2}, [1, 2]),
              (dict(x=1), None),
              ({'x': 1, 'y':[1,2,3], '1':'int'}, None),
              # More exotic objects

--- a/ipykernel/tests/test_kernel.py
+++ b/ipykernel/tests/test_kernel.py
@@ -4,7 +4,6 @@
 # Distributed under the terms of the Modified BSD License.
 
 import ast
-import io
 import os.path
 import platform
 import subprocess
@@ -186,6 +185,7 @@ def test_subprocess_error():
         _check_master(kc, expected=True)
         _check_master(kc, expected=True, stream="stderr")
 
+
 # raw_input tests
 
 def test_raw_input():
@@ -220,7 +220,7 @@ def test_save_history():
         wait_for_idle(kc)
         _, reply = execute("%hist -f " + file, kc=kc)
         assert reply['status'] == 'ok'
-        with io.open(file, encoding='utf-8') as f:
+        with open(file, encoding='utf-8') as f:
             content = f.read()
         assert 'a=1' in content
         assert 'b="abcþ"' in content
@@ -350,7 +350,7 @@ def test_unc_paths():
         file_path = os.path.splitdrive(os.path.dirname(drive_file_path))[1]
         unc_file_path = os.path.join(unc_root, file_path[1:])
 
-        kc.execute("cd {0:s}".format(unc_file_path))
+        kc.execute(f"cd {unc_file_path:s}")
         reply = kc.get_shell_msg(timeout=TIMEOUT)
         assert reply['content']['status'] == 'ok'
         out, err = assemble_output(kc.get_iopub_msg)

--- a/ipykernel/tests/test_kernelspec.py
+++ b/ipykernel/tests/test_kernelspec.py
@@ -2,7 +2,6 @@
 # Distributed under the terms of the Modified BSD License.
 
 import json
-import io
 import os
 import shutil
 import sys
@@ -65,7 +64,7 @@ def assert_is_spec(path):
         assert os.path.exists(dst)
     kernel_json = pjoin(path, 'kernel.json')
     assert os.path.exists(kernel_json)
-    with io.open(kernel_json, encoding='utf8') as f:
+    with open(kernel_json, encoding='utf8') as f:
         json.load(f)
 
 

--- a/ipykernel/tests/test_message_spec.py
+++ b/ipykernel/tests/test_message_spec.py
@@ -62,7 +62,7 @@ class Version(Unicode):
         self.min = kwargs.pop('min', None)
         self.max = kwargs.pop('max', None)
         kwargs['default_value'] = self.min
-        super(Version, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def validate(self, obj, value):
         if self.min and V(value) < V(self.min):
@@ -79,7 +79,7 @@ class RMessage(Reference):
     content = Dict()
 
     def check(self, d):
-        super(RMessage, self).check(d)
+        super().check(d)
         RHeader().check(self.header)
         if self.parent_header:
             RHeader().check(self.parent_header)

--- a/ipykernel/tests/test_pickleutil.py
+++ b/ipykernel/tests/test_pickleutil.py
@@ -1,4 +1,3 @@
-
 import pickle
 
 from ipykernel.pickleutil import can, uncan

--- a/ipykernel/tests/test_zmq_shell.py
+++ b/ipykernel/tests/test_zmq_shell.py
@@ -14,7 +14,7 @@ from ipykernel.zmqshell import ZMQDisplayPublisher
 from jupyter_client.session import Session
 
 
-class NoReturnDisplayHook(object):
+class NoReturnDisplayHook:
     """
     A dummy DisplayHook which allows us to monitor
     the number of times an object is called, but which
@@ -33,7 +33,7 @@ class ReturnDisplayHook(NoReturnDisplayHook):
     message when it is called.
     """
     def __call__(self, obj):
-        super(ReturnDisplayHook, self).__call__(obj)
+        super().__call__(obj)
         return obj
 
 
@@ -51,7 +51,7 @@ class CounterSession(Session):
         with an increment to the send counter.
         """
         self.send_count += 1
-        super(CounterSession, self).send(*args, **kwargs)
+        super().send(*args, **kwargs)
 
 
 class ZMQDisplayPublisherTests(unittest.TestCase):

--- a/ipykernel/zmqshell.py
+++ b/ipykernel/zmqshell.py
@@ -375,15 +375,14 @@ class KernelMagics(Magics):
 
 
         print (info + '\n')
-        print ("Paste the above JSON into a file, and connect with:\n"
-            "    $> jupyter <app> --existing <file>\n"
-            "or, if you are local, you can connect with just:\n"
+        print (
+            f"Paste the above JSON into a file, and connect with:\n"
+            f"    $> jupyter <app> --existing <file>\n"
+            f"or, if you are local, you can connect with just:\n"
             f"    $> jupyter <app> --existing {connection_file}\n"
-            "or even just:\n"
-            "    $> jupyter <app> --existing\n"
-            "if this is the most recent Jupyter kernel you have started.".format(
-            connection_file
-            )
+            f"or even just:\n"
+            f"    $> jupyter <app> --existing\n"
+            f"if this is the most recent Jupyter kernel you have started."
         )
 
     @line_magic

--- a/ipykernel/zmqshell.py
+++ b/ipykernel/zmqshell.py
@@ -378,7 +378,7 @@ class KernelMagics(Magics):
         print ("Paste the above JSON into a file, and connect with:\n"
             "    $> jupyter <app> --existing <file>\n"
             "or, if you are local, you can connect with just:\n"
-            "    $> jupyter <app> --existing {}\n"
+            f"    $> jupyter <app> --existing {connection_file}\n"
             "or even just:\n"
             "    $> jupyter <app> --existing\n"
             "if this is the most recent Jupyter kernel you have started.".format(

--- a/ipykernel/zmqshell.py
+++ b/ipykernel/zmqshell.py
@@ -378,7 +378,7 @@ class KernelMagics(Magics):
         print ("Paste the above JSON into a file, and connect with:\n"
             "    $> jupyter <app> --existing <file>\n"
             "or, if you are local, you can connect with just:\n"
-            "    $> jupyter <app> --existing {0}\n"
+            "    $> jupyter <app> --existing {}\n"
             "or even just:\n"
             "    $> jupyter <app> --existing\n"
             "if this is the most recent Jupyter kernel you have started.".format(
@@ -497,7 +497,7 @@ class ZMQInteractiveShell(InteractiveShell):
         env['GIT_PAGER'] = 'cat'
 
     def init_hooks(self):
-        super(ZMQInteractiveShell, self).init_hooks()
+        super().init_hooks()
         self.set_hook('show_in_pager', page.as_hook(payloadpage.page), 99)
 
     def init_data_pub(self):
@@ -530,7 +530,7 @@ class ZMQInteractiveShell(InteractiveShell):
 
     def run_cell(self, *args, **kwargs):
         self._last_traceback = None
-        return super(ZMQInteractiveShell, self).run_cell(*args, **kwargs)
+        return super().run_cell(*args, **kwargs)
 
     def _showtraceback(self, etype, evalue, stb):
         # try to preserve ordering of tracebacks and print statements
@@ -592,7 +592,7 @@ class ZMQInteractiveShell(InteractiveShell):
         return self.parent_header
 
     def init_magics(self):
-        super(ZMQInteractiveShell, self).init_magics()
+        super().init_magics()
         self.register_magics(KernelMagics)
         self.magics_manager.register_alias('ed', 'edit')
 


### PR DESCRIPTION
* `IOError` is `OSError` in python3
* `io.open` -> `open`
* `return str()` -> `return ''` directly
* direct `super()` call
* do not subclass `object`