### PR TITLE
Clean up testing and coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,0 @@
-[run]
-omit = ipykernel/tests/*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,7 @@ nowarn = "test -W default {args}"
 
 [tool.hatch.envs.cov]
 features = ["test"]
-dependencies = ["coverage", "pytest-cov", "matplotlib", "curio", "trio"]
+dependencies = ["coverage[toml]", "pytest-cov", "matplotlib", "curio", "trio"]
 [tool.hatch.envs.cov.scripts]
 test = "python -m pytest -vv --cov ipykernel --cov-branch --cov-report term-missing:skip-covered {args}"
 nowarn = "test -W default {args}"
@@ -142,6 +142,7 @@ exclude_lines = [
   "class .*\bProtocol\\):",
   "@(abc\\.)?abstractmethod",
 ]
+omit = ["ipykernel/debugger.py", "ipykernel/eventloops.py"]
 
 [tool.flake8]
 ignore = "E501, W503, E402"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,7 +142,13 @@ exclude_lines = [
   "class .*\bProtocol\\):",
   "@(abc\\.)?abstractmethod",
 ]
-omit = ["ipykernel/debugger.py", "ipykernel/eventloops.py"]
+
+[tool.coverage.run]
+omit = [
+  "ipykernel/tests/*",
+  "ipykernel/debugger.py",
+  "ipykernel/eventloops.py",
+]
 
 [tool.flake8]
 ignore = "E501, W503, E402"


### PR DESCRIPTION
- Remove `debugger` and `eventloops` from coverage since they can't be tested directly.  Debugger is tested indirectly.
- Add more coverage of kernel base