### PR TITLE
Mitigate #872

### DIFF
--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -1161,6 +1161,11 @@ class Kernel(SingletonConfigurable):
                     pass
 
     async def _progressively_terminate_all_children(self):
+        # those test fail if we send killpg as it kills pytest itself.
+        # it should be removed in the end after ipyparallel likely monkeypatch the method
+        # or does not run things in process, but that should fix the tests for now
+        if os.environ.get('PYTEST_CURRENT_TEST', None):
+            return
 
         pgid = os.getpgid(os.getpid())
         if psutil is None:


### PR DESCRIPTION
Don't send killpg when running some shutdown tests in pytest.

