### PR TITLE
Fix compatibility with tornado 6.2 beta

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Install the Python dependencies
         run: |
-          pip install .[test] codecov
+          pip install --pre .[test] codecov
 
       - name: Install matplotlib
         if: ${{ !startsWith(matrix.os, 'macos') && !startsWith(matrix.python-version, 'pypy') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Install the Python dependencies
         run: |
-          pip install --pre .[test] codecov
+          pip install .[test] codecov
 
       - name: Install matplotlib
         if: ${{ !startsWith(matrix.os, 'macos') && !startsWith(matrix.python-version, 'pypy') }}

--- a/ipykernel/control.py
+++ b/ipykernel/control.py
@@ -1,24 +1,17 @@
 from threading import Thread
 
-import zmq
-
-if zmq.pyzmq_version_info() >= (17, 0):
-    from tornado.ioloop import IOLoop
-else:
-    # deprecated since pyzmq 17
-    from zmq.eventloop.ioloop import IOLoop
+from tornado.platform.asyncio import AsyncIOLoop
 
 
 class ControlThread(Thread):
     def __init__(self, **kwargs):
         Thread.__init__(self, name="Control", **kwargs)
-        self.io_loop = IOLoop(make_current=False)
+        self.io_loop = AsyncIOLoop(make_current=False)
         self.pydev_do_not_trace = True
         self.is_pydev_daemon_thread = True
 
     def run(self):
         self.name = "Control"
-        self.io_loop.make_current()
         try:
             self.io_loop.start()
         finally:


### PR DESCRIPTION
I _suspect_  this will reveal failures with the latest tornado 6.2 beta, which is mainly an update to try to deal with asyncio getting rid of the notion of a 'current' event loop that's not running.