### PR TITLE
Check if the current thread is the io thread

### DIFF
--- a/ipykernel/iostream.py
+++ b/ipykernel/iostream.py
@@ -455,7 +455,12 @@ class OutStream(TextIOBase):
 
         send will happen in the background thread
         """
-        if self.pub_thread and self.pub_thread.thread is not None and self.pub_thread.thread.is_alive():
+        if (
+                self.pub_thread
+                and self.pub_thread.thread is not None
+                and self.pub_thread.thread.is_alive()
+                and self.pub_thread.thread.ident != threading.current_thread().ident
+        ):
             # request flush on the background thread
             self.pub_thread.schedule(self._flush)
             # wait for flush to actually get through, if we can.


### PR DESCRIPTION
I noticed that I'll somewhat unpredictably run into this issue where the kernel prints "IOStream.flush timed out". I found that OutStream.flush() could be called in the I/O thread itself, leading to a wait() that will block for the full 10 second timeout.

I can't reliably reproduce an instance of flush() getting called in the I/O thread, but in my case it looked like a `logger.warning` call inside the asyncio event loop handling was responsible for it.

I think this could be the issue in #334 ?