### PR TITLE
Pin pytest-asyncio to 0.23.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ test = [
     "flaky",
     "ipyparallel",
     "pre-commit",
-    "pytest-asyncio",
+    "pytest-asyncio==0.23.2",
     "pytest-timeout"
 ]
 cov = [


### PR DESCRIPTION
Seeing if #1188 is fixed by pinning `pytest-asyncio`.