### PR TITLE
fix: use comm package in backwards compatible way

### DIFF
--- a/ipykernel/comm/__init__.py
+++ b/ipykernel/comm/__init__.py
@@ -1,5 +1,4 @@
 __all__ = ["Comm", "CommManager"]
 
-from comm.base_comm import CommManager  # noqa
-
 from .comm import Comm  # noqa
+from .manager import CommManager

--- a/ipykernel/comm/comm.py
+++ b/ipykernel/comm/comm.py
@@ -3,6 +3,7 @@
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
 
+from typing import Optional
 import comm.base_comm
 import traitlets.config
 
@@ -12,6 +13,8 @@ from ipykernel.kernelbase import Kernel
 
 # this is the class that will be created if we do comm.create_comm
 class BaseComm(comm.base_comm.BaseComm):
+    kernel: Optional[Kernel]
+
     def publish_msg(self, msg_type, data=None, metadata=None, buffers=None, **keys):
         """Helper for sending a comm message on IOPub"""
         if not Kernel.initialized():

--- a/ipykernel/comm/comm.py
+++ b/ipykernel/comm/comm.py
@@ -4,6 +4,7 @@
 # Distributed under the terms of the Modified BSD License.
 
 from typing import Optional
+
 import comm.base_comm
 import traitlets.config
 

--- a/ipykernel/comm/comm.py
+++ b/ipykernel/comm/comm.py
@@ -4,21 +4,14 @@
 # Distributed under the terms of the Modified BSD License.
 
 import traitlets.config
-from comm.base_comm import BaseComm
-
 from ipykernel.jsonutil import json_clean
 from ipykernel.kernelbase import Kernel
 
+import comm.base_comm
 
-class Comm(traitlets.config.LoggingConfigurable, BaseComm):
-    """Class for communicating between a Frontend and a Kernel"""
 
-    def __init__(self, *args, **kwargs):
-        self.kernel = None
-        # Comm takes positional arguments, LoggingConfigurable does not, so we explicitly forward arguments
-        traitlets.config.LoggingConfigurable.__init__(self, **kwargs)
-        BaseComm.__init__(self, *args, **kwargs)
-
+# this is the class that will be created if we do comm.create_comm
+class BaseComm(comm.base_comm.BaseComm):
     def publish_msg(self, msg_type, data=None, metadata=None, buffers=None, **keys):
         """Helper for sending a comm message on IOPub"""
         if not Kernel.initialized():
@@ -40,6 +33,17 @@ class Comm(traitlets.config.LoggingConfigurable, BaseComm):
             ident=self.topic,
             buffers=buffers,
         )
+
+
+# but for backwards compatibility, we need to inherit from LoggingConfigurable
+class Comm(traitlets.config.LoggingConfigurable, BaseComm):
+    """Class for communicating between a Frontend and a Kernel"""
+
+    def __init__(self, *args, **kwargs):
+        self.kernel = None
+        # Comm takes positional arguments, LoggingConfigurable does not, so we explicitly forward arguments
+        traitlets.config.LoggingConfigurable.__init__(self, **kwargs)
+        BaseComm.__init__(self, *args, **kwargs)
 
 
 __all__ = ["Comm"]

--- a/ipykernel/comm/comm.py
+++ b/ipykernel/comm/comm.py
@@ -3,11 +3,11 @@
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
 
+import comm.base_comm
 import traitlets.config
+
 from ipykernel.jsonutil import json_clean
 from ipykernel.kernelbase import Kernel
-
-import comm.base_comm
 
 
 # this is the class that will be created if we do comm.create_comm

--- a/ipykernel/comm/comm.py
+++ b/ipykernel/comm/comm.py
@@ -3,19 +3,21 @@
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
 
+import traitlets.config
 from comm.base_comm import BaseComm
 
 from ipykernel.jsonutil import json_clean
 from ipykernel.kernelbase import Kernel
 
 
-class Comm(BaseComm):
+class Comm(traitlets.config.LoggingConfigurable, BaseComm):
     """Class for communicating between a Frontend and a Kernel"""
 
     def __init__(self, *args, **kwargs):
         self.kernel = None
-
-        super().__init__(*args, **kwargs)
+        # Comm takes positional arguments, LoggingConfigurable does not, so we explicitly forward arguments
+        traitlets.config.LoggingConfigurable.__init__(self, **kwargs)
+        BaseComm.__init__(self, *args, **kwargs)
 
     def publish_msg(self, msg_type, data=None, metadata=None, buffers=None, **keys):
         """Helper for sending a comm message on IOPub"""

--- a/ipykernel/comm/manager.py
+++ b/ipykernel/comm/manager.py
@@ -3,4 +3,13 @@
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-from comm.base_comm import CommManager  # noqa
+
+import comm.base_comm
+import traitlets.config
+
+
+class CommManager(traitlets.config.LoggingConfigurable, comm.base_comm.CommManager):
+    def __init__(self, **kwargs):
+        # CommManager doesn't take arguments, so we explicitly forward arguments
+        traitlets.config.LoggingConfigurable.__init__(self, **kwargs)
+        comm.base_comm.CommManager.__init__(self)

--- a/ipykernel/ipkernel.py
+++ b/ipykernel/ipkernel.py
@@ -15,7 +15,7 @@ from IPython.utils.tokenutil import line_at_cursor, token_at_cursor
 from traitlets import Any, Bool, Instance, List, Type, observe, observe_compat
 from zmq.eventloop.zmqstream import ZMQStream
 
-from .comm import Comm
+from .comm.comm import BaseComm
 from .compiler import XCachingCompiler
 from .debugger import Debugger, _is_debugpy_available
 from .eventloops import _use_appnope
@@ -42,8 +42,6 @@ _EXPERIMENTAL_KEY_NAME = "_jupyter_types_experimental"
 
 def create_comm(*args, **kwargs):
     """Create a new Comm."""
-    from .comm.comm import BaseComm
-
     return BaseComm(*args, **kwargs)
 
 

--- a/ipykernel/ipkernel.py
+++ b/ipykernel/ipkernel.py
@@ -42,7 +42,8 @@ _EXPERIMENTAL_KEY_NAME = "_jupyter_types_experimental"
 
 def create_comm(*args, **kwargs):
     """Create a new Comm."""
-    return Comm(*args, **kwargs)
+    from .comm.comm import BaseComm
+    return BaseComm(*args, **kwargs)
 
 
 comm.create_comm = create_comm

--- a/ipykernel/ipkernel.py
+++ b/ipykernel/ipkernel.py
@@ -43,6 +43,7 @@ _EXPERIMENTAL_KEY_NAME = "_jupyter_types_experimental"
 def create_comm(*args, **kwargs):
     """Create a new Comm."""
     from .comm.comm import BaseComm
+
     return BaseComm(*args, **kwargs)
 
 


### PR DESCRIPTION
This makes use of the comm package, but in a backwards compatible way.

Alternative to https://github.com/ipython/comm/pull/6

See 
 * https://github.com/ipython/ipykernel/issues/1026
 * https://github.com/ipython/comm/pull/6