### PR TITLE
Support sending inspect_request and complete_request over the control channel

### DIFF
--- a/ipykernel/comm/comm.py
+++ b/ipykernel/comm/comm.py
@@ -12,9 +12,9 @@ import comm.base_comm
 import traitlets.config
 from traitlets import Bool, Bytes, Instance, Unicode, default
 
+from ipykernel.control import CONTROL_THREAD_NAME
 from ipykernel.jsonutil import json_clean
 from ipykernel.kernelbase import Kernel
-from ipykernel.control import CONTROL_THREAD_NAME
 
 
 # this is the class that will be created if we do comm.create_comm

--- a/ipykernel/comm/comm.py
+++ b/ipykernel/comm/comm.py
@@ -14,7 +14,7 @@ from traitlets import Bool, Bytes, Instance, Unicode, default
 
 from ipykernel.jsonutil import json_clean
 from ipykernel.kernelbase import Kernel
-from ipykernel.control import CONTORL_THREAD_NAME
+from ipykernel.control import CONTROL_THREAD_NAME
 
 
 # this is the class that will be created if we do comm.create_comm
@@ -32,7 +32,7 @@ class BaseComm(comm.base_comm.BaseComm):
         metadata = {} if metadata is None else metadata
         content = json_clean(dict(data=data, comm_id=self.comm_id, **keys))
 
-        if threading.current_thread().name == CONTORL_THREAD_NAME:
+        if threading.current_thread().name == CONTROL_THREAD_NAME:
             channel_from_which_to_get_parent_header = "control"
         else:
             channel_from_which_to_get_parent_header = "shell"
@@ -40,10 +40,6 @@ class BaseComm(comm.base_comm.BaseComm):
         if self.kernel is None:
             self.kernel = Kernel.instance()
 
-        import logging
-        logger = logging.getLogger("ipykernel.comm")
-        logger.error(f"TEST")
-        
         self.kernel.session.send(
             self.kernel.iopub_socket,
             msg_type,

--- a/ipykernel/comm/comm.py
+++ b/ipykernel/comm/comm.py
@@ -3,6 +3,7 @@
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
 
+import threading
 import uuid
 from typing import Optional
 from warnings import warn
@@ -13,6 +14,7 @@ from traitlets import Bool, Bytes, Instance, Unicode, default
 
 from ipykernel.jsonutil import json_clean
 from ipykernel.kernelbase import Kernel
+from ipykernel.control import CONTORL_THREAD_NAME
 
 
 # this is the class that will be created if we do comm.create_comm
@@ -30,15 +32,24 @@ class BaseComm(comm.base_comm.BaseComm):
         metadata = {} if metadata is None else metadata
         content = json_clean(dict(data=data, comm_id=self.comm_id, **keys))
 
+        if threading.current_thread().name == CONTORL_THREAD_NAME:
+            channel_from_which_to_get_parent_header = "control"
+        else:
+            channel_from_which_to_get_parent_header = "shell"
+        
         if self.kernel is None:
             self.kernel = Kernel.instance()
 
+        import logging
+        logger = logging.getLogger("ipykernel.comm")
+        logger.error(f"TEST")
+        
         self.kernel.session.send(
             self.kernel.iopub_socket,
             msg_type,
             content,
             metadata=json_clean(metadata),
-            parent=self.kernel.get_parent("shell"),
+            parent=self.kernel.get_parent(channel_from_which_to_get_parent_header),
             ident=self.topic,
             buffers=buffers,
         )

--- a/ipykernel/control.py
+++ b/ipykernel/control.py
@@ -3,20 +3,21 @@ from threading import Thread
 
 from tornado.ioloop import IOLoop
 
+CONTROL_THREAD_NAME = "Control"
 
 class ControlThread(Thread):
     """A thread for a control channel."""
 
     def __init__(self, **kwargs):
         """Initialize the thread."""
-        Thread.__init__(self, name="Control", **kwargs)
+        Thread.__init__(self, name=CONTROL_THREAD_NAME, **kwargs)
         self.io_loop = IOLoop(make_current=False)
         self.pydev_do_not_trace = True
         self.is_pydev_daemon_thread = True
 
     def run(self):
         """Run the thread."""
-        self.name = "Control"
+        self.name = CONTROL_THREAD_NAME
         try:
             self.io_loop.start()
         finally:


### PR DESCRIPTION
*Disclaimer:* I work for Databricks, where we patched the control channel to handle jupyter messages like `comm_open` and `comm_msg`.

# What changes with this PR?

At Databricks (which uses ipykernel), we often face the situation that customers execute long running pyspark jobs which block the shell channel for minutes or even an hour. In order to provide a better user experience, we unblock some original shell messages by moving them over to the control channel. We successfully did that with `complete_request`, `comm_open` and `comm_msg`.

Part of our fix was changing the comm object so that it gets the parent header from the correct thread. My PR is about that change.