### PR TITLE
Update Pytest configuration (deprecated implicit asyncio mode)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ testpaths = [
     "ipykernel/tests",
     "ipykernel/inprocess/tests"
 ]
+asyncio_mode = "strict"
 timeout = 300
 # Restore this setting to debug failures
 # timeout_method = "thread"


### PR DESCRIPTION
This make downstream test fail.