### PR TITLE
Try to pass cell id to executing kernel.

### DIFF
--- a/ipykernel/inprocess/tests/test_kernel.py
+++ b/ipykernel/inprocess/tests/test_kernel.py
@@ -3,20 +3,18 @@
 
 import sys
 import unittest
+from contextlib import contextmanager
 from io import StringIO
 
 import pytest
 import tornado
 from IPython.utils.io import capture_output
+from jupyter_client.session import Session
 
 from ipykernel.inprocess.blocking import BlockingInProcessKernelClient
 from ipykernel.inprocess.ipkernel import InProcessKernel
 from ipykernel.inprocess.manager import InProcessKernelManager
 from ipykernel.tests.utils import assemble_output
-from IPython.utils.io import capture_output
-
-from jupyter_client.session import Session
-from contextlib import contextmanager
 
 orig_msg = Session.msg
 

--- a/ipykernel/inprocess/tests/test_kernel.py
+++ b/ipykernel/inprocess/tests/test_kernel.py
@@ -13,6 +13,12 @@ from ipykernel.inprocess.blocking import BlockingInProcessKernelClient
 from ipykernel.inprocess.ipkernel import InProcessKernel
 from ipykernel.inprocess.manager import InProcessKernelManager
 from ipykernel.tests.utils import assemble_output
+from IPython.utils.io import capture_output
+
+from jupyter_client.session import Session
+from contextlib import contextmanager
+
+orig_msg = Session.msg
 
 
 def _init_asyncio_patch():
@@ -53,6 +59,26 @@ def _init_asyncio_patch():
                 asyncio.set_event_loop_policy(WindowsSelectorEventLoopPolicy())
 
 
+def _inject_cell_id(_self, *args, **kwargs):
+    """
+    This patch jupyter_client.session:Session.msg to add a cell_id to the return message metadata
+    """
+    assert isinstance(_self, Session)
+    res = orig_msg(_self, *args, **kwargs)
+    assert "cellId" not in res["metadata"]
+    res["metadata"]["cellId"] = "test_cell_id"
+    return res
+
+
+@contextmanager
+def patch_cell_id():
+    try:
+        Session.msg = _inject_cell_id
+        yield
+    finally:
+        Session.msg = orig_msg
+
+
 class InProcessKernelTestCase(unittest.TestCase):
     def setUp(self):
         _init_asyncio_patch()
@@ -61,6 +87,11 @@ class InProcessKernelTestCase(unittest.TestCase):
         self.kc = self.km.client()
         self.kc.start_channels()
         self.kc.wait_for_ready()
+
+    def test_with_cell_id(self):
+
+        with patch_cell_id():
+            self.kc.execute("1+1")
 
     def test_pylab(self):
         """Does %pylab work in the in-process kernel?"""


### PR DESCRIPTION
Is seem that few kernel want to make use of cell id for various
reasons.

One way to get the cell_id in the executing context is to make use of
init_metadata but it is marked for removal.

for example in [there](https://github.com/robots-from-jupyter/robotkernel/blob/19b28267406d1f8555ce73b96e7efb8af8417266/src/robotkernel/kernel.py#L196-L205)

Another is to start passing cell_id down.

This is technically a change of API as our consumer may not support more
parameters so we take a peak at the signature, and pass cell_id only if
it is :
- an explicit parameter,
- the function/method takes varkwargs.

We could also start to refactor to pass a metadata object with multiple
fields if this is the preferred route.

One questions is whether and how we want to deprecated not receiving
cell_id as a parameter.

Related to https://github.com/ipython/ipython/issues/13579 and
subsequent PR on IPython side to support cell_id in progress.