### PR TITLE
use packaging instead of pkg_resources to parse versions

### DIFF
--- a/ipykernel/eventloops.py
+++ b/ipykernel/eventloops.py
@@ -9,7 +9,7 @@ import sys
 from functools import partial
 
 import zmq
-from pkg_resources import parse_version as V
+from packaging.version import Version as V
 from traitlets.config.application import Application
 
 

--- a/ipykernel/tests/test_message_spec.py
+++ b/ipykernel/tests/test_message_spec.py
@@ -9,7 +9,7 @@ from queue import Empty
 
 import jupyter_client
 import pytest
-from pkg_resources import parse_version as V
+from packaging.version import Version as V
 from traitlets import (
     Bool,
     Dict,

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ setup_args = dict(
         'appnope;platform_system=="Darwin"',
         "psutil",
         "nest_asyncio",
-        "setuptools>=60",  # for pkg_resources
+        "packaging",
     ],
     extras_require={
         "test": [


### PR DESCRIPTION
Pinning setuptools as a runtime dependency is often a problem, and setting a minimum of _extremely_ recent setuptools 60 is causing conflicts with e.g. pandas which pins `setuptools<60` (this is making an unsolvable conda environment for me right now).

[migration advice](https://peps.python.org/pep-0632/#migration-advice) suggests using the lighter `packaging` package, and I don't see a reason to use a version pin.

The pkg_resources function is also available for at least 30 versions (setuptools 30), so the `>=60` doesn't seem to have been the right number to use.

Recommend a patch release with the fix, since the dependency in 6.11 is causing installation problems.
