### PR TITLE
feat: let display hook handle clear_output

### DIFF
--- a/ipykernel/zmqshell.py
+++ b/ipykernel/zmqshell.py
@@ -144,11 +144,17 @@ class ZMQDisplayPublisher(DisplayPublisher):
         """
         content = dict(wait=wait)
         self._flush_streams()
+        msg = self.session.msg("clear_output", json_clean(content), parent=self.parent_header)
+
+        # see publish() for details on how this works
+        for hook in self._hooks:
+            msg = hook(msg)
+            if msg is None:
+                return
+
         self.session.send(
             self.pub_socket,
-            "clear_output",
-            content,
-            parent=self.parent_header,
+            msg,
             ident=self.topic,
         )
 


### PR DESCRIPTION
A display hook can handle a publish message, but not yet a clear_output

Upstreaming of: https://github.com/widgetti/solara/pull/132
Follow up of: https://github.com/ipython/ipykernel/pull/1110
Related: https://github.com/ipython/ipykernel/pull/115/files

Would enable https://github.com/jupyter-widgets/ipywidgets/pull/3759 to fully work kernel side.