### PR TITLE
Fix richInspectVariables

### DIFF
--- a/ipykernel/debugger.py
+++ b/ipykernel/debugger.py
@@ -26,10 +26,7 @@ try:
         SuspendedFramesManager,
         _FramesTracker,
     )
-    from _pydevd_bundle.pydevd_safe_repr import SafeRepr  # isort: skip
 
-    SafeRepr.maxstring_inner = 2**16
-    SafeRepr.maxother_inner = 2**16
     _is_debugpy_available = True
 except ImportError:
     _is_debugpy_available = False
@@ -598,7 +595,7 @@ class Debugger:
                     "type": "request",
                     "command": "evaluate",
                     "seq": seq + 1,
-                    "arguments": {"expression": code, "frameId": frame_id},
+                    "arguments": {"expression": code, "frameId": frame_id, "context": "clipboard"},
                 }
             )
             if reply["success"]:

--- a/ipykernel/debugger.py
+++ b/ipykernel/debugger.py
@@ -595,7 +595,7 @@ class Debugger:
                     "type": "request",
                     "command": "evaluate",
                     "seq": seq + 1,
-                    "arguments": {"expression": code, "frameId": frame_id},
+                    "arguments": {"expression": code, "frameId": frame_id, "context": "clipboard"},
                 }
             )
             if reply["success"]:

--- a/ipykernel/debugger.py
+++ b/ipykernel/debugger.py
@@ -26,7 +26,10 @@ try:
         SuspendedFramesManager,
         _FramesTracker,
     )
+    from _pydevd_bundle.pydevd_safe_repr import SafeRepr  # isort: skip
 
+    SafeRepr.maxstring_inner = 2**16
+    SafeRepr.maxother_inner = 2**16
     _is_debugpy_available = True
 except ImportError:
     _is_debugpy_available = False

--- a/ipykernel/debugger.py
+++ b/ipykernel/debugger.py
@@ -595,7 +595,7 @@ class Debugger:
                     "type": "request",
                     "command": "evaluate",
                     "seq": seq + 1,
-                    "arguments": {"expression": code, "frameId": frame_id, "context": "clipboard"},
+                    "arguments": {"expression": code, "frameId": frame_id},
                 }
             )
             if reply["success"]:


### PR DESCRIPTION
It seems that we can always use the interpreter to get the rich representation of the variable, whether we hit a breakpoint or not. The problem with the current situation where we hit a breakpoint and display an HTML representation of a variable is that the HTML is striped and we get something like `'text/html': '<div>\n<style scoped>...le>\n</div>'` instead of the full HTML. I can't find where it is striped, but if we don't need this branch anyway, can we just get rid of it?
@JohanMabille what do you think?
Also, @fcollonval might have some feedback since he [refactored that part](https://github.com/ipython/ipykernel/commit/73efd890b64145b0d28ea011df58e0745270458b#diff-a30b59f7d3dd6506cbed49059d190fec6a329aed08722be170c5c0dbacfae56dR530-R552).