### PR TITLE
InProcessKernelClient: Do not use run_sync if already in a running loop

### DIFF
--- a/ipykernel/inprocess/client.py
+++ b/ipykernel/inprocess/client.py
@@ -27,6 +27,12 @@ from .channels import InProcessChannel, InProcessHBChannel
 # Main kernel Client class
 # -----------------------------------------------------------------------------
 
+def in_running_loop() -> bool:
+    try:
+        return asyncio.get_running_loop() is not None
+    except RuntimeError:
+        return False
+
 
 class InProcessKernelClient(KernelClient):
     """A client for an in-process kernel.
@@ -189,7 +195,7 @@ class InProcessKernelClient(KernelClient):
         stream = kernel.shell_stream
         self.session.send(stream, msg)
         msg_parts = stream.recv_multipart()
-        if run_sync is not None:
+        if not in_running_loop() and run_sync is not None:
             dispatch_shell = run_sync(kernel.dispatch_shell)
             dispatch_shell(msg_parts)
         else:

--- a/ipykernel/inprocess/client.py
+++ b/ipykernel/inprocess/client.py
@@ -27,6 +27,7 @@ from .channels import InProcessChannel, InProcessHBChannel
 # Main kernel Client class
 # -----------------------------------------------------------------------------
 
+
 def in_running_loop() -> bool:
     try:
         return asyncio.get_running_loop() is not None


### PR DESCRIPTION
I have an application that uses an integrated Qt and asyncio event loop that embeds an ipython console using [enaml's ipython console](https://github.com/nucleic/enaml/blob/main/enaml/qt/qt_ipython_console.py). 

When the `run_sync` call finishes here it attempts to close the main loop causing the whole app to hang. 

This just adds a check so if it's already in a running loop it just uses that instead.

 