### PR TITLE
Modifying debugger to return the same breakpoints in 'debugInfo' response as 'setBreakpoints'

### DIFF
--- a/ipykernel/debugger.py
+++ b/ipykernel/debugger.py
@@ -477,11 +477,11 @@ class Debugger:
         # debugpy can set breakpoints on different lines than the ones requested,
         # so we want to record the breakpoints that were actually added
         if "success" in message_response and message_response["success"]:
-            self.breakpoint_list[source] = [{
-                "line": breakpoint["line"]
-            } for breakpoint in message_response["body"]["breakpoints"]]
+            self.breakpoint_list[source] = [
+                {"line": breakpoint["line"]}
+                for breakpoint in message_response["body"]["breakpoints"]
+            ]
         return message_response
-    
 
     async def source(self, message):
         """Handle a source message."""

--- a/ipykernel/debugger.py
+++ b/ipykernel/debugger.py
@@ -473,7 +473,15 @@ class Debugger:
         """Handle a set breakpoints message."""
         source = message["arguments"]["source"]["path"]
         self.breakpoint_list[source] = message["arguments"]["breakpoints"]
-        return await self._forward_message(message)
+        message_response = await self._forward_message(message)
+        # debugpy can set breakpoints on different lines than the ones requested,
+        # so we want to record the breakpoints that were actually added
+        if "success" in message_response and message_response["success"]:
+            self.breakpoint_list[source] = [{
+                "line": breakpoint["line"]
+            } for breakpoint in message_response["body"]["breakpoints"]]
+        return message_response
+    
 
     async def source(self, message):
         """Handle a source message."""


### PR DESCRIPTION
In this PR, I make changes to `debugger.py` so that the breakpoints returned in a `debugInfo` response match the breakpoints returned in the most recent `setBreakpoints` request.

**Bug context:**
When a user clicks on a gutter to add/remove a breakpoint, a setBreakpoints request is sent.  The UI changes according to the response of the setBreakpoints request, which gives a list of the breakpoints that were actually added. debugInfo is used to populate the UI breakpoints when a notebook is refreshed. So, it is important that the debugInfo and setBreakpoints information aligns.

Let's say we try to add a breakpoint at a commented out line (say line 2). `debugpy` will infer that that line is not a runnable piece of code, so it will add a breakpoint to the line of code before that (say line 1), and the `setBreakpoints` response will consist of a breakpoint at line 1. However, the `debugInfo` request is implemented by `ipykernel`, and the list of breakpoints for that is maintained by just recording the breakpoints that were sent in the setBreakpoints request. So, a `debugInfo` request would contain the information that there is a breakpoint at line 2. This causes confusing jumping behavior when the `debugInfo` request gets called, like on refresh.

In the video, the breakpoint jumps from line 1 to line 2 when the page is refreshed. Then, if I try to add a breakpoint at line 1, the breakpoint at line 2 disappears (because the `setBreakpoints` response contains the correct info, which is that there is no breakpoint at line 2).

https://github.com/ipython/ipykernel/assets/24895015/df789da1-f491-4515-8217-ef339c02b82a

**Fix:**
I fix this by modifying the `setBreakpoints` request handler in`debugger.py` to record the response of the `setBreakpoints` request as the information for the debugInfo request.

