### PR TITLE
Enable webagg in %matplotlib

### DIFF
--- a/ipykernel/eventloops.py
+++ b/ipykernel/eventloops.py
@@ -60,6 +60,7 @@ def _notify_stream_qt(kernel):
 loop_map = {
     "inline": None,
     "nbagg": None,
+    "webagg": None,
     "notebook": None,
     "ipympl": None,
     "widget": None,


### PR DESCRIPTION
webagg is enabled in %matplotlib magic in the latest IPython 8.6.0 via this PR:
https://github.com/ipython/ipython/pull/13778

However this trivial change is needed for it to work in an ipykernel environment, otherwise an exception is thrown.