### PR TITLE
Don't call QApplication.setQuitOnLastWindowClosed(False).

### DIFF
--- a/ipykernel/eventloops.py
+++ b/ipykernel/eventloops.py
@@ -535,13 +535,10 @@ def make_qt_app_for_kernel(gui, kernel):
     set_qt_api_env_from_gui(gui)
 
     # This import is guaranteed to work now:
-    from IPython.external.qt_for_kernel import QtCore, QtGui
+    from IPython.external.qt_for_kernel import QtCore
     from IPython.lib.guisupport import get_app_qt4
 
     kernel.app = get_app_qt4([" "])
-    if isinstance(kernel.app, QtGui.QApplication):
-        kernel.app.setQuitOnLastWindowClosed(False)
-
     kernel.app.qt_event_loop = QtCore.QEventLoop(kernel.app)
 
 


### PR DESCRIPTION
That setting previously caused
`plt.plot(); print("pre"); plt.show(block=True); print("post")` to block after the `show()` call *even* after closing the Matplotlib figure window ("post" was never printed).

The new behavior (printing "post" after the window is closed) is consistent with plain IPython.

The setQuitOnLastWindowClosed call came in (with no additional explanation) in the very first commit implementing qt support (bec2d41, in 2010) and seems to have never been touched since then.

This should close #4367 (which is really an ipykernel issue per https://github.com/spyder-ide/spyder/issues/4367#issuecomment-295026348), which had previously been closed as "can't fix, workaround available".  Attn @ccordoba12 who commented on the spyder issue.