### PR TITLE
Support subshells

### DIFF
--- a/ipykernel/inprocess/client.py
+++ b/ipykernel/inprocess/client.py
@@ -179,8 +179,7 @@ class InProcessKernelClient(KernelClient):
         stream = kernel.shell_stream
         self.session.send(stream, msg)
         msg_parts = stream.recv_multipart()
-        loop = asyncio.get_event_loop()
-        loop.run_until_complete(kernel.dispatch_shell(msg_parts))
+        asyncio.run(kernel.dispatch_shell(msg_parts))
         idents, reply_msg = self.session.recv(stream, copy=False)
         self.shell_channel.call_handlers_later(reply_msg)
 

--- a/ipykernel/inprocess/ipkernel.py
+++ b/ipykernel/inprocess/ipkernel.py
@@ -71,6 +71,7 @@ class InProcessKernel(IPythonKernel):
 
         self._underlying_iopub_socket.observe(self._io_dispatch, names=["message_sent"])
         self.shell.kernel = self
+        self.main_shell_queue = None
 
     async def execute_request(self, stream, ident, parent):
         """Override for temporary IO redirection."""

--- a/ipykernel/kernelapp.py
+++ b/ipykernel/kernelapp.py
@@ -43,7 +43,6 @@ from traitlets.utils import filefind
 from traitlets.utils.importstring import import_item
 from zmq.eventloop.zmqstream import ZMQStream
 
-from .shell import ShellThread
 from .control import ControlThread
 from .heartbeat import Heartbeat
 
@@ -51,6 +50,7 @@ from .heartbeat import Heartbeat
 from .iostream import IOPubThread
 from .ipkernel import IPythonKernel
 from .parentpoller import ParentPollerUnix, ParentPollerWindows
+from .shell import ShellThread
 from .zmqshell import ZMQInteractiveShell
 
 # -----------------------------------------------------------------------------

--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -889,7 +889,9 @@ class Kernel(SingletonConfigurable):
             shell_id = str(uuid.uuid4())
         self.log.debug(f"Creating new shell with ID: {shell_id}")
         self.shell_queues[shell_id] = subshell_queue = janus.Queue()
-        self.subshell_threads[shell_id] = subshell_thread = SubshellThread(shell_id, subshell_queue, self)
+        self.subshell_threads[shell_id] = subshell_thread = SubshellThread(
+            shell_id, subshell_queue, self
+        )
         subshell_thread.start()
         content = dict(shell_id=shell_id)
         self.session.send(stream, "subshell_reply", content, parent, ident=ident)

--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -403,7 +403,10 @@ class Kernel(SingletonConfigurable):
             self.log.warning("Unknown message type: %r", msg_type)
         else:
             self.log.debug("%s: %s", msg_type, msg)
-            asyncio.run_coroutine_threadsafe(self.call_handler(shell_id, handler, idents, msg), self.shell_threads[shell_id].io_loop.asyncio_loop)
+            asyncio.run_coroutine_threadsafe(
+                self.call_handler(shell_id, handler, idents, msg),
+                self.shell_threads[shell_id].io_loop.asyncio_loop,
+            )
 
     async def call_handler(self, shell_id, handler, idents, msg):
         try:

--- a/ipykernel/shell.py
+++ b/ipykernel/shell.py
@@ -32,7 +32,7 @@ async def handle_messages(msg_queue, kernel, is_main):
             # flush to ensure reply is sent before
             # handling the next request
             kernel.shell_stream.flush(zmq.POLLOUT)
-            return
+            continue
 
         # Print some info about this message and leave a '--->' marker, so it's
         # easier to trace visually the message chain when debugging.  Each
@@ -41,7 +41,7 @@ async def handle_messages(msg_queue, kernel, is_main):
         kernel.log.debug("   Content: %s\n   --->\n   ", msg["content"])
 
         if not kernel.should_handle(kernel.shell_stream, msg, idents):
-            return
+            continue
 
         handler = kernel.shell_handlers.get(msg_type, None)
         if handler is None:

--- a/ipykernel/shell.py
+++ b/ipykernel/shell.py
@@ -1,3 +1,6 @@
+import asyncio
+import inspect
+import sys
 from threading import Thread
 
 import zmq
@@ -9,23 +12,88 @@ else:
     from zmq.eventloop.ioloop import IOLoop
 
 
+async def handle_messages(msg_queue, kernel):
+    while True:
+        is_main, idents, msg = await msg_queue.get()
+        if is_main:
+            # Set the parent message for side effects.
+            kernel.set_parent(idents, msg, channel="shell")
+            kernel._publish_status("busy", "shell")
+
+        msg_type = msg["header"]["msg_type"]
+
+        # Only abort execute requests
+        if kernel._aborting and msg_type == "execute_request":
+            kernel._send_abort_reply(kernel.shell_stream, msg, idents)
+            kernel._publish_status("idle", "shell")
+            # flush to ensure reply is sent before
+            # handling the next request
+            kernel.shell_stream.flush(zmq.POLLOUT)
+            return
+
+        # Print some info about this message and leave a '--->' marker, so it's
+        # easier to trace visually the message chain when debugging.  Each
+        # handler prints its message at the end.
+        kernel.log.debug("\n*** MESSAGE TYPE:%s***", msg_type)
+        kernel.log.debug("   Content: %s\n   --->\n   ", msg["content"])
+
+        if not kernel.should_handle(kernel.shell_stream, msg, idents):
+            return
+
+        handler = kernel.shell_handlers.get(msg_type, None)
+        if handler is None:
+            kernel.log.warning("Unknown message type: %r", msg_type)
+        else:
+            kernel.log.debug("%s: %s", msg_type, msg)
+            try:
+                kernel.pre_handler_hook()
+            except Exception:
+                kernel.log.debug("Unable to signal in pre_handler_hook:", exc_info=True)
+            try:
+                result = handler(kernel.shell_stream, idents, msg)
+                if inspect.isawaitable(result):
+                    await result
+            except Exception:
+                kernel.log.error("Exception in message handler:", exc_info=True)
+            except KeyboardInterrupt:
+                # Ctrl-c shouldn't crash the kernel here.
+                kernel.log.error("KeyboardInterrupt caught in kernel.")
+            finally:
+                try:
+                    kernel.post_handler_hook()
+                except Exception:
+                    kernel.log.debug("Unable to signal in post_handler_hook:", exc_info=True)
+
+            if is_main:
+                sys.stdout.flush()
+                sys.stderr.flush()
+                kernel._publish_status("idle", "shell")
+
+            # flush to ensure reply is sent before
+            # handling the next request
+            kernel.shell_stream.flush(zmq.POLLOUT)
+
+
+class SubshellThread(Thread):
+    def __init__(self, shell_id, msg_queue, kernel):
+        self.msg_queue = msg_queue
+        self.kernel = kernel
+        super().__init__(name=f"Subshell_{shell_id}", daemon=True)
+
+    def run(self):
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        asyncio.run(handle_messages(self.msg_queue, self.kernel))
+
+
 class ShellThread(Thread):
-    def __init__(self, **kwargs):
-        self._shell_id = kwargs.pop("shell_id")
-        Thread.__init__(self, name=f"Shell_{self._shell_id}", **kwargs)
+    def __init__(self):
+        super().__init__(name="Shell", daemon=True)
         self.io_loop = IOLoop(make_current=False)
 
     def run(self):
-        self.name = f"Shell_{self._shell_id}"
         self.io_loop.make_current()
         try:
             self.io_loop.start()
         finally:
             self.io_loop.close()
-
-    def stop(self):
-        """Stop the thread.
-
-        This method is threadsafe.
-        """
-        self.io_loop.add_callback(self.io_loop.stop)

--- a/ipykernel/shell.py
+++ b/ipykernel/shell.py
@@ -12,69 +12,73 @@ else:
     from zmq.eventloop.ioloop import IOLoop
 
 
+async def handle_message(idents, msg, kernel, is_main):
+    if is_main:
+        # Set the parent message for side effects.
+        kernel.set_parent(idents, msg, channel="shell")
+        kernel._publish_status("busy", "shell")
+
+    msg_type = msg["header"]["msg_type"]
+
+    # Only abort execute requests
+    if kernel._aborting and msg_type == "execute_request":
+        kernel._send_abort_reply(kernel.shell_stream, msg, idents)
+        kernel._publish_status("idle", "shell")
+        # flush to ensure reply is sent before
+        # handling the next request
+        kernel.shell_stream.flush(zmq.POLLOUT)
+        return
+
+    # Print some info about this message and leave a '--->' marker, so it's
+    # easier to trace visually the message chain when debugging.  Each
+    # handler prints its message at the end.
+    kernel.log.debug("\n*** MESSAGE TYPE:%s***", msg_type)
+    kernel.log.debug("   Content: %s\n   --->\n   ", msg["content"])
+
+    if not kernel.should_handle(kernel.shell_stream, msg, idents):
+        return
+
+    handler = kernel.shell_handlers.get(msg_type, None)
+    if handler is None:
+        kernel.log.warning("Unknown message type: %r", msg_type)
+    else:
+        kernel.log.debug("%s: %s", msg_type, msg)
+        try:
+            kernel.pre_handler_hook()
+        except Exception:
+            kernel.log.debug("Unable to signal in pre_handler_hook:", exc_info=True)
+        try:
+            result = handler(kernel.shell_stream, idents, msg)
+            if inspect.isawaitable(result):
+                await result
+        except Exception:
+            kernel.log.error("Exception in message handler:", exc_info=True)
+        except KeyboardInterrupt:
+            # Ctrl-c shouldn't crash the kernel here.
+            kernel.log.error("KeyboardInterrupt caught in kernel.")
+        finally:
+            try:
+                kernel.post_handler_hook()
+            except Exception:
+                kernel.log.debug("Unable to signal in post_handler_hook:", exc_info=True)
+
+        if is_main:
+            sys.stdout.flush()
+            sys.stderr.flush()
+            kernel._publish_status("idle", "shell")
+
+        # flush to ensure reply is sent before
+        # handling the next request
+        kernel.shell_stream.flush(zmq.POLLOUT)
+
+
 async def handle_messages(msg_queue, kernel, is_main):
     while True:
         res = msg_queue.get()
         if is_main:
             res = await res
         idents, msg = res
-        if is_main:
-            # Set the parent message for side effects.
-            kernel.set_parent(idents, msg, channel="shell")
-            kernel._publish_status("busy", "shell")
-
-        msg_type = msg["header"]["msg_type"]
-
-        # Only abort execute requests
-        if kernel._aborting and msg_type == "execute_request":
-            kernel._send_abort_reply(kernel.shell_stream, msg, idents)
-            kernel._publish_status("idle", "shell")
-            # flush to ensure reply is sent before
-            # handling the next request
-            kernel.shell_stream.flush(zmq.POLLOUT)
-            continue
-
-        # Print some info about this message and leave a '--->' marker, so it's
-        # easier to trace visually the message chain when debugging.  Each
-        # handler prints its message at the end.
-        kernel.log.debug("\n*** MESSAGE TYPE:%s***", msg_type)
-        kernel.log.debug("   Content: %s\n   --->\n   ", msg["content"])
-
-        if not kernel.should_handle(kernel.shell_stream, msg, idents):
-            continue
-
-        handler = kernel.shell_handlers.get(msg_type, None)
-        if handler is None:
-            kernel.log.warning("Unknown message type: %r", msg_type)
-        else:
-            kernel.log.debug("%s: %s", msg_type, msg)
-            try:
-                kernel.pre_handler_hook()
-            except Exception:
-                kernel.log.debug("Unable to signal in pre_handler_hook:", exc_info=True)
-            try:
-                result = handler(kernel.shell_stream, idents, msg)
-                if inspect.isawaitable(result):
-                    await result
-            except Exception:
-                kernel.log.error("Exception in message handler:", exc_info=True)
-            except KeyboardInterrupt:
-                # Ctrl-c shouldn't crash the kernel here.
-                kernel.log.error("KeyboardInterrupt caught in kernel.")
-            finally:
-                try:
-                    kernel.post_handler_hook()
-                except Exception:
-                    kernel.log.debug("Unable to signal in post_handler_hook:", exc_info=True)
-
-            if is_main:
-                sys.stdout.flush()
-                sys.stderr.flush()
-                kernel._publish_status("idle", "shell")
-
-            # flush to ensure reply is sent before
-            # handling the next request
-            kernel.shell_stream.flush(zmq.POLLOUT)
+        await handle_message(idents, msg, kernel, is_main)
 
 
 class SubshellThread(Thread):

--- a/ipykernel/shell.py
+++ b/ipykernel/shell.py
@@ -1,0 +1,31 @@
+from threading import Thread
+
+import zmq
+
+if zmq.pyzmq_version_info() >= (17, 0):
+    from tornado.ioloop import IOLoop
+else:
+    # deprecated since pyzmq 17
+    from zmq.eventloop.ioloop import IOLoop
+
+
+class ShellThread(Thread):
+    def __init__(self, **kwargs):
+        self._shell_id = kwargs.pop("shell_id")
+        Thread.__init__(self, name=f"Shell_{self._shell_id}", **kwargs)
+        self.io_loop = IOLoop(make_current=False)
+
+    def run(self):
+        self.name = f"Shell_{self._shell_id}"
+        self.io_loop.make_current()
+        try:
+            self.io_loop.start()
+        finally:
+            self.io_loop.close()
+
+    def stop(self):
+        """Stop the thread.
+
+        This method is threadsafe.
+        """
+        self.io_loop.add_callback(self.io_loop.stop)

--- a/ipykernel/tests/test_subshell.py
+++ b/ipykernel/tests/test_subshell.py
@@ -1,0 +1,60 @@
+import time
+from textwrap import dedent
+
+from jupyter_client.manager import start_new_kernel
+
+
+def test_subshell():
+    km, kc = start_new_kernel()
+
+    shell_id = "foo"
+    content = dict(shell_id=shell_id)
+    msg = kc.session.msg("subshell_request", content)
+    kc.shell_channel.send(msg)
+    msg = kc.get_shell_msg()
+    assert msg["content"]["shell_id"] == shell_id
+
+    def get_content(t):
+        code = dedent(
+            f"""
+            import time
+
+            time.sleep({t})
+            """
+        )
+        content = dict(
+            code=code,
+            silent=False,
+        )
+        return content
+
+    # launch execution in main shell
+    t0 = time.time()
+    msg0 = kc.session.msg("execute_request", get_content(0.3))
+    kc.shell_channel.send(msg0)
+
+    time.sleep(0.1)
+
+    # launch execution in subshell while main shell is executing
+    t1 = time.time()
+    metadata = dict(shell_id=shell_id)
+    msg1 = kc.session.msg("execute_request", get_content(0.1), metadata=metadata)
+    kc.shell_channel.send(msg1)
+
+    msg_cnt = 0
+    while True:
+        msg = kc.get_shell_msg()
+        t = time.time()
+        if msg["parent_header"]["msg_id"] == msg0["msg_id"]:
+            # main shell execution should take ~0.3s
+            assert 0.3 < t - t0 < 0.4
+            msg_cnt += 1
+        elif msg["parent_header"]["msg_id"] == msg1["msg_id"]:
+            # subshell execution should take ~0.1s if done in parallel
+            assert 0.1 < t - t1 < 0.2
+            msg_cnt += 1
+        if msg_cnt == 2:
+            break
+
+    kc.stop_channels()
+    km.shutdown_kernel()

--- a/ipykernel/tests/test_subshell.py
+++ b/ipykernel/tests/test_subshell.py
@@ -10,8 +10,8 @@ def test_subshell():
     shell_id = "foo"
     content = dict(shell_id=shell_id)
     msg = kc.session.msg("subshell_request", content)
-    kc.shell_channel.send(msg)
-    msg = kc.get_shell_msg()
+    kc.control_channel.send(msg)
+    msg = kc.get_control_msg()
     assert msg["content"]["shell_id"] == shell_id
 
     def get_content(t):

--- a/ipykernel/tests/test_subshell.py
+++ b/ipykernel/tests/test_subshell.py
@@ -41,20 +41,19 @@ def test_subshell():
     msg1 = kc.session.msg("execute_request", get_content(0.1), metadata=metadata)
     kc.shell_channel.send(msg1)
 
-    msg_cnt = 0
-    while True:
-        msg = kc.get_shell_msg()
-        t = time.time()
-        if msg["parent_header"]["msg_id"] == msg0["msg_id"]:
-            # main shell execution should take ~0.3s
-            assert 0.3 < t - t0 < 0.4
-            msg_cnt += 1
-        elif msg["parent_header"]["msg_id"] == msg1["msg_id"]:
-            # subshell execution should take ~0.1s if done in parallel
-            assert 0.1 < t - t1 < 0.2
-            msg_cnt += 1
-        if msg_cnt == 2:
-            break
+    msg = kc.get_shell_msg()
+    t = time.time()
+    # subshell should have finished execution first
+    assert msg["parent_header"]["msg_id"] == msg1["msg_id"]
+    # subshell execution should take ~0.1s if done in parallel
+    assert 0.1 < t - t1 < 0.2
+
+    msg = kc.get_shell_msg()
+    t = time.time()
+    # main shell shoud have finished execution last
+    assert msg["parent_header"]["msg_id"] == msg0["msg_id"]
+    # main shell execution should take ~0.3s
+    assert 0.3 < t - t0 < 0.4
 
     kc.stop_channels()
     km.shutdown_kernel()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
     "psutil",
     "nest_asyncio",
     "packaging",
+    "janus>=1.0.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
This PR aims at implementing potential solutions to support "subshells" (see https://github.com/jupyter/jupyter_client/issues/806).

In this first commit, the main shell runs in its own thread (which is not the main thread). A subshell can be created through a `subshell_request` received on the `shell` channel. This creates a new thread for this subshell, identified by a subshell ID. A request targeting this subshell must specify its `subshell_id` in the `metadata` (if not specified, then the request is targeting the main shell).
Shell messages are received in the main thread and handled in the thread corresponding to the shell ID (the ID of the main shell is `main`, the ID of a subshell is a UUID). Thus, it is always possible to receive shell messages, even if a shell request is being handled.
This approach modifies the behavior of ipykernel in the following ways:
- if cells are cooperative (i.e. they have a top-level `await`), then they can be executed concurrently, similarly to what [akernel](https://github.com/davidbrochart/akernel) does.
- because the main shell is not executed in the main thread, it can potentially have consequences on code that expects to run in the main thread.
- the handling of side-effects (e.g. printing to `stdout` or `stderr`) currently makes the assumption that shell requests are received and handled one at a time, which is not the case anymore: the next shell request can be received while the previous one is being handled.