### PR TITLE
Return Comm rather than BaseComm from create_comm

### DIFF
--- a/ipykernel/ipkernel.py
+++ b/ipykernel/ipkernel.py
@@ -29,7 +29,7 @@ from .zmqshell import ZMQInteractiveShell
 try:
     from IPython.core.interactiveshell import _asyncio_runner  # type:ignore[attr-defined]
 except ImportError:
-    _asyncio_runner = None
+    _asyncio_runner = None  # type:ignore
 
 try:
     from IPython.core.completer import provisionalcompleter as _provisionalcompleter
@@ -626,7 +626,7 @@ class IPythonKernel(KernelBase):
         try:
             from ipyparallel.serialize import serialize_object, unpack_apply_message
         except ImportError:
-            from .serialize import serialize_object, unpack_apply_message  # type:ignore
+            from .serialize import serialize_object, unpack_apply_message
 
         shell = self.shell
         try:

--- a/ipykernel/ipkernel.py
+++ b/ipykernel/ipkernel.py
@@ -17,7 +17,7 @@ from IPython.utils.tokenutil import line_at_cursor, token_at_cursor
 from traitlets import Any, Bool, HasTraits, Instance, List, Type, observe, observe_compat
 from zmq.eventloop.zmqstream import ZMQStream
 
-from .comm.comm import BaseComm
+from .comm.comm import Comm
 from .comm.manager import CommManager
 from .compiler import XCachingCompiler
 from .debugger import Debugger, _is_debugpy_available
@@ -45,7 +45,7 @@ _EXPERIMENTAL_KEY_NAME = "_jupyter_types_experimental"
 
 def _create_comm(*args, **kwargs):
     """Create a new Comm."""
-    return BaseComm(*args, **kwargs)
+    return Comm(*args, **kwargs)
 
 
 # there can only be one comm manager in a ipykernel process


### PR DESCRIPTION
This replaces `BaseComm` in `create_comm` with `Comm`, which should match what is expected by `ipywidgets` for validation of the `comm` trait in subclasses of `ipywidgets.Widget`.

Fixes #1090 .