### PR TITLE
Add hostname to the usage reply

### DIFF
--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -13,6 +13,7 @@ import inspect
 import os
 from signal import signal, default_int_handler, SIGINT
 import sys
+import socket
 import time
 import uuid
 import warnings
@@ -879,7 +880,9 @@ class Kernel(SingletonConfigurable):
             return None
 
     async def usage_request(self, stream, ident, parent):
-        reply_content = {}
+        reply_content = {
+            'hostname': socket.gethostname()
+        }
         if psutil is None:
             return reply_content
         current_process = psutil.Process()


### PR DESCRIPTION
Fix https://github.com/ipython/ipykernel/issues/864

The hostname is added to the usage reply