### PR TITLE
Un-expose __file__ and expose __session__ instead.

### DIFF
--- a/ipykernel/ipkernel.py
+++ b/ipykernel/ipkernel.py
@@ -130,7 +130,7 @@ class IPythonKernel(KernelBase):
 
         jupyter_session_name = os.environ.get('JPY_SESSION_NAME')
         if jupyter_session_name:
-            self.shell.user_ns['__file__'] = jupyter_session_name
+            self.shell.user_ns['__session__'] = jupyter_session_name
 
         self.shell.displayhook.pub_socket = self.iopub_socket
         self.shell.displayhook.topic = self._topic("execute_result")


### PR DESCRIPTION
See https://github.com/jupyter-server/jupyter_server/issues/1198,

setting __file__ will break multiprocessing.


I'm not setting `__notebook__` as things that set this value may note be notebooks.