### PR TITLE
Avoid echoing onto a captured FD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,6 +150,11 @@ jobs:
         uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
         with:
           dependency_type: minimum
+
+      - name: List installed packages
+        run: |
+          hatch run test:list
+
       - name: Run the unit tests
         run: |
           hatch run test:nowarn || hatch run test:nowarn --lf

--- a/ipykernel/iostream.py
+++ b/ipykernel/iostream.py
@@ -479,7 +479,6 @@ class OutStream(TextIOBase):
             # restore original FDs
             os.dup2(self._original_stdstream_copy, self._original_stdstream_fd)
             os.close(self._original_stdstream_copy)
-            print("closing", self)
         if self._exc:
             etype, value, tb = self._exc
             traceback.print_exception(etype, value, tb)

--- a/ipykernel/iostream.py
+++ b/ipykernel/iostream.py
@@ -364,7 +364,7 @@ class OutStream(TextIOBase):
         echo : bool
             whether to echo output
         watchfd : bool (default, True)
-            Watch the file descripttor corresponding to the replaced stream.
+            Watch the file descriptor corresponding to the replaced stream.
             This is useful if you know some underlying code will write directly
             the file descriptor by its number. It will spawn a watching thread,
             that will swap the give file descriptor for a pipe, read from the
@@ -408,19 +408,39 @@ class OutStream(TextIOBase):
 
         if (
             watchfd
-            and (sys.platform.startswith("linux") or sys.platform.startswith("darwin"))
-            and ("PYTEST_CURRENT_TEST" not in os.environ)
+            and (
+                (sys.platform.startswith("linux") or sys.platform.startswith("darwin"))
+                # Pytest set its own capture. Don't redirect from within pytest.
+                and ("PYTEST_CURRENT_TEST" not in os.environ)
+            )
+            # allow forcing watchfd (mainly for tests)
+            or watchfd == "force"
         ):
-            # Pytest set its own capture. Dont redirect from within pytest.
-
             self._should_watch = True
             self._setup_stream_redirects(name)
 
         if echo:
             if hasattr(echo, "read") and hasattr(echo, "write"):
+                # make sure we aren't trying to echo on the FD we're watching!
+                # that would cause an infinite loop, always echoing on itself
+                if self._should_watch:
+                    try:
+                        echo_fd = echo.fileno()
+                    except Exception:
+                        echo_fd = None
+
+                    if echo_fd is not None and echo_fd == self._original_stdstream_fd:
+                        # echo on the _copy_ we made during
+                        # this is the actual terminal FD now
+                        echo = io.TextIOWrapper(
+                            io.FileIO(
+                                self._original_stdstream_copy,
+                                "w",
+                            )
+                        )
                 self.echo = echo
             else:
-                msg = "echo argument must be a file like object"
+                msg = "echo argument must be a file-like object"
                 raise ValueError(msg)
 
     def isatty(self):
@@ -433,7 +453,7 @@ class OutStream(TextIOBase):
 
     def _setup_stream_redirects(self, name):
         pr, pw = os.pipe()
-        fno = getattr(sys, name).fileno()
+        fno = self._original_stdstream_fd = getattr(sys, name).fileno()
         self._original_stdstream_copy = os.dup(fno)
         os.dup2(pw, fno)
 
@@ -456,6 +476,10 @@ class OutStream(TextIOBase):
         if self._should_watch:
             self._should_watch = False
             self.watch_fd_thread.join()
+            # restore original FDs
+            os.dup2(self._original_stdstream_copy, self._original_stdstream_fd)
+            os.close(self._original_stdstream_copy)
+            print("closing", self)
         if self._exc:
             etype, value, tb = self._exc
             traceback.print_exception(etype, value, tb)

--- a/ipykernel/iostream.py
+++ b/ipykernel/iostream.py
@@ -475,6 +475,9 @@ class OutStream(TextIOBase):
         """Close the stream."""
         if self._should_watch:
             self._should_watch = False
+            # thread won't wake unless there's something to read
+            # writing something after _should_watch will not be echoed
+            os.write(self._original_stdstream_fd, b'\0')
             self.watch_fd_thread.join()
             # restore original FDs
             os.dup2(self._original_stdstream_copy, self._original_stdstream_fd)

--- a/ipykernel/tests/test_io.py
+++ b/ipykernel/tests/test_io.py
@@ -2,7 +2,9 @@
 
 import io
 import os
+import subprocess
 import sys
+import time
 import warnings
 from unittest import mock
 
@@ -113,37 +115,100 @@ def test_outstream(iopub_thread):
         assert stream.writable()
 
 
+def subprocess_test_echo_watch():
+    # handshake Pub subscription
+    session = Session(key=b'abc')
+
+    # use PUSH socket to avoid subscription issues
+    with zmq.Context() as ctx, ctx.socket(zmq.PUSH) as pub:
+        pub.connect(os.environ["IOPUB_URL"])
+        iopub_thread = IOPubThread(pub)
+        stdout_fd = sys.stdout.fileno()
+        sys.stdout.flush()
+        stream = OutStream(
+            session,
+            iopub_thread,
+            "stdout",
+            isatty=True,
+            echo=sys.stdout,
+            watchfd="force",
+        )
+        save_stdout = sys.stdout
+        with stream, mock.patch.object(sys, "stdout", stream):
+            # write to low-level FD
+            os.write(stdout_fd, b"fd\n")
+            # print (writes to stream)
+            print("print")
+            sys.stdout.flush()
+            # write to unwrapped __stdout__ (should also go to original FD)
+            sys.__stdout__.write("__stdout__\n")
+            sys.__stdout__.flush()
+            # write to original sys.stdout (should be the same as __stdout__)
+            save_stdout.write("stdout\n")
+            save_stdout.flush()
+            stream.flush()
+            # we don't have a sync flush on _reading_ from the watched pipe
+            time.sleep(0.5)
+        iopub_thread.stop()
+        iopub_thread.close()
+
+
 @pytest.mark.skipif(sys.platform.startswith("win"), reason="Windows")
-def test_echo_watch(capfd, iopub_thread):
+def test_echo_watch(ctx):
     """Test echo on underlying FD while capturing the same FD
 
-    If not careful, this
+    Test runs in a subprocess to avoid messing with pytest output capturing.
     """
-    session = Session()
+    s = ctx.socket(zmq.PULL)
+    port = s.bind_to_random_port("tcp://127.0.0.1")
+    url = f"tcp://127.0.0.1:{port}"
+    session = Session(key=b'abc')
+    messages = []
+    stdout_chunks = []
+    with s:
+        env = dict(os.environ)
+        env["IOPUB_URL"] = url
+        env["PYTHONUNBUFFERED"] = "1"
+        env.pop("PYTEST_CURRENT_TEST", None)
+        p = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                f"import {__name__}; {__name__}.subprocess_test_echo_watch()",
+            ],
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        print(f"{p.stdout=}")
+        print(f"{p.stderr}=", file=sys.stderr)
+        assert p.returncode == 0
+        while s.poll(timeout=100):
+            ident, msg = session.recv(s)
+            if msg["header"]["msg_type"] == "stream" and msg["content"]["name"] == "stdout":
+                stdout_chunks.append(msg["content"]["text"])
 
-    stdout_fd = sys.stdout.fileno()
-    stream = OutStream(
-        session,
-        iopub_thread,
+    # check outputs
+    # use sets of lines to ignore ordering issues with
+    # async flush and watchfd thread
+
+    # Check the stream output forwarded over zmq
+    zmq_stdout = "".join(stdout_chunks)
+    assert set(zmq_stdout.strip().splitlines()) == {
+        "fd",
+        "print",
+        # original stdout streams don't get captured,
+        # they write directly to the terminal
+        # "stdout",
+        # "__stdout__",
+    }
+
+    # Check what was written to the process stdout (kernel terminal)
+    # just check that each output source went to the terminal
+    assert set(p.stdout.strip().splitlines()) == {
+        "fd",
+        "print",
         "stdout",
-        isatty=True,
-        echo=sys.stdout,
-    )
-    save_stdout = sys.stdout
-    with stream, mock.patch.object(sys, "stdout", stream):
-        # write to low-level FD
-        os.write(stdout_fd, b"fd\n")
-        os.fsync(stdout_fd)
-        # write to unwrapped __stdout__ (should also go to original FD)
-        sys.__stdout__.write("__stdout__\n")
-        sys.__stdout__.flush()
-        # write to original sys.stdout (should be the same as __stdout__)
-        save_stdout.write("stdout\n")
-        save_stdout.flush()
-        # print (writes to stream)
-        print("print")
-        sys.stdout.flush()
-
-    out, err = capfd.readouterr()
-    print(out, err)
-    assert out.strip() == "fd\n__stdout__\nstdout\nprint"
+        "__stdout__",
+    }

--- a/ipykernel/tests/test_io.py
+++ b/ipykernel/tests/test_io.py
@@ -18,8 +18,7 @@ from ipykernel.iostream import MASTER, BackgroundSocket, IOPubThread, OutStream
 @pytest.fixture
 def ctx():
     ctx = zmq.Context()
-    return ctx
-    # yield ctx
+    yield ctx
     ctx.destroy()
 
 

--- a/ipykernel/tests/test_io.py
+++ b/ipykernel/tests/test_io.py
@@ -139,7 +139,7 @@ def subprocess_test_echo_watch():
             # write to low-level FD
             os.write(stdout_fd, b"fd\n")
             # print (writes to stream)
-            print("print")
+            print("print\n", end="")
             sys.stdout.flush()
             # write to unwrapped __stdout__ (should also go to original FD)
             sys.__stdout__.write("__stdout__\n")

--- a/ipykernel/tests/test_io.py
+++ b/ipykernel/tests/test_io.py
@@ -123,6 +123,7 @@ def subprocess_test_echo_watch():
     with zmq.Context() as ctx, ctx.socket(zmq.PUSH) as pub:
         pub.connect(os.environ["IOPUB_URL"])
         iopub_thread = IOPubThread(pub)
+        iopub_thread.start()
         stdout_fd = sys.stdout.fileno()
         sys.stdout.flush()
         stream = OutStream(

--- a/ipykernel/tests/test_io.py
+++ b/ipykernel/tests/test_io.py
@@ -71,7 +71,7 @@ def test_io_thread(iopub_thread):
     ctx1, pipe = thread._setup_pipe_out()
     pipe.close()
     thread._pipe_in.close()
-    thread._check_mp_mode = lambda: MASTER  # type:ignore
+    thread._check_mp_mode = lambda: MASTER
     thread._really_send([b"hi"])
     ctx1.destroy()
     thread.close()

--- a/ipykernel/tests/test_io.py
+++ b/ipykernel/tests/test_io.py
@@ -146,9 +146,12 @@ def subprocess_test_echo_watch():
             # write to original sys.stdout (should be the same as __stdout__)
             save_stdout.write("stdout\n")
             save_stdout.flush()
-            stream.flush()
+            # is there another way to flush on the FD?
+            fd_file = os.fdopen(stdout_fd, "w")
+            fd_file.flush()
             # we don't have a sync flush on _reading_ from the watched pipe
-            time.sleep(0.5)
+            time.sleep(1)
+            stream.flush()
         iopub_thread.stop()
         iopub_thread.close()
 
@@ -198,10 +201,8 @@ def test_echo_watch(ctx):
     assert set(zmq_stdout.strip().splitlines()) == {
         "fd",
         "print",
-        # original stdout streams don't get captured,
-        # they write directly to the terminal
-        # "stdout",
-        # "__stdout__",
+        "stdout",
+        "__stdout__",
     }
 
     # Check what was written to the process stdout (kernel terminal)

--- a/ipykernel/tests/test_io.py
+++ b/ipykernel/tests/test_io.py
@@ -189,6 +189,7 @@ def test_echo_watch(ctx):
         assert p.returncode == 0
         while s.poll(timeout=100):
             ident, msg = session.recv(s)
+            assert msg is not None  # for type narrowing
             if msg["header"]["msg_type"] == "stream" and msg["content"]["name"] == "stdout":
                 stdout_chunks.append(msg["content"]["text"])
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,7 @@ api = "sphinx-apidoc -o docs/api -f -E ipykernel ipykernel/tests ipykernel/inpro
 [tool.hatch.envs.test]
 features = ["test"]
 [tool.hatch.envs.test.scripts]
+list = "python -m pip freeze"
 test = "python -m pytest -vv {args}"
 nowarn = "test -W default {args}"
 


### PR DESCRIPTION
When echoing output onto stderr, it should be onto the copy, not the redirected FD, so it only goes to the terminal instead of making an infinite loop, echoing and then capturing and then re-echoing the same output.

I've verified that this works, I just need to work out the tests without messing up pytest output itself.

closes #859