### PR TITLE
Catch error when shutting down kernel from the control channel

### DIFF
--- a/ipykernel/eventloops.py
+++ b/ipykernel/eventloops.py
@@ -285,7 +285,10 @@ def loop_tk(kernel):
 
 @loop_tk.exit
 def loop_tk_exit(kernel):
-    kernel.app_wrapper.app.destroy()
+    try:
+        kernel.app_wrapper.app.destroy()
+    except RuntimeError:
+        pass
 
 
 @register_integration('gtk')


### PR DESCRIPTION
- This problem is not allowing kernel restarts to complete when the Tk backend is active.
- The error is the following:

```python-traceback
Traceback (most recent call last):
    File "/home/carlos/miniconda3/envs/spyder‑stable‑cf/lib/python3.7/site‑packages/ipykernel/kernelbase.py", line 285, in process_control
    await result
    File "/home/carlos/miniconda3/envs/spyder‑stable‑cf/lib/python3.7/site‑packages/ipykernel/kernelbase.py", line 814, in shutdown_request
    content = self.do_shutdown(parent['content']['restart'])
    File "/home/carlos/Projects/spyder/github‑repo/external‑deps/spyder‑kernels/spyder_kernels/console/kernel.py", line 105, in do_shutdown
    super(SpyderKernel, self).do_shutdown(restart)
    File "/home/carlos/miniconda3/envs/spyder‑stable‑cf/lib/python3.7/site‑packages/ipykernel/ipkernel.py", line 513, in do_shutdown
    self.shell.exit_now = True
    File "/home/carlos/miniconda3/envs/spyder‑stable‑cf/lib/python3.7/site‑packages/traitlets/traitlets.py", line 606, in __set__
    self.set(obj, value)
    File "/home/carlos/miniconda3/envs/spyder‑stable‑cf/lib/python3.7/site‑packages/traitlets/traitlets.py", line 595, in set
    obj._notify_trait(self.name, old_value, new_value)
    File "/home/carlos/miniconda3/envs/spyder‑stable‑cf/lib/python3.7/site‑packages/traitlets/traitlets.py", line 1224, in _notify_trait
    type='change',
    File "/home/carlos/miniconda3/envs/spyder‑stable‑cf/lib/python3.7/site‑packages/traitlets/traitlets.py", line 1229, in notify_change
    return self._notify_observers(change)
    File "/home/carlos/miniconda3/envs/spyder‑stable‑cf/lib/python3.7/site‑packages/traitlets/traitlets.py", line 1266, in _notify_observers
    c(event)
    File "/home/carlos/miniconda3/envs/spyder‑stable‑cf/lib/python3.7/site‑packages/ipykernel/zmqshell.py", line 472, in _update_exit_now
    exit_hook(self.kernel)
    File "/home/carlos/miniconda3/envs/spyder‑stable‑cf/lib/python3.7/site‑packages/ipykernel/eventloops.py", line 289, in loop_tk_exit
    kernel.app_wrapper.app.destroy()
    File "/home/carlos/miniconda3/envs/spyder‑stable‑cf/lib/python3.7/tkinter/__init__.py", line 2062, in destroy
    self.tk.call('destroy', self._w)
    RuntimeError: main thread is not in main loop
```