### PR TITLE
Fix interrupt reply

### DIFF
--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -898,13 +898,13 @@ class Kernel(SingletonConfigurable):
 
     async def interrupt_request(self, stream, ident, parent):
         """Handle an interrupt request."""
+        content: t.Dict[str, t.Any] = {"status": "ok"}
         try:
             self._send_interrupt_children()
-            content = {"status": "ok"}
         except OSError as err:
             import traceback
 
-            content: t.Dict[str, t.Any] = {
+            content = {
                 "status": "error",
                 "traceback": traceback.format_stack(),
                 "ename": str(type(err).__name__),

--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -892,7 +892,11 @@ class Kernel(SingletonConfigurable):
             # Prefer process-group over process
             # but only if the kernel is the leader of the process group
             if pgid and pgid == pid and hasattr(os, "killpg"):
-                os.killpg(pgid, SIGINT)
+                try:
+                    os.killpg(pgid, SIGINT)
+                except OSError:
+                    os.kill(pid, SIGINT)
+                    raise
             else:
                 os.kill(pid, SIGINT)
 

--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -904,7 +904,7 @@ class Kernel(SingletonConfigurable):
         except OSError as err:
             import traceback
 
-            content = {
+            content: t.Dict[str, t.Any] = {
                 "status": "error",
                 "traceback": traceback.format_stack(),
                 "ename": str(type(err).__name__),

--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -900,9 +900,10 @@ class Kernel(SingletonConfigurable):
         """Handle an interrupt request."""
         try:
             self._send_interrupt_children()
-            content = { "status": "ok" }
+            content = {"status": "ok"}
         except OSError as err:
             import traceback
+
             content = {
                 "status": "error",
                 "traceback": traceback.format_stack(),

--- a/ipykernel/tests/conftest.py
+++ b/ipykernel/tests/conftest.py
@@ -99,7 +99,7 @@ class KernelMixin:
         _, msg = self.session.feed_identities(self._reply)
         return self.session.deserialize(msg)
 
-    def _send_interupt_children(self):
+    def _send_interrupt_children(self):
         # override to prevent deadlock
         pass
 

--- a/ipykernel/tests/test_ipkernel_direct.py
+++ b/ipykernel/tests/test_ipkernel_direct.py
@@ -90,9 +90,20 @@ async def test_comm_info_request(ipkernel):
 
 
 async def test_direct_interrupt_request(ipkernel):
-    reply = await ipkernel.test_shell_message("interrupt_request", {})
+    reply = await ipkernel.test_control_message("interrupt_request", {})
     assert reply["header"]["msg_type"] == "interrupt_reply"
+    assert reply["content"] == { "status": "ok" }
 
+    # test failure on interrupt request
+    def raiseOSError():
+        raise OSError("evalue")
+    ipkernel._send_interrupt_children = raiseOSError
+    reply = await ipkernel.test_control_message("interrupt_request", {})
+    assert reply["header"]["msg_type"] == "interrupt_reply"
+    assert reply["content"]["status"] == "error"
+    assert reply["content"]["ename"] == "OSError"
+    assert reply["content"]["evalue"] == "evalue"
+    assert len(reply["content"]["traceback"]) > 0
 
 # TODO: this causes deadlock
 # async def test_direct_shutdown_request(ipkernel):

--- a/ipykernel/tests/test_ipkernel_direct.py
+++ b/ipykernel/tests/test_ipkernel_direct.py
@@ -92,11 +92,12 @@ async def test_comm_info_request(ipkernel):
 async def test_direct_interrupt_request(ipkernel):
     reply = await ipkernel.test_control_message("interrupt_request", {})
     assert reply["header"]["msg_type"] == "interrupt_reply"
-    assert reply["content"] == { "status": "ok" }
+    assert reply["content"] == {"status": "ok"}
 
     # test failure on interrupt request
     def raiseOSError():
         raise OSError("evalue")
+
     ipkernel._send_interrupt_children = raiseOSError
     reply = await ipkernel.test_control_message("interrupt_request", {})
     assert reply["header"]["msg_type"] == "interrupt_reply"
@@ -104,6 +105,7 @@ async def test_direct_interrupt_request(ipkernel):
     assert reply["content"]["ename"] == "OSError"
     assert reply["content"]["evalue"] == "evalue"
     assert len(reply["content"]["traceback"]) > 0
+
 
 # TODO: this causes deadlock
 # async def test_direct_shutdown_request(ipkernel):

--- a/ipykernel/tests/test_kernel_direct.py
+++ b/ipykernel/tests/test_kernel_direct.py
@@ -71,11 +71,12 @@ async def test_comm_info_request(kernel):
 async def test_direct_interrupt_request(kernel):
     reply = await kernel.test_control_message("interrupt_request", {})
     assert reply["header"]["msg_type"] == "interrupt_reply"
-    assert reply["content"] == { "status": "ok" }
+    assert reply["content"] == {"status": "ok"}
 
     # test failure on interrupt request
     def raiseOSError():
         raise OSError("evalue")
+
     kernel._send_interrupt_children = raiseOSError
     reply = await kernel.test_control_message("interrupt_request", {})
     assert reply["header"]["msg_type"] == "interrupt_reply"

--- a/ipykernel/tests/test_kernel_direct.py
+++ b/ipykernel/tests/test_kernel_direct.py
@@ -69,8 +69,20 @@ async def test_comm_info_request(kernel):
 
 
 async def test_direct_interrupt_request(kernel):
-    reply = await kernel.test_shell_message("interrupt_request", {})
+    reply = await kernel.test_control_message("interrupt_request", {})
     assert reply["header"]["msg_type"] == "interrupt_reply"
+    assert reply["content"] == { "status": "ok" }
+
+    # test failure on interrupt request
+    def raiseOSError():
+        raise OSError("evalue")
+    kernel._send_interrupt_children = raiseOSError
+    reply = await kernel.test_control_message("interrupt_request", {})
+    assert reply["header"]["msg_type"] == "interrupt_reply"
+    assert reply["content"]["status"] == "error"
+    assert reply["content"]["ename"] == "OSError"
+    assert reply["content"]["evalue"] == "evalue"
+    assert len(reply["content"]["traceback"]) > 0
 
 
 async def test_direct_shutdown_request(kernel):
@@ -145,8 +157,8 @@ async def test_connect_request(kernel):
     await kernel.connect_request(kernel.shell_stream, "foo", {})
 
 
-async def test_send_interupt_children(kernel):
-    kernel._send_interupt_children()
+async def test_send_interrupt_children(kernel):
+    kernel._send_interrupt_children()
 
 
 # TODO: this causes deadlock


### PR DESCRIPTION
issue: https://github.com/ipython/ipykernel/issues/1100#issuecomment-1448133194 

Changes in PR
* Added reply content properties for interrupt_request
* `send_interupt_children` => `send_interrupt_children` renaming
* Added test coverage to verify statuses are received