### PR TITLE
Adds a flag in debug_info for the copyToGlobals support

### DIFF
--- a/ipykernel/debugger.py
+++ b/ipykernel/debugger.py
@@ -605,6 +605,7 @@ class Debugger:
                 "stoppedThreads": list(self.stopped_threads),
                 "richRendering": True,
                 "exceptionPaths": ["Python Exceptions"],
+                "copyToGlobals": True,
             },
         }
 


### PR DESCRIPTION
This PR is adding a flag in the `debug_info` response to inform the UI about the support of `copyToGlobals` request.

This should wait for https://github.com/jupyter/enhancement-proposals/pull/93 to be approved.