### PR TITLE
Handle all threads stopped correctly

### DIFF
--- a/ipykernel/control.py
+++ b/ipykernel/control.py
@@ -10,12 +10,13 @@ else:
 class ControlThread(Thread):
 
     def __init__(self, **kwargs):
-        Thread.__init__(self, **kwargs)
+        Thread.__init__(self, name="Control", **kwargs)
         self.io_loop = IOLoop(make_current=False)
         self.pydev_do_not_trace = True
         self.is_pydev_daemon_thread = True
 
     def run(self):
+        self.name="Control"
         self.io_loop.make_current()
         try:
             self.io_loop.start()

--- a/ipykernel/control.py
+++ b/ipykernel/control.py
@@ -16,7 +16,7 @@ class ControlThread(Thread):
         self.is_pydev_daemon_thread = True
 
     def run(self):
-        self.name="Control"
+        self.name = "Control"
         self.io_loop.make_current()
         try:
             self.io_loop.start()

--- a/ipykernel/heartbeat.py
+++ b/ipykernel/heartbeat.py
@@ -90,7 +90,7 @@ class Heartbeat(Thread):
                 return
 
     def run(self):
-        self.name="Heartbeat"
+        self.name = "Heartbeat"
         self.socket = self.context.socket(zmq.ROUTER)
         self.socket.linger = 1000
         try:

--- a/ipykernel/heartbeat.py
+++ b/ipykernel/heartbeat.py
@@ -32,7 +32,7 @@ class Heartbeat(Thread):
     def __init__(self, context, addr=None):
         if addr is None:
             addr = ('tcp', localhost(), 0)
-        Thread.__init__(self)
+        Thread.__init__(self, name="Heartbeat")
         self.context = context
         self.transport, self.ip, self.port = addr
         self.original_port = self.port
@@ -42,6 +42,7 @@ class Heartbeat(Thread):
         self.daemon = True
         self.pydev_do_not_trace = True
         self.is_pydev_daemon_thread = True
+        self.name="Heartbeat"
 
     def pick_port(self):
         if self.transport == 'tcp':
@@ -89,6 +90,7 @@ class Heartbeat(Thread):
                 return
 
     def run(self):
+        self.name="Heartbeat"
         self.socket = self.context.socket(zmq.ROUTER)
         self.socket.linger = 1000
         try:

--- a/ipykernel/heartbeat.py
+++ b/ipykernel/heartbeat.py
@@ -42,7 +42,7 @@ class Heartbeat(Thread):
         self.daemon = True
         self.pydev_do_not_trace = True
         self.is_pydev_daemon_thread = True
-        self.name="Heartbeat"
+        self.name = "Heartbeat"
 
     def pick_port(self):
         if self.transport == 'tcp':

--- a/ipykernel/iostream.py
+++ b/ipykernel/iostream.py
@@ -70,10 +70,11 @@ class IOPubThread:
         self._events = deque()
         self._event_pipes = WeakSet()
         self._setup_event_pipe()
-        self.thread = threading.Thread(target=self._thread_main)
+        self.thread = threading.Thread(target=self._thread_main, name="IOPub")
         self.thread.daemon = True
         self.thread.pydev_do_not_trace = True
         self.thread.is_pydev_daemon_thread = True
+        self.thread.name="IOPub"
 
     def _thread_main(self):
         """The inner loop that's actually run in a thread"""
@@ -176,6 +177,7 @@ class IOPubThread:
 
     def start(self):
         """Start the IOPub thread"""
+        self.thread.name="IOPub"
         self.thread.start()
         # make sure we don't prevent process exit
         # I'm not sure why setting daemon=True above isn't enough, but it doesn't appear to be.

--- a/ipykernel/iostream.py
+++ b/ipykernel/iostream.py
@@ -74,7 +74,7 @@ class IOPubThread:
         self.thread.daemon = True
         self.thread.pydev_do_not_trace = True
         self.thread.is_pydev_daemon_thread = True
-        self.thread.name="IOPub"
+        self.thread.name = "IOPub"
 
     def _thread_main(self):
         """The inner loop that's actually run in a thread"""

--- a/ipykernel/iostream.py
+++ b/ipykernel/iostream.py
@@ -177,7 +177,7 @@ class IOPubThread:
 
     def start(self):
         """Start the IOPub thread"""
-        self.thread.name="IOPub"
+        self.thread.name = "IOPub"
         self.thread.start()
         # make sure we don't prevent process exit
         # I'm not sure why setting daemon=True above isn't enough, but it doesn't appear to be.

--- a/ipykernel/tests/test_debugger.py
+++ b/ipykernel/tests/test_debugger.py
@@ -227,6 +227,7 @@ def test_rich_inspect_at_breakpoint(kernel_with_debug):
 
 f(2, 3)"""
 
+
     r = wait_for_debug_request(kernel_with_debug, "dumpCell", {"code": code})
     source = r["body"]["sourcePath"]
 
@@ -245,6 +246,11 @@ f(2, 3)"""
     r = wait_for_debug_request(kernel_with_debug, "configurationDone")
 
     kernel_with_debug.execute(code)
+
+    # Wait for stop on breakpoint
+    msg = {"msg_type": "", "content": {}}
+    while msg.get('msg_type') != 'debug_event' or msg["content"].get("event") != "stopped":
+        msg = kernel_with_debug.get_iopub_msg(timeout=TIMEOUT)
 
     stacks = wait_for_debug_request(kernel_with_debug, "stackTrace", {"threadId": 1})[
         "body"


### PR DESCRIPTION
This PR fix the issues of the stored stopped threads when receiving a `stopped` event with `allThreadsStopped` set to True