### PR TITLE
Allow enforce PR label workflow to add labels

### DIFF
--- a/.github/workflows/enforce-label.yml
+++ b/.github/workflows/enforce-label.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   enforce-label:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - name: enforce-triage-label
         uses: jupyterlab/maintainer-tools/.github/actions/enforce-label@v1


### PR DESCRIPTION
This allows the bot PRs to be automatically labeled as `maintenance`.