### PR TITLE
Back to top-level tornado IOLoop

### DIFF
--- a/ipykernel/control.py
+++ b/ipykernel/control.py
@@ -1,12 +1,12 @@
 from threading import Thread
 
-from tornado.platform.asyncio import AsyncIOLoop
+from tornado.ioloop import IOLoop
 
 
 class ControlThread(Thread):
     def __init__(self, **kwargs):
         Thread.__init__(self, name="Control", **kwargs)
-        self.io_loop = AsyncIOLoop(make_current=False)
+        self.io_loop = IOLoop(make_current=False)
         self.pydev_do_not_trace = True
         self.is_pydev_daemon_thread = True
 

--- a/ipykernel/iostream.py
+++ b/ipykernel/iostream.py
@@ -18,10 +18,7 @@ from weakref import WeakSet
 
 import zmq
 from jupyter_client.session import extract_header
-
-# AsyncIOLoop always creates a new asyncio event loop,
-# rather than the default AsyncIOMainLoop
-from tornado.platform.asyncio import AsyncIOLoop
+from tornado.ioloop import IOLoop
 from zmq.eventloop.zmqstream import ZMQStream
 
 # -----------------------------------------------------------------------------
@@ -60,7 +57,7 @@ class IOPubThread:
         self.background_socket = BackgroundSocket(self)
         self._master_pid = os.getpid()
         self._pipe_flag = pipe
-        self.io_loop = AsyncIOLoop(make_current=False)
+        self.io_loop = IOLoop(make_current=False)
         if pipe:
             self._setup_pipe_in()
         self._local = threading.local()


### PR DESCRIPTION
I think I misunderstood deprecation warnings about make_current in #956, and this works after all. It may be that all we needed was the removal of `loop.make_current()`