### PR TITLE
Avoid starting IOPub background thread after it's been stopped

### DIFF
--- a/ipykernel/iostream.py
+++ b/ipykernel/iostream.py
@@ -57,6 +57,7 @@ class IOPubThread:
             piped from subprocesses.
         """
         self.socket = socket
+        self._stopped = False
         self.background_socket = BackgroundSocket(self)
         self._master_pid = os.getpid()
         self._pipe_flag = pipe
@@ -83,7 +84,12 @@ class IOPubThread:
             self._event_pipe_gc_task = asyncio.ensure_future(self._run_event_pipe_gc())
 
         self.io_loop.run_sync(_start_event_gc)
-        self.io_loop.start()
+
+        if not self._stopped:
+            # avoid race if stop called before start thread gets here
+            # probably only comes up in tests
+            self.io_loop.start()
+
         if self._event_pipe_gc_task is not None:
             # cancel gc task to avoid pending task warnings
             async def _cancel():
@@ -219,10 +225,16 @@ class IOPubThread:
 
     def stop(self):
         """Stop the IOPub thread"""
+        self._stopped = True
         if not self.thread.is_alive():
             return
         self.io_loop.add_callback(self.io_loop.stop)
-        self.thread.join()
+
+        self.thread.join(timeout=30)
+        if self.thread.is_alive():
+            # avoid infinite hang if stop fails
+            msg = "IOPub thread did not terminate in 30 seconds"
+            raise TimeoutError(msg)
         # close *all* event pipes, created in any thread
         # event pipes can only be used from other threads while self.thread.is_alive()
         # so after thread.join, this should be safe

--- a/ipykernel/iostream.py
+++ b/ipykernel/iostream.py
@@ -94,8 +94,11 @@ class IOPubThread:
             # cancel gc task to avoid pending task warnings
             async def _cancel():
                 self._event_pipe_gc_task.cancel()  # type:ignore
-
-            self.io_loop.run_sync(_cancel)
+            
+            try:
+                self.io_loop.run_sync(_cancel)
+            except TimeoutError:
+                pass
         self.io_loop.close(all_fds=True)
 
     def _setup_event_pipe(self):

--- a/ipykernel/iostream.py
+++ b/ipykernel/iostream.py
@@ -94,7 +94,7 @@ class IOPubThread:
             # cancel gc task to avoid pending task warnings
             async def _cancel():
                 self._event_pipe_gc_task.cancel()  # type:ignore
-            
+
             try:
                 self.io_loop.run_sync(_cancel)
             except TimeoutError:


### PR DESCRIPTION
`loop.add_callback(loop.stop)` called before the thread starts can get consumed by the run_sync before loop.start, so it won't close the loop. This is causing some tests to hang (e.g. ipython downstream tests), but isn't likely to affect any users at runtime.

The run_sync was added in #1125 