### PR TITLE
Don't pass `None` kernels to logging configurable in `Comm`

### DIFF
--- a/ipykernel/comm/comm.py
+++ b/ipykernel/comm/comm.py
@@ -70,14 +70,15 @@ class Comm(BaseComm, traitlets.config.LoggingConfigurable):
 
     def __init__(self, target_name='', data=None, metadata=None, buffers=None, **kwargs):
         # Handle differing arguments between base classes.
+        had_kernel = 'kernel' in kwargs
         kernel = kwargs.pop('kernel', None)
         if target_name:
             kwargs['target_name'] = target_name
         BaseComm.__init__(
             self, data=data, metadata=metadata, buffers=buffers, **kwargs
         )  # type:ignore[call-arg]
-        # avoid an explict ``None`` kernel bypassing ``_default_kernel``
-        if kernel is not None:
+        # only re-add kernel if explicitly provided
+        if had_kernel:
             kwargs['kernel'] = kernel
         traitlets.config.LoggingConfigurable.__init__(self, **kwargs)
 

--- a/ipykernel/comm/comm.py
+++ b/ipykernel/comm/comm.py
@@ -76,7 +76,9 @@ class Comm(BaseComm, traitlets.config.LoggingConfigurable):
         BaseComm.__init__(
             self, data=data, metadata=metadata, buffers=buffers, **kwargs
         )  # type:ignore[call-arg]
-        kwargs['kernel'] = kernel
+        # avoid an explict ``None`` kernel bypassing ``_default_kernel``
+        if kernel is not None:
+            kwargs['kernel'] = kernel
         traitlets.config.LoggingConfigurable.__init__(self, **kwargs)
 
 

--- a/ipykernel/tests/test_comm.py
+++ b/ipykernel/tests/test_comm.py
@@ -7,7 +7,7 @@ from ipykernel.kernelbase import Kernel
 
 def test_comm(kernel: Kernel) -> None:
     manager = CommManager(kernel=kernel)
-    kernel.comm_manager = manager
+    kernel.comm_manager = manager  # type:ignore
 
     c = Comm(kernel=kernel, target_name="bar")
     msgs = []
@@ -60,7 +60,7 @@ def test_comm_manager(kernel: Kernel) -> None:
         assert publish_msg.call_count == 1
 
     # make sure that when we don't pass a kernel, the 'default' kernel is taken
-    Kernel._instance = kernel
+    Kernel._instance = kernel  # type:ignore
     assert comm.kernel is kernel  # type:ignore
     Kernel.clear_instance()
 

--- a/ipykernel/tests/test_comm.py
+++ b/ipykernel/tests/test_comm.py
@@ -2,6 +2,7 @@ import unittest.mock
 
 from ipykernel.comm import Comm, CommManager
 from ipykernel.ipkernel import IPythonKernel
+from ipykernel.kernelbase import Kernel
 
 
 def test_comm(kernel):
@@ -10,6 +11,8 @@ def test_comm(kernel):
 
     c = Comm(kernel=kernel, target_name="bar")
     msgs = []
+
+    assert kernel is c.kernel
 
     def on_close(msg):
         msgs.append(msg)
@@ -55,6 +58,11 @@ def test_comm_manager(kernel):
         comm.on_close(on_close)
         manager.register_comm(comm)
         assert publish_msg.call_count == 1
+
+    # make sure that when we don't pass a kernel, the 'default' kernel is taken
+    Kernel._instance = kernel
+    assert comm.kernel is kernel
+    Kernel.clear_instance()
 
     assert manager.get_comm(comm.comm_id) == comm
     assert manager.get_comm('foo') is None

--- a/ipykernel/tests/test_comm.py
+++ b/ipykernel/tests/test_comm.py
@@ -5,7 +5,7 @@ from ipykernel.ipkernel import IPythonKernel
 from ipykernel.kernelbase import Kernel
 
 
-def test_comm(kernel):
+def test_comm(kernel: Kernel):
     manager = CommManager(kernel=kernel)
     kernel.comm_manager = manager
 
@@ -31,7 +31,7 @@ def test_comm(kernel):
     assert c.target_name == "bar"
 
 
-def test_comm_manager(kernel):
+def test_comm_manager(kernel: Kernel):
     manager = CommManager(kernel=kernel)
     msgs = []
 

--- a/ipykernel/tests/test_comm.py
+++ b/ipykernel/tests/test_comm.py
@@ -5,14 +5,14 @@ from ipykernel.ipkernel import IPythonKernel
 from ipykernel.kernelbase import Kernel
 
 
-def test_comm(kernel: Kernel):
+def test_comm(kernel: Kernel) -> None:
     manager = CommManager(kernel=kernel)
     kernel.comm_manager = manager
 
     c = Comm(kernel=kernel, target_name="bar")
     msgs = []
 
-    assert kernel is c.kernel
+    assert kernel is c.kernel  # type:ignore
 
     def on_close(msg):
         msgs.append(msg)
@@ -31,7 +31,7 @@ def test_comm(kernel: Kernel):
     assert c.target_name == "bar"
 
 
-def test_comm_manager(kernel: Kernel):
+def test_comm_manager(kernel: Kernel) -> None:
     manager = CommManager(kernel=kernel)
     msgs = []
 
@@ -51,7 +51,7 @@ def test_comm_manager(kernel: Kernel):
     manager.register_target("foo", foo)
     manager.register_target("fizz", fizz)
 
-    kernel.comm_manager = manager
+    kernel.comm_manager = manager  # type:ignore
     with unittest.mock.patch.object(Comm, "publish_msg") as publish_msg:
         comm = Comm()
         comm.on_msg(on_msg)
@@ -61,7 +61,7 @@ def test_comm_manager(kernel: Kernel):
 
     # make sure that when we don't pass a kernel, the 'default' kernel is taken
     Kernel._instance = kernel
-    assert comm.kernel is kernel
+    assert comm.kernel is kernel  # type:ignore
     Kernel.clear_instance()
 
     assert manager.get_comm(comm.comm_id) == comm


### PR DESCRIPTION
## References

- fixes #1060

## Changes

- [x] doesn't pass `kernel=None` values to `LoggingConfigurable.__init__`