### PR TITLE
Explicitly require pyzmq >= 17

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "tornado>=6.1",
     "matplotlib-inline>=0.1",
     'appnope;platform_system=="Darwin"',
+    "pyzmq>=17",
     "psutil",
     "nest_asyncio",
     "packaging",


### PR DESCRIPTION
pyzmq is pulled transitively from jupyter-client, so this will have little to no effect in practice, but it is a direct dependency here.

pyzmq 17 is the version that introduces support for running directly with tornado

it's possible an even more recent version is required