### PR TITLE
Do not try to send on iostream if closed

### DIFF
--- a/ipykernel/iostream.py
+++ b/ipykernel/iostream.py
@@ -226,6 +226,9 @@ class IOPubThread:
 
     def _really_send(self, msg, *args, **kwargs):
         """The callback that actually sends messages"""
+        if self.closed:
+            return
+
         mp_mode = self._check_mp_mode()
 
         if mp_mode != CHILD:


### PR DESCRIPTION
Failure seen in https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=483837&view=logs&jobId=bb1c2637-64c6-57bd-9ea6-93823b2df951&j=bb1c2637-64c6-57bd-9ea6-93823b2df951&t=350df31b-3291-5209-0bb7-031395f0baa1