### PR TITLE
Extend argument handling of do_execute with cell metadata

### DIFF
--- a/ipykernel/ipkernel.py
+++ b/ipykernel/ipkernel.py
@@ -23,7 +23,7 @@ from .compiler import XCachingCompiler
 from .debugger import Debugger, _is_debugpy_available
 from .eventloops import _use_appnope
 from .kernelbase import Kernel as KernelBase
-from .kernelbase import _accepts_cell_id
+from .kernelbase import _accepts_parameters
 from .zmqshell import ZMQInteractiveShell
 
 try:
@@ -347,6 +347,7 @@ class IPythonKernel(KernelBase):
         user_expressions=None,
         allow_stdin=False,
         *,
+        cell_meta=None,
         cell_id=None,
     ):
         """Handle code execution."""
@@ -359,7 +360,7 @@ class IPythonKernel(KernelBase):
         if hasattr(shell, "run_cell_async") and hasattr(shell, "should_run_async"):
             run_cell = shell.run_cell_async
             should_run_async = shell.should_run_async
-            with_cell_id = _accepts_cell_id(run_cell)
+            with_cell_id = _accepts_parameters(run_cell, ["cell_id"])
         else:
             should_run_async = lambda cell: False  # noqa
             # older IPython,
@@ -368,7 +369,7 @@ class IPythonKernel(KernelBase):
             async def run_cell(*args, **kwargs):
                 return shell.run_cell(*args, **kwargs)
 
-            with_cell_id = _accepts_cell_id(shell.run_cell)
+            with_cell_id = _accepts_parameters(shell.run_cell, ["cell_id"])
         try:
             # default case: runner is asyncio and asyncio is already running
             # TODO: this should check every case for "are we inside the runner",

--- a/ipykernel/ipkernel.py
+++ b/ipykernel/ipkernel.py
@@ -360,7 +360,7 @@ class IPythonKernel(KernelBase):
         if hasattr(shell, "run_cell_async") and hasattr(shell, "should_run_async"):
             run_cell = shell.run_cell_async
             should_run_async = shell.should_run_async
-            with_cell_id = _accepts_parameters(run_cell, ["cell_id"])
+            accepts_params = _accepts_parameters(run_cell, ["cell_id"])
         else:
             should_run_async = lambda cell: False  # noqa
             # older IPython,
@@ -369,7 +369,7 @@ class IPythonKernel(KernelBase):
             async def run_cell(*args, **kwargs):
                 return shell.run_cell(*args, **kwargs)
 
-            with_cell_id = _accepts_parameters(shell.run_cell, ["cell_id"])
+            accepts_params = _accepts_parameters(shell.run_cell, ["cell_id"])
         try:
             # default case: runner is asyncio and asyncio is already running
             # TODO: this should check every case for "are we inside the runner",
@@ -391,7 +391,7 @@ class IPythonKernel(KernelBase):
                     preprocessing_exc_tuple=preprocessing_exc_tuple,
                 )
             ):
-                if with_cell_id:
+                if accepts_params["cell_id"]:
                     coro = run_cell(
                         code,
                         store_history=store_history,
@@ -423,7 +423,7 @@ class IPythonKernel(KernelBase):
                 # runner isn't already running,
                 # make synchronous call,
                 # letting shell dispatch to loop runners
-                if with_cell_id:
+                if accepts_params["cell_id"]:
                     res = shell.run_cell(
                         code,
                         store_history=store_history,

--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -742,7 +742,7 @@ class Kernel(SingletonConfigurable):
             self._publish_execute_input(code, parent, self.execution_count)
 
         cell_meta = parent.get("metadata", {})
-        cell_id = metadata.get("cellId")
+        cell_id = cell_meta.get("cellId") or {}
 
         # Check which parameters do_execute can accept
         accepts_params = _accepts_parameters(self.do_execute, ["cell_meta", "cell_id"])
@@ -756,8 +756,8 @@ class Kernel(SingletonConfigurable):
             "allow_stdin": allow_stdin,
         }
 
-        if accepts_params["metadata"]:
-            do_execute_args["metadata"] = cell_meta
+        if accepts_params["cell_meta"]:
+            do_execute_args["cell_meta"] = cell_meta
         if accepts_params["cell_id"]:
             do_execute_args["cell_id"] = cell_id
 

--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -742,7 +742,7 @@ class Kernel(SingletonConfigurable):
             self._publish_execute_input(code, parent, self.execution_count)
 
         cell_meta = parent.get("metadata", {})
-        cell_id = cell_meta.get("cellId") or {}
+        cell_id = cell_meta.get("cellId")
 
         # Check which parameters do_execute can accept
         accepts_params = _accepts_parameters(self.do_execute, ["cell_meta", "cell_id"])

--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -745,7 +745,7 @@ class Kernel(SingletonConfigurable):
         cell_id = metadata.get("cellId")
 
         # Check which parameters do_execute can accept
-        accepts_params = _accepts_parameters(self.do_execute, ["metadata", "cell_id"])
+        accepts_params = _accepts_parameters(self.do_execute, ["cell_meta", "cell_id"])
 
         # Arguments based on the do_execute signature
         do_execute_args = {


### PR DESCRIPTION
Enhances the `do_execute` method by allowing an optional `cell_meta` parameter, which represents cell metadata. This addition aligns with the Jupyter messaging protocol on [metadata](https://jupyter-client.readthedocs.io/en/latest/messaging.html#metadata), which acknowledges the potential use of metadata in various message types.

Although `metadata` may not be often used, the capability to handle metadata within `do_execute` can expand the kernel's flexibility, especially in scenarios involving complex interactions or custom extensions, as detailed in the [jupyter_client docs](https://jupyter-client.readthedocs.io/en/latest/messaging.html#metadata).

A noteable use case is in the development of [Python wrapper kernels](https://jupyter-client.readthedocs.io/en/latest/wrapperkernels.html#making-simple-python-wrapper-kernels), where additional information might be passed via metadata to influence execution behavior, provide additional context, or interact with external services.

Changes:
 - Extending the `do_execute` signature to include an optional metadata parameter
 - Implementing logic in `execute_request` to extract and pass down cell metadata to `do_execute` 
   - This involved expanding `_accepts_cell_id` to `_accepts_parameters` for broader parameter checks, which in turn seemly created nice flow in `execute_request`.

---

It seemed bold requesting to replace `cell_id` with `metadata` despite one is derived from the other. However, `_accepts_parameters` enables flexible handling of these optional parameters, thus somewhat ensuring backward compatibility. A minor concern might involve the imports of `_accepts_cell_id`, which has been removed/replaced, but can be reintegrated if necessary.

Thanks