### PR TITLE
fix: too many arguments dropped when passing to base comm constructor

### DIFF
--- a/ipykernel/comm/comm.py
+++ b/ipykernel/comm/comm.py
@@ -72,9 +72,7 @@ class Comm(traitlets.config.LoggingConfigurable, BaseComm):
         # Comm takes positional arguments, LoggingConfigurable does not, so we explicitly forward arguments
         traitlets.config.LoggingConfigurable.__init__(self, **kwargs)
         # drop arguments not in BaseComm
-        for name in ["kernel"]:
-            if name in kwargs:
-                kwargs.pop(name)
+        kwargs.pop("kernel", None)
         BaseComm.__init__(self, *args, **kwargs)
 
 

--- a/ipykernel/comm/comm.py
+++ b/ipykernel/comm/comm.py
@@ -71,7 +71,8 @@ class Comm(traitlets.config.LoggingConfigurable, BaseComm):
     def __init__(self, *args, **kwargs):
         # Comm takes positional arguments, LoggingConfigurable does not, so we explicitly forward arguments
         traitlets.config.LoggingConfigurable.__init__(self, **kwargs)
-        for name in self.trait_names():
+        # drop arguments not in BaseComm
+        for name in ["kernel"]:
             if name in kwargs:
                 kwargs.pop(name)
         BaseComm.__init__(self, *args, **kwargs)

--- a/ipykernel/tests/test_comm.py
+++ b/ipykernel/tests/test_comm.py
@@ -6,7 +6,7 @@ def test_comm(kernel):
     manager = CommManager(kernel=kernel)
     kernel.comm_manager = manager
 
-    c = Comm(kernel=kernel)
+    c = Comm(kernel=kernel, target_name="bar")
     msgs = []
 
     def on_close(msg):
@@ -23,6 +23,7 @@ def test_comm(kernel):
     c.handle_close({})
     c.close()
     assert len(msgs) == 2
+    assert c.target_name == "bar"
 
 
 def test_comm_manager(kernel):


### PR DESCRIPTION
Bug introduced in fee98e5, covered by test now.

Closes #1050