### PR TITLE
fix: protect stdout/stderr restoration in `InProcessKernel._redirected_io`

### DIFF
--- a/ipykernel/inprocess/ipkernel.py
+++ b/ipykernel/inprocess/ipkernel.py
@@ -121,9 +121,11 @@ class InProcessKernel(IPythonKernel):
     def _redirected_io(self):
         """Temporarily redirect IO to the kernel."""
         sys_stdout, sys_stderr = sys.stdout, sys.stderr
-        sys.stdout, sys.stderr = self.stdout, self.stderr
-        yield
-        sys.stdout, sys.stderr = sys_stdout, sys_stderr
+        try:
+            sys.stdout, sys.stderr = self.stdout, self.stderr
+            yield
+        finally:
+            sys.stdout, sys.stderr = sys_stdout, sys_stderr
 
     # ------ Trait change handlers --------------------------------------------
 


### PR DESCRIPTION
`contextlib.contextmanager` does not always run code following the `yield` statement. this commit adds a finally block to ensure that stdout and stderr are properly restored even in the presence of uncaught exceptions.