### PR TITLE
Configurables needs to be configurable

### DIFF
--- a/ipykernel/ipkernel.py
+++ b/ipykernel/ipkernel.py
@@ -55,13 +55,13 @@ def _create_comm(*args, **kwargs):
     return BaseComm(*args, **kwargs)
 
 
-def _create_manager(*args, **kwargs):
+def _get_comm_manager(*args, **kwargs):
     """Create a new CommManager."""
     return CommManager(*args, **kwargs)
 
 
 comm.create_comm = _create_comm
-comm.create_manager = _create_manager
+comm.get_comm_manager = _get_comm_manager
 
 
 class IPythonKernel(KernelBase):

--- a/ipykernel/ipkernel.py
+++ b/ipykernel/ipkernel.py
@@ -24,7 +24,7 @@ from traitlets import (
 )
 from zmq.eventloop.zmqstream import ZMQStream
 
-from .comm.comm import BaseComm, CommManager
+from .comm import BaseComm, CommManager
 from .compiler import XCachingCompiler
 from .debugger import Debugger, _is_debugpy_available
 from .eventloops import _use_appnope

--- a/ipykernel/ipkernel.py
+++ b/ipykernel/ipkernel.py
@@ -24,7 +24,8 @@ from traitlets import (
 )
 from zmq.eventloop.zmqstream import ZMQStream
 
-from .comm import BaseComm, CommManager
+from .comm.comm import BaseComm
+from .comm.manager import CommManager
 from .compiler import XCachingCompiler
 from .debugger import Debugger, _is_debugpy_available
 from .eventloops import _use_appnope

--- a/ipykernel/ipkernel.py
+++ b/ipykernel/ipkernel.py
@@ -12,7 +12,16 @@ from functools import partial
 import comm
 from IPython.core import release
 from IPython.utils.tokenutil import line_at_cursor, token_at_cursor
-from traitlets import Any, Bool, Instance, List, Type, observe, observe_compat, HasTraits
+from traitlets import (
+    Any,
+    Bool,
+    HasTraits,
+    Instance,
+    List,
+    Type,
+    observe,
+    observe_compat,
+)
 from zmq.eventloop.zmqstream import ZMQStream
 
 from .comm.comm import BaseComm

--- a/ipykernel/ipkernel.py
+++ b/ipykernel/ipkernel.py
@@ -24,7 +24,7 @@ from traitlets import (
 )
 from zmq.eventloop.zmqstream import ZMQStream
 
-from .comm.comm import BaseComm
+from .comm.comm import BaseComm, CommManager
 from .compiler import XCachingCompiler
 from .debugger import Debugger, _is_debugpy_available
 from .eventloops import _use_appnope

--- a/ipykernel/ipkernel.py
+++ b/ipykernel/ipkernel.py
@@ -12,7 +12,7 @@ from functools import partial
 import comm
 from IPython.core import release
 from IPython.utils.tokenutil import line_at_cursor, token_at_cursor
-from traitlets import Any, Bool, Instance, List, Type, observe, observe_compat
+from traitlets import Any, Bool, Instance, List, Type, observe, observe_compat, HasTraits
 from zmq.eventloop.zmqstream import ZMQStream
 
 from .comm.comm import BaseComm
@@ -112,6 +112,7 @@ class IPythonKernel(KernelBase):
 
         self.comm_manager = comm.get_comm_manager()
 
+        assert isinstance(self.comm_manager, HasTraits)
         self.shell.configurables.append(self.comm_manager)
         comm_msg_types = ["comm_open", "comm_msg", "comm_close"]
         for msg_type in comm_msg_types:

--- a/ipykernel/ipkernel.py
+++ b/ipykernel/ipkernel.py
@@ -49,12 +49,18 @@ except ImportError:
 _EXPERIMENTAL_KEY_NAME = "_jupyter_types_experimental"
 
 
-def create_comm(*args, **kwargs):
+def _create_comm(*args, **kwargs):
     """Create a new Comm."""
     return BaseComm(*args, **kwargs)
 
 
-comm.create_comm = create_comm
+def _create_manager(*args, **kwargs):
+    """Create a new CommManager."""
+    return CommManager(*args, **kwargs)
+
+
+comm.create_comm = _create_comm
+comm.create_manager = _create_manager
 
 
 class IPythonKernel(KernelBase):

--- a/ipykernel/tests/test_ipkernel_direct.py
+++ b/ipykernel/tests/test_ipkernel_direct.py
@@ -7,7 +7,7 @@ import pytest
 import zmq
 from IPython.core.history import DummyDB
 
-from ipykernel.ipkernel import BaseComm, IPythonKernel, create_comm
+from ipykernel.ipkernel import BaseComm, IPythonKernel, _create_comm
 
 from .conftest import MockIPyKernel
 
@@ -187,7 +187,7 @@ async def test_start_no_debugpy(ipkernel: IPythonKernel):
 
 
 def test_create_comm():
-    assert isinstance(create_comm(), BaseComm)
+    assert isinstance(_create_comm(), BaseComm)
 
 
 def test_finish_metadata(ipkernel: IPythonKernel):


### PR DESCRIPTION
IPython rely on configurables being configurables to ... configure things.

Comm seem to insert or return a non-configurable in IPython, that make ipykernel crash in some instances. For example but not limited to:

    %config Completer.use_jedi = False

Or trying to use hvplot for example.

This is just a "this is wrong" PR, there should be a proper fix, and I will likely add a hard check in IPython that what is added in configurables is actually a configurables.

This will need a fix in a Comm pacakge.