### PR TITLE
[WIP] PR: Call `Tk.quit` to prevent Spyder IPython Console to freeze when debugging

### DIFF
--- a/ipykernel/eventloops.py
+++ b/ipykernel/eventloops.py
@@ -283,6 +283,7 @@ def loop_tk(kernel):
                     loop.run_until_complete(self.func())
                 except Exception:
                     kernel.log.exception("Error in message handler")
+                self.app.quit()
                 self.app.after(poll_interval, self.on_timer)
 
             def start(self):


### PR DESCRIPTION
Hi! While checking spyder-ide/spyder#17523 seems like adding a call to `self.app.quit()` on the `TimedAppWrapper.on_timer` definition allows the debugging to work as expected when the Tkinter backend is selected inside Spyder.

Part of spyder-ide/spyder#17523