### PR TITLE
process_one only accepts coroutines for dispatch

### DIFF
--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -985,7 +985,8 @@ class Kernel(SingletonConfigurable):
         self.shell_stream.flush()
 
         # Callback to signal that we are done aborting
-        def stop_aborting():
+        # dispatch functions _must_ be async
+        async def stop_aborting():
             self.log.info("Finishing abort")
             self._aborting = False
 


### PR DESCRIPTION
closes #860

alternately: make the `await dispatch` check `inspect.isawaitable` first.