### PR TITLE
Update pytest commands in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Follow the instructions from `Installation from source`.
 and then from the root directory
 
 ```bash
-pytest ipykernel
+pytest
 ```
 
 ## Running tests with coverage
@@ -30,7 +30,7 @@ Follow the instructions from `Installation from source`.
 and then from the root directory
 
 ```bash
-pytest ipykernel -vv -s --cov ipykernel --cov-branch --cov-report term-missing:skip-covered --durations 10
+pytest -vv -s --cov ipykernel --cov-branch --cov-report term-missing:skip-covered --durations 10
 ```
 
 ## About the IPython Development Team


### PR DESCRIPTION
This PR updates the two `pytest` commands in the README to be the same as those in CI and the various `hatch` commands. It replaces `pytest ipykernel` with `pytest`. An alternative would be to use the more explicit `pytest tests`, but this seems unnecessary.

Problem discovered when following the developer instructions for the first time.

This is my first contribution to `ipykernel` :smiley: