### PR TITLE
Enable standard library debugging via config

### DIFF
--- a/ipykernel/debugger.py
+++ b/ipykernel/debugger.py
@@ -270,7 +270,7 @@ class Debugger:
         'richInspectVariables', 'modules'
     ]
 
-    def __init__(self, log, debugpy_stream, event_callback, shell_socket, session, just_my_code):
+    def __init__(self, log, debugpy_stream, event_callback, shell_socket, session, just_my_code = True):
         self.log = log
         self.debugpy_client = DebugpyClient(log, debugpy_stream, self._handle_event)
         self.shell_socket = shell_socket

--- a/ipykernel/ipkernel.py
+++ b/ipykernel/ipkernel.py
@@ -83,7 +83,8 @@ class IPythonKernel(KernelBase):
                                     self.debugpy_stream,
                                     self._publish_debug_event,
                                     self.debug_shell_socket,
-                                    self.session)
+                                    self.session,
+                                    self.debug_just_my_code)
 
         # Initialize the InteractiveShell subclass
         self.shell = self.shell_class.instance(parent=self,

--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -127,6 +127,15 @@ class Kernel(SingletonConfigurable):
     # any links that should go in the help menu
     help_links = List()
 
+    # Experimental option to break in non-user code.
+    # The ipykernel source is in the call stack, so the user
+    # has to manipulate the step-over and step-into in a wize way.
+    debug_just_my_code = Bool(True,
+        help="""Set to False if you want to debug python standard and dependent libraries.
+        """
+    ).tag(config=True)
+
+    # track associations with current request
     # Private interface
 
     _darwin_app_nap = Bool(True,


### PR DESCRIPTION
Fix https://github.com/ipython/ipykernel/issues/862

This adds a configuration `debug_just_my_code` being True by default.

The name has been chosen based on the existing VS Code configuraiton https://docs.microsoft.com/en-us/visualstudio/debugger/just-my-code?view=vs-2022