### PR TITLE
update readthedocs env to 3.11

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,8 +1,14 @@
 version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
 sphinx:
   configuration: docs/conf.py
+
 python:
-  version: 3.8
   install:
     # install itself with pip install .
     - method: pip


### PR DESCRIPTION
should fix recently failing RTD builds with "Could not import extension sphinx.builders.linkcheck"