### PR TITLE
use message queue for abort_queues

### DIFF
--- a/ipykernel/tests/test_message_spec.py
+++ b/ipykernel/tests/test_message_spec.py
@@ -341,15 +341,23 @@ def test_execute_stop_on_error():
     """execute request should not abort execution queue with stop_on_error False"""
     flush_channels()
 
-    fail = '\n'.join([
-        # sleep to ensure subsequent message is waiting in the queue to be aborted
-        'import time',
-        'time.sleep(0.5)',
-        'raise ValueError',
-    ])
+    fail = "\n".join(
+        [
+            # sleep to ensure subsequent message is waiting in the queue to be aborted
+            # async sleep to ensure coroutines are processing while this happens
+            "import asyncio",
+            "await asyncio.sleep(1)",
+            "raise ValueError()",
+        ]
+    )
     KC.execute(code=fail)
     KC.execute(code='print("Hello")')
-    KC.get_shell_msg(timeout=TIMEOUT)
+    KC.execute(code='print("world")')
+    reply = KC.get_shell_msg(timeout=TIMEOUT)
+    print(reply)
+    reply = KC.get_shell_msg(timeout=TIMEOUT)
+    assert reply["content"]["status"] == "aborted"
+    # second message, too
     reply = KC.get_shell_msg(timeout=TIMEOUT)
     assert reply['content']['status'] == 'aborted'
 


### PR DESCRIPTION
ensures queued messages are aborted, rather than racing with coroutine processing which would complete too soon during asynchronous executions.

Discovered in https://github.com/ipython/ipyparallel/pull/663 where making `do_execute` return a Future would cause abort tests to fail.