### PR TITLE
Forward source requests to debugpy as fallback

### DIFF
--- a/ipykernel/debugger.py
+++ b/ipykernel/debugger.py
@@ -442,9 +442,7 @@ class Debugger:
                     'content': f.read()
                 }
         else:
-            reply['success'] = False
-            reply['message'] = 'source unavailable'
-            reply['body'] = {}
+            reply = await self._forward_message(message)
 
         return reply
 


### PR DESCRIPTION
~If the source cannot be looked up by the `path` argument, forward it to debugpy as it might be able to resolve it using the sourceReference field.~

EDIT: If the `sourceReference` is non-zero, forward it to debugpy, as the specification requires the reference to be used in those cases.

Proposed fix to #870.

TODO: Write some tests.