### PR TITLE
Add outstream hook similar to display publisher

### DIFF
--- a/ipykernel/iostream.py
+++ b/ipykernel/iostream.py
@@ -13,9 +13,9 @@ import warnings
 from binascii import b2a_hex
 from collections import deque
 from io import StringIO, TextIOBase
+from threading import local
 from typing import Any, Callable, Deque, Optional
 from weakref import WeakSet
-from threading import local
 
 import zmq
 from jupyter_client.session import extract_header
@@ -618,7 +618,6 @@ class OutStream(TextIOBase):
             # create new list for a new thread
             self._local.hooks = []
         return self._local.hooks
-
 
     def register_hook(self, hook):
         """


### PR DESCRIPTION
Similar to #115 but for stdout/stderr

This can be useful for a thread to redirect stdout/stderr to a file, while other threads can still write to stdout/stderr.