### PR TITLE
Fix Comm interface for downstream users

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -52,7 +52,7 @@ jobs:
         uses: jupyterlab/maintainer-tools/.github/actions/downstream-test@v1
         with:
           package_name: jdaviz
-          test_command: pytest --pyargs jdaviz
+          test_command: pytest --pyargs jdaviz -W defaulut
 
   jupyter_client:
     runs-on: ubuntu-latest

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -52,7 +52,7 @@ jobs:
         uses: jupyterlab/maintainer-tools/.github/actions/downstream-test@v1
         with:
           package_name: jdaviz
-          test_command: pytest --pyargs jdaviz -W defaulut
+          test_command: pytest --pyargs jdaviz -W default
 
   jupyter_client:
     runs-on: ubuntu-latest

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -52,7 +52,7 @@ jobs:
         uses: jupyterlab/maintainer-tools/.github/actions/downstream-test@v1
         with:
           package_name: jdaviz
-          test_command: pytest --pyargs jdaviz -W default
+          test_command: cd $HOME && pytest --pyargs jdaviz -W default
 
   jupyter_client:
     runs-on: ubuntu-latest

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -25,6 +25,20 @@ jobs:
           package_name: nbclient
           env_values: IPYKERNEL_CELL_NAME=\<IPY-INPUT\>
 
+  ipywidgets:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Base Setup
+        uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+
+      - name: Run Test
+        uses: jupyterlab/maintainer-tools/.github/actions/downstream-test@v1
+        with:
+          package_name: ipywidgets
+
   jupyter_client:
     runs-on: ubuntu-latest
     steps:
@@ -69,3 +83,18 @@ jobs:
           cd jupyter_kernel_test
           pip install -e ".[test]"
           python test_ipykernel.py
+
+  downstream_check: # This job does nothing and is only used for the branch protection
+    if: always()
+    needs:
+      - nbclient
+      - ipywidgets
+      - jupyter_client
+      - ipyparallel
+      - jupyter_kernel_test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Decide whether the needed jobs succeeded or failed
+        uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -39,6 +39,20 @@ jobs:
         with:
           package_name: ipywidgets
 
+  jdaviz:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Base Setup
+        uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+
+      - name: Run Test
+        uses: jupyterlab/maintainer-tools/.github/actions/downstream-test@v1
+        with:
+          package_name: jdaviz
+
   jupyter_client:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -39,21 +39,6 @@ jobs:
         with:
           package_name: ipywidgets
 
-  jdaviz:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Base Setup
-        uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
-
-      - name: Run Test
-        uses: jupyterlab/maintainer-tools/.github/actions/downstream-test@v1
-        with:
-          package_name: jdaviz
-          test_command: cd $HOME && pytest --pyargs jdaviz -W default
-
   jupyter_client:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -52,6 +52,7 @@ jobs:
         uses: jupyterlab/maintainer-tools/.github/actions/downstream-test@v1
         with:
           package_name: jdaviz
+          test_command: pytest --pyargs jdaviz
 
   jupyter_client:
     runs-on: ubuntu-latest

--- a/ipykernel/comm/comm.py
+++ b/ipykernel/comm/comm.py
@@ -7,6 +7,7 @@ from typing import Optional
 
 import comm.base_comm
 import traitlets.config
+from traitlets import Instance, default
 
 from ipykernel.jsonutil import json_clean
 from ipykernel.kernelbase import Kernel
@@ -43,8 +44,14 @@ class BaseComm(comm.base_comm.BaseComm):
 class Comm(traitlets.config.LoggingConfigurable, BaseComm):
     """Class for communicating between a Frontend and a Kernel"""
 
+    kernel = Instance("ipykernel.kernelbase.Kernel", allow_none=True)
+    @default("kernel")
+    def _default_kernel(self):
+        if Kernel.initialized():
+            return Kernel.instance()
+
+
     def __init__(self, *args, **kwargs):
-        self.kernel = None
         # Comm takes positional arguments, LoggingConfigurable does not, so we explicitly forward arguments
         traitlets.config.LoggingConfigurable.__init__(self, **kwargs)
         BaseComm.__init__(self, *args, **kwargs)

--- a/ipykernel/comm/comm.py
+++ b/ipykernel/comm/comm.py
@@ -7,7 +7,7 @@ from typing import Optional
 
 import comm.base_comm
 import traitlets.config
-from traitlets import Instance, default
+from traitlets import Instance, default, Unicode, Bool, Bytes 
 
 from ipykernel.jsonutil import json_clean
 from ipykernel.kernelbase import Kernel
@@ -44,12 +44,24 @@ class BaseComm(comm.base_comm.BaseComm):
 class Comm(traitlets.config.LoggingConfigurable, BaseComm):
     """Class for communicating between a Frontend and a Kernel"""
 
-    kernel = Instance("ipykernel.kernelbase.Kernel", allow_none=True)
+    kernel = Instance("ipykernel.kernelbase.Kernel", allow_none=True)  # type:ignore[assignment]
+    comm_id = Unicode()
+    primary = Bool(True, help="Am I the primary or secondary Comm?")
+
+    target_name = Unicode('comm')
+    target_module = Unicode(None, allow_none=True, help="""requirejs module from
+        which to load comm target.""")
+
+    topic = Bytes()
 
     @default("kernel")
     def _default_kernel(self):
         if Kernel.initialized():
             return Kernel.instance()
+
+    @default('comm_id')
+    def _default_comm_id(self):
+        return uuid.uuid4().hex
 
     def __init__(self, *args, **kwargs):
         # Comm takes positional arguments, LoggingConfigurable does not, so we explicitly forward arguments

--- a/ipykernel/comm/comm.py
+++ b/ipykernel/comm/comm.py
@@ -3,6 +3,7 @@
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
 
+import uuid
 from typing import Optional
 
 import comm.base_comm

--- a/ipykernel/comm/comm.py
+++ b/ipykernel/comm/comm.py
@@ -7,7 +7,7 @@ from typing import Optional
 
 import comm.base_comm
 import traitlets.config
-from traitlets import Instance, default, Unicode, Bool, Bytes 
+from traitlets import Bool, Bytes, Instance, Unicode, default
 
 from ipykernel.jsonutil import json_clean
 from ipykernel.kernelbase import Kernel
@@ -48,9 +48,13 @@ class Comm(traitlets.config.LoggingConfigurable, BaseComm):
     comm_id = Unicode()
     primary = Bool(True, help="Am I the primary or secondary Comm?")
 
-    target_name = Unicode('comm')
-    target_module = Unicode(None, allow_none=True, help="""requirejs module from
-        which to load comm target.""")
+    target_name = Unicode("comm")
+    target_module = Unicode(
+        None,
+        allow_none=True,
+        help="""requirejs module from
+        which to load comm target.""",
+    )
 
     topic = Bytes()
 
@@ -59,7 +63,7 @@ class Comm(traitlets.config.LoggingConfigurable, BaseComm):
         if Kernel.initialized():
             return Kernel.instance()
 
-    @default('comm_id')
+    @default("comm_id")
     def _default_comm_id(self):
         return uuid.uuid4().hex
 

--- a/ipykernel/comm/comm.py
+++ b/ipykernel/comm/comm.py
@@ -45,11 +45,11 @@ class Comm(traitlets.config.LoggingConfigurable, BaseComm):
     """Class for communicating between a Frontend and a Kernel"""
 
     kernel = Instance("ipykernel.kernelbase.Kernel", allow_none=True)
+
     @default("kernel")
     def _default_kernel(self):
         if Kernel.initialized():
             return Kernel.instance()
-
 
     def __init__(self, *args, **kwargs):
         # Comm takes positional arguments, LoggingConfigurable does not, so we explicitly forward arguments

--- a/ipykernel/comm/manager.py
+++ b/ipykernel/comm/manager.py
@@ -6,9 +6,16 @@
 
 import comm.base_comm
 import traitlets.config
+import traitlets
+
 
 
 class CommManager(traitlets.config.LoggingConfigurable, comm.base_comm.CommManager):
+
+    kernel = traitlets.Instance('ipykernel.kernelbase.Kernel')
+    comms = traitlets.Dict()
+    targets = traitlets.Dict()
+
     def __init__(self, **kwargs):
         # CommManager doesn't take arguments, so we explicitly forward arguments
         traitlets.config.LoggingConfigurable.__init__(self, **kwargs)

--- a/ipykernel/comm/manager.py
+++ b/ipykernel/comm/manager.py
@@ -5,14 +5,13 @@
 
 
 import comm.base_comm
-import traitlets.config
 import traitlets
-
+import traitlets.config
 
 
 class CommManager(traitlets.config.LoggingConfigurable, comm.base_comm.CommManager):
 
-    kernel = traitlets.Instance('ipykernel.kernelbase.Kernel')
+    kernel = traitlets.Instance("ipykernel.kernelbase.Kernel")
     comms = traitlets.Dict()
     targets = traitlets.Dict()
 


### PR DESCRIPTION
Fixes https://github.com/ipython/ipykernel/issues/1040

cf https://github.com/ipython/ipykernel/pull/973

Adds a downstream test for `ipywidgets` and restores the public traits for the `Comm` and `CommManager` classes.

