### PR TITLE
ENH: add `%gui` support for Qt6

### DIFF
--- a/ipykernel/eventloops.py
+++ b/ipykernel/eventloops.py
@@ -90,7 +90,6 @@ def _notify_stream_qt(kernel):
         # if there were any, wake it up
         if kernel.shell_stream.flush(limit=1):
             kernel._qt_notifier.setEnabled(False)
-            print('ZMQ events to process; quitting Qt event loop.')
             kernel.app.qt_event_loop.quit()
 
     if not hasattr(kernel, "_qt_notifier"):
@@ -118,21 +117,18 @@ def _notify_stream_qt(kernel):
 @register_integration("qt", "qt4", "qt5", "qt6")
 def loop_qt(kernel):
     """Event loop for all versions of Qt."""
-    print(f'Starting Qt loop with {os.environ.get("QT_API", None)=}')
     _notify_stream_qt(kernel) # install hook to stop event loop.
     # Start the event loop.
     kernel.app._in_event_loop = True
     # `exec` blocks until there's ZMQ activity.
     el = kernel.app.qt_event_loop  # for brevity
     el.exec() if hasattr(el, 'exec') else el.exec_()
-    print('Qt loop exited.')
     kernel.app._in_event_loop = False
 
 
 # exit and watch are the same for qt 4 and 5
 @loop_qt.exit
 def loop_qt_exit(kernel):
-    print('Request Qt app exit (will close all open windows).')
     kernel.app.exit()
 
 
@@ -480,13 +476,11 @@ def set_qt_api(gui, kernel):
                     os.environ["QT_API"] = "pyqt5"
         elif gui == 'qt6':
             try:
-                print('Trying to import PyQt6...')
                 import PyQt6  # noqa
 
                 os.environ["QT_API"] = "pyqt6"
             except ImportError:
                 try:
-                    print('Trying to import PySide6...')
                     import PySide6  # noqa
 
                     os.environ["QT_API"] = "pyside6"
@@ -515,7 +509,6 @@ def set_qt_api(gui, kernel):
 
     from IPython.lib.guisupport import get_app_qt4
 
-    print(f'`qt_for_kernel` says {QT_API=}')
     kernel.app = get_app_qt4([" "])
     if isinstance(kernel.app, QtGui.QApplication):
         kernel.app.setQuitOnLastWindowClosed(False)

--- a/ipykernel/eventloops.py
+++ b/ipykernel/eventloops.py
@@ -33,7 +33,7 @@ def _notify_stream_qt(kernel):
         # if there were any, wake it up
         if kernel.shell_stream.flush(limit=1):
             kernel._qt_notifier.setEnabled(False)
-            kernel.app.quit()
+            print('ZMQ events to process; quitting Qt event loop.')
 
     if not hasattr(kernel, "_qt_notifier"):
         fd = kernel.shell_stream.getsockopt(zmq.FD)
@@ -110,17 +110,19 @@ def _loop_qt(app):
     rather than if the eventloop is actually running.
     """
     app._in_event_loop = True
-    app.exec_()
+    print('Qt loop exited.')
     app._in_event_loop = False
 
 
 @register_integration("qt4")
 def loop_qt4(kernel):
     """Start a kernel with PyQt4 event loop integration."""
+    print(f'Starting Qt4 loop with {os.environ.get("QT_API", None)=}')
 
-    from IPython.external.qt_for_kernel import QtGui
+    from IPython.external.qt_for_kernel import QtGui, QtCore, QT_API
     from IPython.lib.guisupport import get_app_qt4
 
+    print(f'`qt_for_kernel` says {QT_API=}')
     kernel.app = get_app_qt4([" "])
     if isinstance(kernel.app, QtGui.QApplication):
         kernel.app.setQuitOnLastWindowClosed(False)
@@ -131,6 +133,7 @@ def loop_qt4(kernel):
 
 @register_integration("qt", "qt5")
 def loop_qt5(kernel):
+    print(f'Starting Qt5 loop with {os.environ.get("QT_API", None)=}')
     """Start a kernel with PyQt5 event loop integration."""
     if os.environ.get("QT_API", None) is None:
         try:
@@ -151,6 +154,7 @@ def loop_qt5(kernel):
 @loop_qt4.exit
 @loop_qt5.exit
 def loop_qt_exit(kernel):
+    print('Request Qt event loop exit.')
     kernel.app.exit()
 
 

--- a/ipykernel/eventloops.py
+++ b/ipykernel/eventloops.py
@@ -465,16 +465,17 @@ def set_qt_api_env_from_gui(gui):
         QT_API_PYSIDE6: 'qt6',
         QT_API_PYQT6: 'qt6',
     }
+    if loaded is not None and gui != 'qt':
+        if qt_env2gui[loaded] != gui:
+            raise ImportError(
+                f'Cannot switch Qt versions for this session; must use {qt_env2gui[loaded]}.'
+            )
+
     if qt_api is not None and gui != 'qt':
         if qt_env2gui[qt_api] != gui:
             print(
                 f'Request for "{gui}" will be ignored because `QT_API` '
                 f'environment variable is set to "{qt_api}"'
-            )
-    elif loaded is not None and gui != 'qt':
-        if qt_env2gui[loaded] != gui:
-            raise ImportError(
-                f'Cannot switch Qt versions for this session; must use {qt_env2gui[loaded]}.'
             )
     else:
         if gui == 'qt4':

--- a/ipykernel/eventloops.py
+++ b/ipykernel/eventloops.py
@@ -70,17 +70,16 @@ def register_integration(*toolkitnames):
 def _notify_stream_qt(kernel):
     import operator
     from functools import lru_cache
+
     from IPython.external.qt_for_kernel import QtCore
 
     try:
         from IPython.external.qt_for_kernel import enum_helper
     except ImportError:
+
         @lru_cache(None)
         def enum_helper(name):
-            return operator.attrgetter(
-                name.rpartition(".")[0]
-            )(sys.modules[QtCore.__package__])
-
+            return operator.attrgetter(name.rpartition(".")[0])(sys.modules[QtCore.__package__])
 
     def process_stream_events():
         """fall back to main loop when there's a socket event"""
@@ -95,7 +94,8 @@ def _notify_stream_qt(kernel):
     if not hasattr(kernel, "_qt_notifier"):
         fd = kernel.shell_stream.getsockopt(zmq.FD)
         kernel._qt_notifier = QtCore.QSocketNotifier(
-            fd, enum_helper('QtCore.QSocketNotifier.Type').Read, kernel.app.qt_event_loop)
+            fd, enum_helper('QtCore.QSocketNotifier.Type').Read, kernel.app.qt_event_loop
+        )
         kernel._qt_notifier.activated.connect(process_stream_events)
     else:
         kernel._qt_notifier.setEnabled(True)
@@ -117,7 +117,7 @@ def _notify_stream_qt(kernel):
 @register_integration("qt", "qt4", "qt5", "qt6")
 def loop_qt(kernel):
     """Event loop for all versions of Qt."""
-    _notify_stream_qt(kernel) # install hook to stop event loop.
+    _notify_stream_qt(kernel)  # install hook to stop event loop.
     # Start the event loop.
     kernel.app._in_event_loop = True
     # `exec` blocks until there's ZMQ activity.
@@ -421,6 +421,7 @@ def loop_asyncio_exit(kernel):
         loop.run_until_complete(close_loop)  # type:ignore[call-overload]
         loop.close()
 
+
 # The user can generically request `qt` or a specific Qt version, e.g. `qt6`. For a generic Qt
 # request, we let the mechanism in IPython choose the best available version by leaving the `QT_API`
 # environment variable blank.
@@ -437,23 +438,27 @@ def set_qt_api(gui, kernel):
     if hasattr(kernel, 'app'):
         raise RuntimeError('Kernel already running a Qt event loop.')
 
-    if gui!= 'qt' and hasattr(kernel, 'last_qt_version'):
+    if gui != 'qt' and hasattr(kernel, 'last_qt_version'):
         if kernel.last_qt_version != gui:
-            raise ValueError('Cannot switch Qt versions for this session; '
-                             f'must use {kernel.last_qt_version}.')
+            raise ValueError(
+                'Cannot switch Qt versions for this session; ' f'must use {kernel.last_qt_version}.'
+            )
 
     qt_api = os.environ.get("QT_API", None)
     if qt_api is not None and gui != 'qt':
-        env2gui = {'pyside': 'qt4',
-                   'pyqt': 'qt4',
-                   'pyside2': 'qt5',
-                   'pyqt5': 'qt5',
-                   'pyside6': 'qt6',
-                   'pyqt6': 'qt6',
-                   }
+        env2gui = {
+            'pyside': 'qt4',
+            'pyqt': 'qt4',
+            'pyside2': 'qt5',
+            'pyqt5': 'qt5',
+            'pyside6': 'qt6',
+            'pyqt6': 'qt6',
+        }
         if env2gui[qt_api] != gui:
-            print(f'Request for "{gui}" will be ignored because `QT_API` '
-                  f'environment variable is set to "{qt_api}"')
+            print(
+                f'Request for "{gui}" will be ignored because `QT_API` '
+                f'environment variable is set to "{qt_api}"'
+            )
     else:
         if gui == 'qt4':
             try:
@@ -497,11 +502,13 @@ def set_qt_api(gui, kernel):
             if 'QT_API' in os.environ.keys():
                 del os.environ['QT_API']
         else:
-            raise ValueError(f'Unrecognized Qt version: {gui}. Should be "qt4", "qt5", "qt6", or "qt".')
+            raise ValueError(
+                f'Unrecognized Qt version: {gui}. Should be "qt4", "qt5", "qt6", or "qt".'
+            )
 
     # Do the actual import now that the environment variable is set.
     try:
-        from IPython.external.qt_for_kernel import QtGui, QtCore, QT_API
+        from IPython.external.qt_for_kernel import QT_API, QtCore, QtGui
     except ImportError:
         # Clear the environment variable for the next attempt.
         if 'QT_API' in os.environ.keys():
@@ -519,6 +526,7 @@ def set_qt_api(gui, kernel):
     # Due to the import mechanism, we can't change Qt versions once we've chosen one. So we tag the
     # version so we can check for this and give an error.
     kernel.last_qt_version = gui
+
 
 def enable_gui(gui, kernel=None):
     """Enable integration with a given GUI"""

--- a/ipykernel/eventloops.py
+++ b/ipykernel/eventloops.py
@@ -508,7 +508,7 @@ def set_qt_api(gui, kernel):
 
     # Do the actual import now that the environment variable is set.
     try:
-        from IPython.external.qt_for_kernel import QT_API, QtCore, QtGui
+        from IPython.external.qt_for_kernel import QtCore, QtGui
     except ImportError:
         # Clear the environment variable for the next attempt.
         if 'QT_API' in os.environ.keys():

--- a/ipykernel/eventloops.py
+++ b/ipykernel/eventloops.py
@@ -436,6 +436,12 @@ def set_qt_api(gui, kernel):
     """Sets the `QT_API` environment variable if it isn't already set."""
     if hasattr(kernel, 'app'):
         raise RuntimeError('Kernel already running a Qt event loop.')
+
+    if gui!= 'qt' and hasattr(kernel, 'last_qt_version'):
+        if kernel.last_qt_version != gui:
+            raise ValueError('Cannot switch Qt versions for this session; '
+                             f'must use {kernel.last_qt_version}.')
+
     qt_api = os.environ.get("QT_API", None)
     if qt_api is not None and gui != 'qt':
         env2gui = {'pyside': 'qt4',
@@ -492,11 +498,6 @@ def set_qt_api(gui, kernel):
                 del os.environ['QT_API']
         else:
             raise ValueError(f'Unrecognized Qt version: {gui}. Should be "qt4", "qt5", "qt6", or "qt".')
-
-    if gui!= 'qt' and hasattr(kernel, 'last_qt_version') and 'QT_API' in os.environ.keys():
-        if kernel.last_qt_version != gui:
-            raise ValueError('Cannot switch Qt versions for this session; '
-                             f'must use {kernel.last_qt_version}.')
 
     # Do the actual import now that the environment variable is set.
     try:

--- a/ipykernel/tests/test_eventloop.py
+++ b/ipykernel/tests/test_eventloop.py
@@ -19,9 +19,6 @@ from ipykernel.eventloops import (
 
 from .utils import execute, flush_channels, start_new_kernel
 
-if os.name == 'nt':
-    pytest.skip("skipping eventloop tests on Windows", allow_module_level=True)
-
 KC = KM = None
 
 guis_avail = []
@@ -88,6 +85,7 @@ def test_asyncio_interrupt():
 windows_skip = pytest.mark.skipif(os.name == "nt", reason="causing failures on windows")
 
 
+@windows_skip
 @pytest.mark.skipif(sys.platform == "darwin", reason="hangs on macos")
 def test_tk_loop(kernel):
     def do_thing():
@@ -108,6 +106,7 @@ def test_tk_loop(kernel):
     t.join()
 
 
+@windows_skip
 def test_asyncio_loop(kernel):
     def do_thing():
         loop.call_soon(loop.stop)
@@ -117,6 +116,7 @@ def test_asyncio_loop(kernel):
     loop_asyncio(kernel)
 
 
+@windows_skip
 def test_enable_gui(kernel):
     enable_gui("tk", kernel)
 

--- a/ipykernel/tests/test_eventloop.py
+++ b/ipykernel/tests/test_eventloop.py
@@ -33,6 +33,8 @@ def _get_qt_vers():
                 del os.environ['QT_API']
         except ImportError:
             pass  # that version of Qt isn't available.
+        except RuntimeError:
+            pass  # the version of IPython doesn't know what to do with this Qt version.
 
 
 _get_qt_vers()

--- a/ipykernel/tests/test_eventloop.py
+++ b/ipykernel/tests/test_eventloop.py
@@ -19,6 +19,9 @@ from ipykernel.eventloops import (
 
 from .utils import execute, flush_channels, start_new_kernel
 
+if os.name == 'nt':
+    pytest.skip("skipping eventloop tests on Windows", allow_module_level=True)
+
 KC = KM = None
 
 guis_avail = []

--- a/ipykernel/tests/test_eventloop.py
+++ b/ipykernel/tests/test_eventloop.py
@@ -126,7 +126,9 @@ def test_cocoa_loop(kernel):
     loop_cocoa(kernel)
 
 
-@pytest.mark.skipif(len(qt_guis_avail) == 0, reason='No viable version of PyQt or PySide installed.')
+@pytest.mark.skipif(
+    len(qt_guis_avail) == 0, reason='No viable version of PyQt or PySide installed.'
+)
 def test_qt_enable_gui(kernel):
     gui = qt_guis_avail[0]
 

--- a/ipykernel/tests/test_eventloop.py
+++ b/ipykernel/tests/test_eventloop.py
@@ -21,7 +21,7 @@ from .utils import execute, flush_channels, start_new_kernel
 
 KC = KM = None
 
-guis_avail = []
+qt_guis_avail = []
 
 
 def _get_qt_vers():
@@ -31,7 +31,7 @@ def _get_qt_vers():
         print(f'Trying {gui}')
         try:
             set_qt_api_env_from_gui(gui)
-            guis_avail.append(gui)
+            qt_guis_avail.append(gui)
             if 'QT_API' in os.environ.keys():
                 del os.environ['QT_API']
         except ImportError:
@@ -126,9 +126,9 @@ def test_cocoa_loop(kernel):
     loop_cocoa(kernel)
 
 
-@pytest.mark.skipif(len(guis_avail) == 0, reason='No viable version of PyQt or PySide installed.')
+@pytest.mark.skipif(len(qt_guis_avail) == 0, reason='No viable version of PyQt or PySide installed.')
 def test_qt_enable_gui(kernel):
-    gui = guis_avail[0]
+    gui = qt_guis_avail[0]
 
     enable_gui(gui, kernel)
 
@@ -147,7 +147,7 @@ def test_qt_enable_gui(kernel):
 
     # But now we're stuck with this version of Qt for good; can't switch.
     for not_gui in ['qt6', 'qt5', 'qt4']:
-        if not_gui not in guis_avail:
+        if not_gui not in qt_guis_avail:
             break
 
     with pytest.raises(ImportError):

--- a/ipykernel/tests/test_eventloop.py
+++ b/ipykernel/tests/test_eventloop.py
@@ -58,7 +58,6 @@ def test_asyncio_interrupt():
 windows_skip = pytest.mark.skipif(os.name == "nt", reason="causing failures on windows")
 
 
-@windows_skip
 @pytest.mark.skipif(sys.platform == "darwin", reason="hangs on macos")
 def test_tk_loop(kernel):
     def do_thing():
@@ -79,7 +78,6 @@ def test_tk_loop(kernel):
     t.join()
 
 
-@windows_skip
 def test_asyncio_loop(kernel):
     def do_thing():
         loop.call_soon(loop.stop)
@@ -89,7 +87,6 @@ def test_asyncio_loop(kernel):
     loop_asyncio(kernel)
 
 
-@windows_skip
 def test_enable_gui(kernel):
     enable_gui("tk", kernel)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,8 @@ cov = [
   "curio",
   "trio",
 ]
+pyqt5 = ["pyqt5"]
+pyside6 = ["pyside6"]
 
 [tool.hatch.version]
 path = "ipykernel/_version.py"
@@ -91,6 +93,15 @@ features = ["test", "cov"]
 [tool.hatch.envs.cov.scripts]
 test = "python -m pytest -vv --cov ipykernel --cov-branch --cov-report term-missing:skip-covered {args}"
 nowarn = "test -W default {args}"
+
+[[tool.hatch.envs.cov.matrix]]
+qt = ["qt5", "qt6"]
+
+[tool.hatch.envs.cov.overrides]
+matrix.qt.features = [
+  { value = "pyqt5", if = ["qt5"] },
+  { value = "pyside6", if = ["qt6"] },
+]
 
 [tool.hatch.envs.typing]
 features = ["test"]


### PR DESCRIPTION
Addresses #775 

1. Support for Qt 4, 5, and 6, via `PyQt` or `PySide`. Replicated logic from `IPython` (e.g. prefer `PyQt` over `PySide`)
2. Put Qt importing at the level of `enable_gui` so that any import errors show up in the client as opposed to in the kernel's console.
3. Added checks for more helpful error messages / warnings when you can't / aren't going to get the version you're requesting.
4. Included relevant parts of @tacaswell's work in #782