### PR TITLE
Ensure psutil for the  process is accurate

### DIFF
--- a/ipykernel/control.py
+++ b/ipykernel/control.py
@@ -1,17 +1,12 @@
 from threading import Thread
 
 import zmq
-import psutil
 
 if zmq.pyzmq_version_info() >= (17, 0):
     from tornado.ioloop import IOLoop
 else:
     # deprecated since pyzmq 17
     from zmq.eventloop.ioloop import IOLoop
-
-import logging
-logger = logging.getLogger()
-logger.setLevel(logging.INFO)
 
 class ControlThread(Thread):
 

--- a/ipykernel/control.py
+++ b/ipykernel/control.py
@@ -1,6 +1,7 @@
 from threading import Thread
 
 import zmq
+import psutil
 
 if zmq.pyzmq_version_info() >= (17, 0):
     from tornado.ioloop import IOLoop
@@ -8,13 +9,19 @@ else:
     # deprecated since pyzmq 17
     from zmq.eventloop.ioloop import IOLoop
 
+import logging
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
 
 class ControlThread(Thread):
+    processes = {}
+
     def __init__(self, **kwargs):
         Thread.__init__(self, name="Control", **kwargs)
         self.io_loop = IOLoop(make_current=False)
         self.pydev_do_not_trace = True
         self.is_pydev_daemon_thread = True
+        self.cpu_percent = psutil.cpu_percent()
 
     def run(self):
         self.name = "Control"
@@ -23,6 +30,24 @@ class ControlThread(Thread):
             self.io_loop.start()
         finally:
             self.io_loop.close()
+
+    def get_process_metric_value(self, process, name, attribute=None):
+        try:
+            # psutil.Process methods will either return...
+            pid = process.pid
+            p = self.processes.get(pid, None)
+            if not p:
+                self.processes[process.pid] = process
+            p = self.processes.get(pid)
+            metric_value = getattr(p, name)()
+            if attribute is not None:  # ... a named tuple
+                return getattr(metric_value, attribute)
+            else:  # ... or a number
+                return metric_value
+        # Avoid littering logs with stack traces
+        # complaining about dead processes
+        except BaseException:
+            return None
 
     def stop(self):
         """Stop the thread.

--- a/ipykernel/control.py
+++ b/ipykernel/control.py
@@ -14,14 +14,12 @@ logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
 class ControlThread(Thread):
-    processes = {}
 
     def __init__(self, **kwargs):
         Thread.__init__(self, name="Control", **kwargs)
         self.io_loop = IOLoop(make_current=False)
         self.pydev_do_not_trace = True
         self.is_pydev_daemon_thread = True
-        self.cpu_percent = psutil.cpu_percent()
 
     def run(self):
         self.name = "Control"
@@ -30,24 +28,6 @@ class ControlThread(Thread):
             self.io_loop.start()
         finally:
             self.io_loop.close()
-
-    def get_process_metric_value(self, process, name, attribute=None):
-        try:
-            # psutil.Process methods will either return...
-            pid = process.pid
-            p = self.processes.get(pid, None)
-            if not p:
-                self.processes[process.pid] = process
-            p = self.processes.get(pid)
-            metric_value = getattr(p, name)()
-            if attribute is not None:  # ... a named tuple
-                return getattr(metric_value, attribute)
-            else:  # ... or a number
-                return metric_value
-        # Avoid littering logs with stack traces
-        # complaining about dead processes
-        except BaseException:
-            return None
 
     def stop(self):
         """Stop the thread.

--- a/ipykernel/control.py
+++ b/ipykernel/control.py
@@ -10,7 +10,6 @@ else:
 
 
 class ControlThread(Thread):
-
     def __init__(self, **kwargs):
         Thread.__init__(self, name="Control", **kwargs)
         self.io_loop = IOLoop(make_current=False)

--- a/ipykernel/control.py
+++ b/ipykernel/control.py
@@ -8,6 +8,7 @@ else:
     # deprecated since pyzmq 17
     from zmq.eventloop.ioloop import IOLoop
 
+
 class ControlThread(Thread):
 
     def __init__(self, **kwargs):

--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -977,6 +977,12 @@ class Kernel(SingletonConfigurable):
         reply_content = {"hostname": socket.gethostname(), "pid": os.getpid()}
         current_process = psutil.Process()
         all_processes = [current_process] + current_process.children(recursive=True)
+        pruned_processes = {}
+        for process in all_processes:
+            p = self.processes.get(process.pid)
+            if p is not None:
+                pruned_processes[process.pid] = p
+        self.processes = pruned_processes
         reply_content["kernel_cpu"] = sum(
             [self.get_process_metric_value(process, "cpu_percent", None) for process in all_processes]
         )

--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -76,7 +76,7 @@ class Kernel(SingletonConfigurable):
     # attribute to override with a GUI
     eventloop = Any(None)
 
-    processes = {}
+    processes: dict[str, psutil.Process] = {}
 
     @observe("eventloop")
     def _update_eventloop(self, change):

--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -76,7 +76,7 @@ class Kernel(SingletonConfigurable):
     # attribute to override with a GUI
     eventloop = Any(None)
 
-    processes: dict[str, psutil.Process] = {}
+    processes: t.Dict[str, psutil.Process] = {}
 
     @observe("eventloop")
     def _update_eventloop(self, change):

--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -977,12 +977,12 @@ class Kernel(SingletonConfigurable):
         reply_content = {"hostname": socket.gethostname(), "pid": os.getpid()}
         current_process = psutil.Process()
         all_processes = [current_process] + current_process.children(recursive=True)
-        pruned_processes = {}
-        for process in all_processes:
-            p = self.processes.get(process.pid)
-            if p is not None:
-                pruned_processes[process.pid] = p
-        self.processes = pruned_processes
+        # Ensure 1) self.processes is updated to only current subprocesses
+        # and 2) we reuse processes when possible (needed for accurate CPU)
+        self.processes = {process.pid: self.processes.get(process.pid, process) for process in all_processes}
+        self.processes = {
+            process.pid: self.processes.get(process.pid, process) for process in all_processes
+        }
         reply_content["kernel_cpu"] = sum(
             [self.get_process_metric_value(process, "cpu_percent", None) for process in all_processes]
         )

--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -977,10 +977,16 @@ class Kernel(SingletonConfigurable):
             process.pid: self.processes.get(process.pid, process) for process in all_processes
         }
         reply_content["kernel_cpu"] = sum(
-            [self.get_process_metric_value(process, "cpu_percent", None) for process in self.processes.values()]
+            [
+                self.get_process_metric_value(process, "cpu_percent", None)
+                for process in self.processes.values()
+            ]
         )
         reply_content["kernel_memory"] = sum(
-            [self.get_process_metric_value(process, "memory_info", "rss") for process in self.processes.values()]
+            [
+                self.get_process_metric_value(process, "memory_info", "rss")
+                for process in self.processes.values()
+            ]
         )
         cpu_percent = psutil.cpu_percent()
         # https://psutil.readthedocs.io/en/latest/index.html?highlight=cpu#psutil.cpu_percent


### PR DESCRIPTION
Fixes https://github.com/ipython/ipykernel/issues/912

This add to the control_thread a map of processes to allow the requesting the cpu_usage in a way psutil excepts (the cpu is only correct if is requested on the same process object).