### PR TITLE
Removed DebugStdLib from arguments of attach

### DIFF
--- a/ipykernel/debugger.py
+++ b/ipykernel/debugger.py
@@ -477,8 +477,11 @@ class Debugger:
             'port': port
         }
         message['arguments']['logToFile'] = True
+        # Reverts that option for now since it leads to spurious break of the code
+        # in ipykernel source and resuming the execution leads to several errors
+        # in the kernel.
         # Set debugOptions for breakpoints in python standard library source.
-        message['arguments']['debugOptions'] = [ 'DebugStdLib' ]
+        # message['arguments']['debugOptions'] = [ 'DebugStdLib' ]
         return await self._forward_message(message)
 
     async def configurationDone(self, message):


### PR DESCRIPTION
Fixes #832.

This reverts #812 , which is responsible for the bug of #832 and another issue where the code suddenly breaks in ipykernel sources. Resuming the execution leads to many errors in the kernel.

![debugstdlib](https://user-images.githubusercontent.com/6754742/149108672-b342d7ec-d0ba-4680-a627-63c45dc97b1c.gif)

