### PR TITLE
Let get_parent decide the channel to get parent header

### DIFF
--- a/ipykernel/comm/comm.py
+++ b/ipykernel/comm/comm.py
@@ -32,11 +32,6 @@ class BaseComm(comm.base_comm.BaseComm):
         metadata = {} if metadata is None else metadata
         content = json_clean(dict(data=data, comm_id=self.comm_id, **keys))
 
-        if threading.current_thread().name == CONTROL_THREAD_NAME:
-            channel_from_which_to_get_parent_header = "control"
-        else:
-            channel_from_which_to_get_parent_header = "shell"
-
         if self.kernel is None:
             self.kernel = Kernel.instance()
 
@@ -45,7 +40,7 @@ class BaseComm(comm.base_comm.BaseComm):
             msg_type,
             content,
             metadata=json_clean(metadata),
-            parent=self.kernel.get_parent(channel_from_which_to_get_parent_header),
+            parent=self.kernel.get_parent(),
             ident=self.topic,
             buffers=buffers,
         )

--- a/ipykernel/comm/comm.py
+++ b/ipykernel/comm/comm.py
@@ -3,7 +3,6 @@
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-import threading
 import uuid
 from typing import Optional
 from warnings import warn
@@ -12,7 +11,6 @@ import comm.base_comm
 import traitlets.config
 from traitlets import Bool, Bytes, Instance, Unicode, default
 
-from ipykernel.control import CONTROL_THREAD_NAME
 from ipykernel.jsonutil import json_clean
 from ipykernel.kernelbase import Kernel
 

--- a/ipykernel/ipkernel.py
+++ b/ipykernel/ipkernel.py
@@ -675,7 +675,6 @@ class IPythonKernel(KernelBase):
                 "error",
                 reply_content,
                 ident=self._topic("error"),
-                channel="shell",
             )
             self.log.info("Exception in apply request:\n%s", "\n".join(reply_content["traceback"]))
             result_buf = []

--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -16,10 +16,11 @@ import time
 import typing as t
 import uuid
 import warnings
-from .control import CONTROL_THREAD_NAME
 from datetime import datetime
 from functools import partial
 from signal import SIGINT, SIGTERM, Signals, default_int_handler, signal
+
+from .control import CONTROL_THREAD_NAME
 
 if sys.platform != "win32":
     from signal import SIGKILL
@@ -638,7 +639,7 @@ class Kernel(SingletonConfigurable):
                 channel = "control"
             else:
                 channel = "shell"
-        
+
         return self._parents.get(channel, {})
 
     def send_response(


### PR DESCRIPTION
In the previous [PR](https://github.com/ipython/ipykernel/pull/1114) we addressed the problem where iopub `comm` messages generated by control channel have the wrong parent header from shell channel due to hard code. This PR move the logic to `get_parent` (following discussions [here](https://github.com/ipython/ipykernel/pull/1114#issuecomment-1542933370) from @jasongrout and @minrk ) so we remove the hard-coding problem not only for the `comm` messages, but for other iopub messages as well.