### PR TITLE
Include method signatures in experimental completion results

### DIFF
--- a/ipykernel/ipkernel.py
+++ b/ipykernel/ipkernel.py
@@ -452,6 +452,7 @@ class IPythonKernel(KernelBase):
                         end=comp.end,
                         text=comp.text,
                         type=comp.type,
+                        signature=comp.signature,
                     )
                 )
 


### PR DESCRIPTION
Method signatures are trivially available for autocomplete requests, I'd like to make them available via the jupyter complete_request. 