### PR TITLE
fix: on exception, return a 0, so that the "sum" still computes

### DIFF
--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -1049,7 +1049,7 @@ class Kernel(SingletonConfigurable):
         # Avoid littering logs with stack traces
         # complaining about dead processes
         except BaseException:
-            return None
+            return 0
 
     async def usage_request(self, stream, ident, parent):
         """Handle a usage request."""


### PR DESCRIPTION
This fixes a bug where after a while in a Jupyter notebook, we start to see many log lines like this:

```
[IPKernelApp] ERROR | Exception in control handler:
Traceback (most recent call last):
  File ".../lib/python3.8/site-packages/ipykernel/kernelbase.py", line 336, in process_control
    await result
  File ".../lib/python3.8/site-packages/ipykernel/kernelbase.py", line 998, in usage_request
    reply_content["kernel_memory"] = sum(
TypeError: unsupported operand type(s) for +: 'int' and 'NoneType'
```

Since the "sum" expects a number (float or int) as elements given to the "sum", we should pass "0" (zero) and not None when we that process id does not exist anymore.

This was tested in an actually running notebook and it fixed the problem:
* no more Exceptions like the one reported above
* correct memory stats where seen with the Kernel Usage plug-ins