### PR TITLE
Bugfix: binary stdout/stderr handling

### DIFF
--- a/ipykernel/iostream.py
+++ b/ipykernel/iostream.py
@@ -29,6 +29,8 @@ from zmq.eventloop.zmqstream import ZMQStream
 MASTER = 0
 CHILD = 1
 
+PIPE_BUFFER_SIZE = 1000
+
 # -----------------------------------------------------------------------------
 # IO classes
 # -----------------------------------------------------------------------------
@@ -367,11 +369,11 @@ class OutStream(TextIOBase):
         """
 
         try:
-            bts = os.read(self._fid, 1000)
+            bts = os.read(self._fid, PIPE_BUFFER_SIZE)
             while bts and self._should_watch:
-                self.write(bts.decode())
+                self.write(bts.decode(errors='replace'))
                 os.write(self._original_stdstream_copy, bts)
-                bts = os.read(self._fid, 1000)
+                bts = os.read(self._fid, PIPE_BUFFER_SIZE)
         except Exception:
             self._exc = sys.exc_info()
 


### PR DESCRIPTION
`_watch_pipe_fd()` decodes the incoming data from the pipe using str::decode(). By default this passed the `strict` errors flag to the unicode engine. However, if the pipe command returns binary data this will through a `UnicodeError` exception.
We change the code to explicitly pass the `replace` errors flag, which will replace the output with output that can be displayed on screen.
We also specify the buffer size as a constant so it can be changed for edge cases where the task pipes a lot of output/error text.