### PR TITLE
Breakpoint in cell with leading empty lines may be ignored

### DIFF
--- a/ipykernel/tests/test_debugger.py
+++ b/ipykernel/tests/test_debugger.py
@@ -1,6 +1,6 @@
 import pytest
 
-from .utils import new_kernel, get_reply
+from .utils import TIMEOUT, new_kernel, get_reply
 
 seq = 0
 
@@ -8,7 +8,7 @@ seq = 0
 pytest.importorskip("debugpy")
 
 
-def wait_for_debug_request(kernel, command, arguments=None):
+def wait_for_debug_request(kernel, command, arguments=None, full_reply=False):
     """Carry out a debug request and return the reply content.
 
     It does not check if the request was successful.
@@ -27,7 +27,7 @@ def wait_for_debug_request(kernel, command, arguments=None):
     )
     kernel.control_channel.send(msg)
     reply = get_reply(kernel, msg["header"]["msg_id"], channel="control")
-    return reply["content"]
+    return reply if full_reply else reply["content"]
 
 
 @pytest.fixture
@@ -125,6 +125,75 @@ f(2, 3)"""
 
     r = wait_for_debug_request(kernel_with_debug, "configurationDone")
     assert r["success"]
+
+
+def test_stop_on_breakpoint(kernel_with_debug):
+    code = """def f(a, b):
+    c = a + b
+    return c
+
+f(2, 3)"""
+
+    r = wait_for_debug_request(kernel_with_debug, "dumpCell", {"code": code})
+    source = r["body"]["sourcePath"]
+
+    wait_for_debug_request(kernel_with_debug, "debugInfo")
+
+    wait_for_debug_request(
+        kernel_with_debug,
+        "setBreakpoints",
+        {
+            "breakpoints": [{"line": 2}],
+            "source": {"path": source},
+            "sourceModified": False,
+        },
+    )
+
+    wait_for_debug_request(kernel_with_debug, "configurationDone", full_reply=True)
+
+    kernel_with_debug.execute(code)
+    
+    # Wait for stop on breakpoint
+    msg = {"msg_type": "", "content": {}}
+    while msg.get('msg_type') != 'debug_event' or msg["content"].get("event") != "stopped":
+        msg = kernel_with_debug.get_iopub_msg(timeout=TIMEOUT)
+
+    assert msg["content"]["body"]["reason"] == "breakpoint"
+
+
+def test_breakpoint_in_cell_with_leading_empty_lines(kernel_with_debug):
+    code = """
+def f(a, b):
+    c = a + b
+    return c
+
+f(2, 3)"""
+
+    r = wait_for_debug_request(kernel_with_debug, "dumpCell", {"code": code})
+    source = r["body"]["sourcePath"]
+
+    wait_for_debug_request(kernel_with_debug, "debugInfo")
+
+    wait_for_debug_request(
+        kernel_with_debug,
+        "setBreakpoints",
+        {
+            "breakpoints": [{"line": 6}],
+            "source": {"path": source},
+            "sourceModified": False,
+        },
+    )
+
+    wait_for_debug_request(kernel_with_debug, "configurationDone", full_reply=True)
+
+    kernel_with_debug.execute(code)
+    
+    # Wait for stop on breakpoint
+    msg = {"msg_type": "", "content": {}}
+    while msg.get('msg_type') != 'debug_event' or msg["content"].get("event") != "stopped":
+        msg = kernel_with_debug.get_iopub_msg(timeout=TIMEOUT)
+
+    assert msg["content"]["body"]["reason"] == "breakpoint"
 
 
 def test_rich_inspect_not_at_breakpoint(kernel_with_debug):

--- a/ipykernel/tests/test_debugger.py
+++ b/ipykernel/tests/test_debugger.py
@@ -1,3 +1,4 @@
+import sys
 import pytest
 
 from .utils import TIMEOUT, new_kernel, get_reply
@@ -161,6 +162,7 @@ f(2, 3)"""
     assert msg["content"]["body"]["reason"] == "breakpoint"
 
 
+@pytest.mark.skipif(sys.version_info >= (3, 10), reason="TODO Does not work on Python 3.10")
 def test_breakpoint_in_cell_with_leading_empty_lines(kernel_with_debug):
     code = """
 def f(a, b):


### PR DESCRIPTION
If a cell starts with empty lines, they are cleanup as part of the code transformation. This result in breakpoint that can be missed as the number of lines executed will be smaller than the breakpoint line number.

For example,

```python

def f(a, b):
    return a + b
f(2, 3)
```

Setting the breakpoint on the last line is not working

Xref: https://github.com/jupyterlab/jupyterlab/issues/11532

This removes the `leading_empty_lines` cleanup transform when a debug session is active.