### PR TITLE
Fixed event forwarding

### DIFF
--- a/ipykernel/debugger.py
+++ b/ipykernel/debugger.py
@@ -314,6 +314,8 @@ class Debugger:
             else:
                 self.stopped_threads.remove(msg['body']['threadId'])
             self.event_callback(msg)
+        else:
+            self.event_callback(msg)
 
     async def _forward_message(self, msg):
         return await self.debugpy_client.send_dap_request(msg)


### PR DESCRIPTION
I know a lot of calls to `event_callback` could be factorized out of the `if/else` logic, but I find it more readable this way.