### PR TITLE
Merge connection info into existing connection file if it already exists

### DIFF
--- a/ipykernel/tests/test_ipkernel_direct.py
+++ b/ipykernel/tests/test_ipkernel_direct.py
@@ -20,7 +20,7 @@ class user_mod:
     __dict__ = {}
 
 
-async def test_properities(ipkernel: IPythonKernel) -> None:
+async def test_properties(ipkernel: IPythonKernel) -> None:
     ipkernel.user_module = user_mod()
     ipkernel.user_ns = {}
 

--- a/ipykernel/tests/test_kernelapp.py
+++ b/ipykernel/tests/test_kernelapp.py
@@ -50,7 +50,7 @@ def test_start_app():
     app.kernel.destroy()
     app.close()
 
-
+@pytest.mark.skipif(os.name == "nt", reason="permission errors on windows")
 def test_merge_connection_file():
     cfg = Config()
     with TemporaryWorkingDirectory() as d:

--- a/ipykernel/tests/test_kernelapp.py
+++ b/ipykernel/tests/test_kernelapp.py
@@ -50,6 +50,7 @@ def test_start_app():
     app.kernel.destroy()
     app.close()
 
+
 @pytest.mark.skipif(os.name == "nt", reason="permission errors on windows")
 def test_merge_connection_file():
     cfg = Config()

--- a/ipykernel/tests/test_kernelapp.py
+++ b/ipykernel/tests/test_kernelapp.py
@@ -1,13 +1,17 @@
+import json
 import os
 import threading
 import time
 from unittest.mock import patch
 
 import pytest
+from jupyter_core.paths import secure_write
+from traitlets.config.loader import Config
 
 from ipykernel.kernelapp import IPKernelApp
 
 from .conftest import MockKernel
+from .utils import TemporaryWorkingDirectory
 
 try:
     import trio
@@ -45,6 +49,71 @@ def test_start_app():
     app.cleanup_connection_file()
     app.kernel.destroy()
     app.close()
+
+
+def test_merge_connection_file():
+    cfg = Config()
+    with TemporaryWorkingDirectory() as d:
+        cfg.ProfileDir.location = d
+        cf = os.path.join(d, "kernel.json")
+        initial_connection_info = {
+            "ip": "*",
+            "transport": "tcp",
+            "shell_port": 0,
+            "hb_port": 0,
+            "iopub_port": 0,
+            "stdin_port": 0,
+            "control_port": 53555,
+            "key": "abc123",
+            "signature_scheme": "hmac-sha256",
+            "kernel_name": "My Kernel",
+        }
+        # We cannot use connect.write_connection_file since
+        # it replaces port number 0 with a random port
+        # and we want IPKernelApp to do that replacement.
+        with secure_write(cf) as f:
+            json.dump(initial_connection_info, f)
+        assert os.path.exists(cf)
+
+        app = IPKernelApp(config=cfg, connection_file=cf)
+
+        # Calling app.initialize() does not work in the test, so we call the relevant functions that initialize() calls
+        super(IPKernelApp, app).initialize(argv=None)
+        app.init_connection_file()
+        app.init_sockets()
+        app.init_heartbeat()
+        app.write_connection_file()
+
+        # Initialize should have merged the actual connection info
+        # with the connection info in the file
+        assert cf == app.abs_connection_file
+        assert os.path.exists(cf)
+
+        with open(cf) as f:
+            new_connection_info = json.load(f)
+
+        # ports originally set as 0 have been replaced
+        for port in ("shell", "hb", "iopub", "stdin"):
+            key = f"{port}_port"
+            # We initially had the port as 0
+            assert initial_connection_info[key] == 0
+            # the port is not 0 now
+            assert new_connection_info[key] > 0
+            # the port matches the port the kernel actually used
+            assert new_connection_info[key] == getattr(app, key), f"{key}"
+            del new_connection_info[key]
+            del initial_connection_info[key]
+
+        # The wildcard ip address was also replaced
+        assert(new_connection_info["ip"] != "*")
+        del new_connection_info["ip"]
+        del initial_connection_info["ip"]
+
+        # everything else in the connection file is the same
+        assert initial_connection_info == new_connection_info
+
+        app.close()
+        os.remove(cf)
 
 
 @pytest.mark.skipif(trio is None, reason="requires trio")

--- a/ipykernel/tests/test_kernelapp.py
+++ b/ipykernel/tests/test_kernelapp.py
@@ -78,7 +78,8 @@ def test_merge_connection_file():
         app = IPKernelApp(config=cfg, connection_file=cf)
 
         # Calling app.initialize() does not work in the test, so we call the relevant functions that initialize() calls
-        super(IPKernelApp, app).initialize(argv=None)
+        # We must pass in an empty argv, otherwise the default is to try to parse the test runner's argv
+        super(IPKernelApp, app).initialize(argv=[""])
         app.init_connection_file()
         app.init_sockets()
         app.init_heartbeat()
@@ -105,7 +106,7 @@ def test_merge_connection_file():
             del initial_connection_info[key]
 
         # The wildcard ip address was also replaced
-        assert(new_connection_info["ip"] != "*")
+        assert new_connection_info["ip"] != "*"
         del new_connection_info["ip"]
         del initial_connection_info["ip"]
 


### PR DESCRIPTION
This PR lets a connection file specify a port as 0 and then be updated when ipykernel picks a port, as a follow-up to https://github.com/ipython/ipykernel/pull/1127.

In https://github.com/ipython/ipykernel/pull/1127, ipykernel was changed to not overwrite a kernel connection file when it already exists. This broke a pattern we used at Databricks (thanks to @mrbago) that addresses the same handshaking issues as https://github.com/jupyter/jupyter_client/issues/487 and https://github.com/jupyter/enhancement-proposals/pull/66 (i.e., [JEP 66](https://github.com/jupyter/enhancement-proposals/blob/master/66-jupyter-handshaking/jupyter-handshaking.md)). Our pattern was this:

1. The kernel client writes a connection file `connect.json` like the following, where all the port numbers are zero:
   ```json
    {
      "shell_port": 0,
      "iopub_port": 0,
      "stdin_port": 0,
      "control_port": 0,
      "hb_port": 0,
      "ip": "*",
      "key": "abc123",
      "transport": "tcp",
      "signature_scheme": "hmac-sha256",
      "kernel_name": "My Kernel"
    }
   ```
2. ipykernel is started, pointing at that connection file.
   ```
   python -m ipykernel -f ./connect.json
   ```
4. ipykernel/zmq picks random ports for each of the channels
5. ipykernel (before https://github.com/ipython/ipykernel/pull/1127) overwrites the connection file with the correct port numbers and `ip` interface address it actually connected to
6. We read the connection file to see what ports the client needs to use to communicate with ipykernel.
    ```
    $ cat connect.json 
    {
      "shell_port": 62757,
      "iopub_port": 62761,
      "stdin_port": 62758,
      "control_port": 62759,
      "hb_port": 62763,
      "ip": "0.0.0.0",
      "key": "abc123",
      "transport": "tcp",
      "signature_scheme": "hmac-sha256",
      "kernel_name": ""
    }
    ```
In https://github.com/ipython/ipykernel/pull/1127, it was noticed that this overwrote the kernel_name as well. In essence, ipykernel was taking over the file that someone else had created. The solution in https://github.com/ipython/ipykernel/pull/1127 was to not touch the connection file if it exists, but that breaks the usecase of letting the kernel pick ports and interfaces.

This PR instead merges the new information from ipykernel into the connection file. If the file would not change from the updated information, then we don't write to the connection file. In short, with this PR, we get the following in the last step above:
```
$ cat connect.json 
{
  "shell_port": 62914,
  "iopub_port": 62918,
  "stdin_port": 62915,
  "control_port": 62916,
  "hb_port": 62920,
  "ip": "0.0.0.0",
  "key": "abc123",
  "transport": "tcp",
  "signature_scheme": "hmac-sha256",
  "kernel_name": "My Kernel"
}
```