### PR TITLE
Fix Exception in OutStream.close()

### DIFF
--- a/ipykernel/iostream.py
+++ b/ipykernel/iostream.py
@@ -401,6 +401,7 @@ class OutStream(TextIOBase):
         self._buffer = StringIO()
         self.echo = None
         self._isatty = bool(isatty)
+        self._should_watch = False
 
         if (
             watchfd
@@ -449,7 +450,7 @@ class OutStream(TextIOBase):
 
     def close(self):
         """Close the stream."""
-        if sys.platform.startswith("linux") or sys.platform.startswith("darwin"):
+        if self._should_watch:
             self._should_watch = False
             self.watch_fd_thread.join()
         if self._exc:

--- a/ipykernel/tests/test_io.py
+++ b/ipykernel/tests/test_io.py
@@ -98,6 +98,9 @@ def test_outstream():
         stream = OutStream(session, pub, "stdout")
         stream = OutStream(session, thread, "stdout", pipe=object())
 
+        stream = OutStream(session, thread, "stdout", watchfd=False)
+        stream.close()
+
     stream = OutStream(session, thread, "stdout", isatty=True, echo=io.StringIO())
     with pytest.raises(io.UnsupportedOperation):
         stream.fileno()


### PR DESCRIPTION
This bug fixes an Exception which was thrown
in OutStream.close() whenever the OutStream was
constructed with watchfd=False.

closes #867 

A regression test was also added to test_io.py.