### PR TITLE
Fix: ipython version incompatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,10 +23,11 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
 ]
 urls = {Homepage = "https://ipython.org"}
-requires-python = ">=3.9"
+requires-python = ">=3.8"
 dependencies = [
     "debugpy>=1.6.5",
-    "ipython>=7.23.1",
+    "ipython>=7.23.1<=8.12;python_version=='3.8'",
+    "ipython>=7.23.1;python_version>='3.9'",
     "comm>=0.1.1",
     "traitlets>=5.4.0",
     "jupyter_client>=6.1.12",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
 ]
 urls = {Homepage = "https://ipython.org"}
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
     "debugpy>=1.6.5",
     "ipython>=7.23.1",


### PR DESCRIPTION
ipython requires python>=3.9 where as ipykernel requires python>=3.8

This mismatch causes kernel installs with python=3.8 to fail. 