### PR TITLE
Don't raise error when trying to create another Qt app for Qt eventloop

### DIFF
--- a/ipykernel/eventloops.py
+++ b/ipykernel/eventloops.py
@@ -117,10 +117,12 @@ def _notify_stream_qt(kernel):
 
 @register_integration("qt", "qt5", "qt6")
 def loop_qt(kernel):
-    """Event loop for all versions of Qt."""
+    """Event loop for all supported versions of Qt."""
     _notify_stream_qt(kernel)  # install hook to stop event loop.
+
     # Start the event loop.
     kernel.app._in_event_loop = True
+
     # `exec` blocks until there's ZMQ activity.
     el = kernel.app.qt_event_loop  # for brevity
     el.exec() if hasattr(el, 'exec') else el.exec_()
@@ -428,24 +430,24 @@ def loop_asyncio_exit(kernel):
         loop.close()
 
 
-# The user can generically request `qt` or a specific Qt version, e.g. `qt6`. For a generic Qt
-# request, we let the mechanism in IPython choose the best available version by leaving the `QT_API`
-# environment variable blank.
-#
-# For specific versions, we check to see whether the PyQt or PySide implementations are present and
-# set `QT_API` accordingly to indicate to IPython which version we want. If neither implementation
-# is present, we leave the environment variable set so IPython will generate a helpful error
-# message.
-#
-# NOTE: if the environment variable is already set, it will be used unchanged, regardless of what
-# the user requested.
-
-
 def set_qt_api_env_from_gui(gui):
     """
     Sets the QT_API environment variable by trying to import PyQtx or PySidex.
 
-    If QT_API is already set, ignore the request.
+    The user can generically request `qt` or a specific Qt version, e.g. `qt6`.
+    For a generic Qt request, we let the mechanism in IPython choose the best
+    available version by leaving the `QT_API` environment variable blank.
+
+    For specific versions, we check to see whether the PyQt or PySide
+    implementations are present and set `QT_API` accordingly to indicate to
+    IPython which version we want. If neither implementation is present, we
+    leave the environment variable set so IPython will generate a helpful error
+    message.
+
+    Notes
+    -----
+    - If the environment variable is already set, it will be used unchanged,
+      regardless of what the user requested.
     """
     qt_api = os.environ.get("QT_API", None)
 

--- a/ipykernel/eventloops.py
+++ b/ipykernel/eventloops.py
@@ -469,8 +469,8 @@ def set_qt_api_env_from_gui(gui):
     }
     if loaded is not None and gui != 'qt':
         if qt_env2gui[loaded] != gui:
-            raise ImportError(
-                f'Cannot switch Qt versions for this session; must use {qt_env2gui[loaded]}.'
+            print(
+                f'Cannot switch Qt versions for this session; you must use {qt_env2gui[loaded]}.'
             )
 
     if qt_api is not None and gui != 'qt':
@@ -483,24 +483,20 @@ def set_qt_api_env_from_gui(gui):
         if gui == 'qt5':
             try:
                 import PyQt5  # noqa
-
                 os.environ["QT_API"] = "pyqt5"
             except ImportError:
                 try:
                     import PySide2  # noqa
-
                     os.environ["QT_API"] = "pyside2"
                 except ImportError:
                     os.environ["QT_API"] = "pyqt5"
         elif gui == 'qt6':
             try:
                 import PyQt6  # noqa
-
                 os.environ["QT_API"] = "pyqt6"
             except ImportError:
                 try:
                     import PySide6  # noqa
-
                     os.environ["QT_API"] = "pyside6"
                 except ImportError:
                     os.environ["QT_API"] = "pyqt6"
@@ -509,18 +505,19 @@ def set_qt_api_env_from_gui(gui):
             if 'QT_API' in os.environ.keys():
                 del os.environ['QT_API']
         else:
-            raise ValueError(
+            print(
                 f'Unrecognized Qt version: {gui}. Should be "qt5", "qt6", or "qt".'
             )
 
     # Do the actual import now that the environment variable is set to make sure it works.
     try:
         from IPython.external.qt_for_kernel import QtCore, QtGui  # noqa
-    except ImportError:
+    except Exception as e:
         # Clear the environment variable for the next attempt.
         if 'QT_API' in os.environ.keys():
             del os.environ["QT_API"]
-        raise
+            print(f"QT_API couldn't be set due to error {e}")
+        return
 
 
 def make_qt_app_for_kernel(gui, kernel):
@@ -531,6 +528,7 @@ def make_qt_app_for_kernel(gui, kernel):
         return
 
     set_qt_api_env_from_gui(gui)
+
     # This import is guaranteed to work now:
     from IPython.external.qt_for_kernel import QtCore, QtGui
     from IPython.lib.guisupport import get_app_qt4

--- a/ipykernel/eventloops.py
+++ b/ipykernel/eventloops.py
@@ -474,6 +474,7 @@ def set_qt_api_env_from_gui(gui):
     if loaded is not None and gui != 'qt':
         if qt_env2gui[loaded] != gui:
             print(f'Cannot switch Qt versions for this session; you must use {qt_env2gui[loaded]}.')
+            return
 
     if qt_api is not None and gui != 'qt':
         if qt_env2gui[qt_api] != gui:
@@ -481,6 +482,7 @@ def set_qt_api_env_from_gui(gui):
                 f'Request for "{gui}" will be ignored because `QT_API` '
                 f'environment variable is set to "{qt_api}"'
             )
+            return
     else:
         if gui == 'qt5':
             try:
@@ -512,6 +514,7 @@ def set_qt_api_env_from_gui(gui):
                 del os.environ['QT_API']
         else:
             print(f'Unrecognized Qt version: {gui}. Should be "qt5", "qt6", or "qt".')
+            return
 
     # Do the actual import now that the environment variable is set to make sure it works.
     try:

--- a/ipykernel/eventloops.py
+++ b/ipykernel/eventloops.py
@@ -129,6 +129,10 @@ def loop_qt(kernel):
     kernel.app._in_event_loop = False
 
 
+# NOTE: To be removed in version 7
+loop_qt5 = loop_qt
+
+
 # exit and watch are the same for qt 4 and 5
 @loop_qt.exit
 def loop_qt_exit(kernel):

--- a/ipykernel/eventloops.py
+++ b/ipykernel/eventloops.py
@@ -543,7 +543,9 @@ def set_qt_api_env_from_gui(gui):
 def make_qt_app_for_kernel(gui, kernel):
     """Sets the `QT_API` environment variable if it isn't already set."""
     if hasattr(kernel, 'app'):
-        raise RuntimeError('Kernel already running a Qt event loop.')
+        # Kernel is already running a Qt event loop, so there's no need to
+        # create another app for it.
+        return
 
     set_qt_api_env_from_gui(gui)
     # This import is guaranteed to work now:

--- a/ipykernel/eventloops.py
+++ b/ipykernel/eventloops.py
@@ -473,9 +473,7 @@ def set_qt_api_env_from_gui(gui):
     }
     if loaded is not None and gui != 'qt':
         if qt_env2gui[loaded] != gui:
-            print(
-                f'Cannot switch Qt versions for this session; you must use {qt_env2gui[loaded]}.'
-            )
+            print(f'Cannot switch Qt versions for this session; you must use {qt_env2gui[loaded]}.')
 
     if qt_api is not None and gui != 'qt':
         if qt_env2gui[qt_api] != gui:
@@ -487,20 +485,24 @@ def set_qt_api_env_from_gui(gui):
         if gui == 'qt5':
             try:
                 import PyQt5  # noqa
+
                 os.environ["QT_API"] = "pyqt5"
             except ImportError:
                 try:
                     import PySide2  # noqa
+
                     os.environ["QT_API"] = "pyside2"
                 except ImportError:
                     os.environ["QT_API"] = "pyqt5"
         elif gui == 'qt6':
             try:
                 import PyQt6  # noqa
+
                 os.environ["QT_API"] = "pyqt6"
             except ImportError:
                 try:
                     import PySide6  # noqa
+
                     os.environ["QT_API"] = "pyside6"
                 except ImportError:
                     os.environ["QT_API"] = "pyqt6"
@@ -509,9 +511,7 @@ def set_qt_api_env_from_gui(gui):
             if 'QT_API' in os.environ.keys():
                 del os.environ['QT_API']
         else:
-            print(
-                f'Unrecognized Qt version: {gui}. Should be "qt5", "qt6", or "qt".'
-            )
+            print(f'Unrecognized Qt version: {gui}. Should be "qt5", "qt6", or "qt".')
 
     # Do the actual import now that the environment variable is set to make sure it works.
     try:

--- a/ipykernel/eventloops.py
+++ b/ipykernel/eventloops.py
@@ -115,7 +115,7 @@ def _notify_stream_qt(kernel):
     kernel._qt_timer.start(0)
 
 
-@register_integration("qt", "qt4", "qt5", "qt6")
+@register_integration("qt", "qt5", "qt6")
 def loop_qt(kernel):
     """Event loop for all versions of Qt."""
     _notify_stream_qt(kernel)  # install hook to stop event loop.
@@ -450,22 +450,16 @@ def set_qt_api_env_from_gui(gui):
     qt_api = os.environ.get("QT_API", None)
 
     from IPython.external.qt_loaders import (
-        QT_API_PYQT,
         QT_API_PYQT5,
         QT_API_PYQT6,
-        QT_API_PYSIDE,
         QT_API_PYSIDE2,
         QT_API_PYSIDE6,
-        QT_API_PYQTv1,
         loaded_api,
     )
 
     loaded = loaded_api()
 
     qt_env2gui = {
-        QT_API_PYSIDE: 'qt4',
-        QT_API_PYQTv1: 'qt4',
-        QT_API_PYQT: 'qt4',
         QT_API_PYSIDE2: 'qt5',
         QT_API_PYQT5: 'qt5',
         QT_API_PYSIDE6: 'qt6',
@@ -484,20 +478,7 @@ def set_qt_api_env_from_gui(gui):
                 f'environment variable is set to "{qt_api}"'
             )
     else:
-        if gui == 'qt4':
-            try:
-                import PyQt  # noqa
-
-                os.environ["QT_API"] = "pyqt"
-            except ImportError:
-                try:
-                    import PySide  # noqa
-
-                    os.environ["QT_API"] = "pyside"
-                except ImportError:
-                    # Neither implementation installed; set it to something so IPython gives an error
-                    os.environ["QT_API"] = "pyqt"
-        elif gui == 'qt5':
+        if gui == 'qt5':
             try:
                 import PyQt5  # noqa
 
@@ -527,7 +508,7 @@ def set_qt_api_env_from_gui(gui):
                 del os.environ['QT_API']
         else:
             raise ValueError(
-                f'Unrecognized Qt version: {gui}. Should be "qt4", "qt5", "qt6", or "qt".'
+                f'Unrecognized Qt version: {gui}. Should be "qt5", "qt6", or "qt".'
             )
 
     # Do the actual import now that the environment variable is set to make sure it works.


### PR DESCRIPTION
- This is a follow-up PR that fixes the `%matplotlib qt` magic in Spyder.
- Avoid raising `RuntimeError('Kernel already running a Qt event loop.')` in `make_qt_app_for_kernel`. This was the cause of the mentioned failure and it also generated an unnecessary traceback when trying to set another backend:

    ![imagen](https://user-images.githubusercontent.com/365293/210439913-948afca1-ed98-445c-88d0-5f96fddbdcd2.png)

    Instead, replace that raise with a return.

- Remove the Qt4 eventloop because it's ancient and not supported anymore.
- Restore `loop_qt5` function (and make it equal to `loop_qt`) because it's been public API for years and we're using it in Spyder-kernels.
- Avoid raising errors when calling `set_qt_api_env_from_gui` because they are not displayed to clients and instead use prints. Now you get this, for instance:

    ![imagen](https://user-images.githubusercontent.com/365293/210440467-b1fc5861-e964-4da7-b327-1df128e9dd5f.png)

- Do some cleanup after PR #1054.