### PR TITLE
Check existence of connection_file before writing

### DIFF
--- a/ipykernel/eventloops.py
+++ b/ipykernel/eventloops.py
@@ -429,7 +429,7 @@ def loop_asyncio_exit(kernel):
         close_loop()
 
     elif not loop.is_closed():
-        loop.run_until_complete(close_loop)  # type:ignore[call-overload]
+        loop.run_until_complete(close_loop)  # type:ignore
         loop.close()
 
 

--- a/ipykernel/inprocess/tests/test_kernelmanager.py
+++ b/ipykernel/inprocess/tests/test_kernelmanager.py
@@ -3,6 +3,8 @@
 
 import unittest
 
+from flaky import flaky
+
 from ipykernel.inprocess.manager import InProcessKernelManager
 
 # -----------------------------------------------------------------------------
@@ -18,6 +20,7 @@ class InProcessKernelManagerTestCase(unittest.TestCase):
         if self.km.has_kernel:
             self.km.shutdown_kernel()
 
+    @flaky
     def test_interface(self):
         """Does the in-process kernel manager implement the basic KM interface?"""
         km = self.km

--- a/ipykernel/kernelapp.py
+++ b/ipykernel/kernelapp.py
@@ -260,9 +260,10 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp, ConnectionFileMix
     def write_connection_file(self):
         """write connection info to JSON file"""
         cf = self.abs_connection_file
-        self.log.debug("Writing connection file: %s", cf)
         if os.path.exists(cf):
+            self.log.debug("connection file %s alreasy exist", cf)
             return
+        self.log.debug("Writing connection file: %s", cf)
         write_connection_file(
             cf,
             ip=self.ip,

--- a/ipykernel/kernelapp.py
+++ b/ipykernel/kernelapp.py
@@ -261,6 +261,8 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp, ConnectionFileMix
         """write connection info to JSON file"""
         cf = self.abs_connection_file
         self.log.debug("Writing connection file: %s", cf)
+        if os.path.exists(cf):
+            return
         write_connection_file(
             cf,
             ip=self.ip,

--- a/ipykernel/kernelapp.py
+++ b/ipykernel/kernelapp.py
@@ -261,7 +261,7 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp, ConnectionFileMix
         """write connection info to JSON file"""
         cf = self.abs_connection_file
         if os.path.exists(cf):
-            self.log.debug("connection file %s alreasy exist", cf)
+            self.log.debug("Connection file %s already exists", cf)
             return
         self.log.debug("Writing connection file: %s", cf)
         write_connection_file(

--- a/ipykernel/tests/test_debugger.py
+++ b/ipykernel/tests/test_debugger.py
@@ -208,7 +208,7 @@ print({var_name})
     get_reply(kernel_with_debug, msg_id)
 
     r = wait_for_debug_request(kernel_with_debug, "inspectVariables")
-    assert var_name in list(map(lambda v: v["name"], r["body"]["variables"]))  # type:ignore  # noqa
+    assert var_name in list(map(lambda v: v["name"], r["body"]["variables"]))  # noqa
 
     reply = wait_for_debug_request(
         kernel_with_debug,

--- a/ipykernel/tests/test_debugger.py
+++ b/ipykernel/tests/test_debugger.py
@@ -121,7 +121,7 @@ f(2, 3)"""
     assert reply["body"]["breakpoints"][0]["source"]["path"] == source
 
     r = wait_for_debug_request(kernel_with_debug, "debugInfo")
-    assert source in map(lambda b: b["source"], r["body"]["breakpoints"])  # type:ignore # noqa
+    assert source in map(lambda b: b["source"], r["body"]["breakpoints"])  # noqa
 
     r = wait_for_debug_request(kernel_with_debug, "configurationDone")
     assert r["success"]


### PR DESCRIPTION
I find the connection file `kernel-<uuid>.json` would be created twice when starting and connecting kernel. I thought this is not as expected since the first time kernel created:

https://github.com/jupyter/jupyter_client/blob/57b11c36b1eceae138cfc6044a2274e2e1caa135/jupyter_client/connect.py#L488

do check this. But the second call, i.e., come from the kernelapp doesn't. Thus that json file would overwrite the previous one. I don't know the general order though, this order is I observed when open a new jupyter notebook.


And this time `kernelname` was not passed. So I never find `kernelname` in connection file, I believe this was a bug.

