### PR TITLE
Only kill children in process group at shutdown

### DIFF
--- a/ipykernel/debugger.py
+++ b/ipykernel/debugger.py
@@ -19,10 +19,14 @@ except ImportError:
 
 from .compiler import (get_file_name, get_tmp_directory, get_tmp_hash_seed)
 
-# This import is required to have the next ones working...
-from debugpy.server import api  # noqa
-from _pydevd_bundle import pydevd_frame_utils
-from _pydevd_bundle.pydevd_suspended_frames import SuspendedFramesManager, _FramesTracker
+try:
+    # This import is required to have the next ones working...
+    from debugpy.server import api  # noqa
+    from _pydevd_bundle import pydevd_frame_utils
+    from _pydevd_bundle.pydevd_suspended_frames import SuspendedFramesManager, _FramesTracker
+    _is_debugpy_available = True
+except ImportError:
+    _is_debugpy_available = False
 
 # Required for backwards compatiblity
 ROUTING_ID = getattr(zmq, 'ROUTING_ID', None) or zmq.IDENTITY

--- a/ipykernel/ipkernel.py
+++ b/ipykernel/ipkernel.py
@@ -18,6 +18,7 @@ from .kernelbase import Kernel as KernelBase
 from .zmqshell import ZMQInteractiveShell
 from .eventloops import _use_appnope
 from .compiler import XCachingCompiler
+from .debugger import Debugger, _is_debugpy_available
 
 try:
     from IPython.core.interactiveshell import _asyncio_runner
@@ -33,12 +34,6 @@ try:
 except ImportError:
     _use_experimental_60_completion = False
 
-try:
-    import debugpy
-    from .debugger import Debugger
-    _is_debugpy_available = True
-except ImportError:
-    _is_debugpy_available = False
 
 _EXPERIMENTAL_KEY_NAME = '_jupyter_types_experimental'
 

--- a/ipykernel/kernelspec.py
+++ b/ipykernel/kernelspec.py
@@ -13,7 +13,7 @@ import tempfile
 
 from jupyter_client.kernelspec import KernelSpecManager
 
-from .ipkernel import _is_debugpy_available
+from .debugger import _is_debugpy_available
 
 pjoin = os.path.join
 

--- a/ipykernel/tests/test_kernel.py
+++ b/ipykernel/tests/test_kernel.py
@@ -14,12 +14,8 @@ from subprocess import Popen
 from tempfile import TemporaryDirectory
 
 from flaky import flaky
+import psutil
 import pytest
-
-try:
-    import psutil
-except ImportError:
-    psutil = None
 
 import IPython
 from IPython.paths import locate_profile
@@ -534,10 +530,6 @@ def _start_children():
 @pytest.mark.skipif(
     platform.python_implementation() == "PyPy",
     reason="does not work on PyPy",
-)
-@pytest.mark.skipif(
-    psutil is None,
-    reason="requires psutil",
 )
 def test_shutdown_subprocesses():
     """Kernel exits after polite shutdown_request"""

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ setup_args = dict(
         'tornado>=4.2,<7.0',
         'matplotlib-inline>=0.1.0,<0.2.0',
         'appnope;platform_system=="Darwin"',
-        'psutil;platform_system=="Windows"',
+        'psutil',
         'nest_asyncio',
     ],
     extras_require={


### PR DESCRIPTION
- not the whole process group (`killpg`), which includes kernel itself and possibly parents (closes #872)
- not children which have started their own process groups, which is the standard indicator for "leave me alone when my parent shuts down"

closes #873 