### PR TITLE
Fix: ipykernel_launcher, delete absolute sys.path[0]

### DIFF
--- a/ipykernel_launcher.py
+++ b/ipykernel_launcher.py
@@ -5,11 +5,12 @@ after removing the cwd from sys.path.
 """
 
 import sys
+from pathlib import Path
 
 if __name__ == "__main__":
     # Remove the CWD from sys.path while we load stuff.
     # This is added back by InteractiveShellApp.init_path()
-    if sys.path[0] == "":
+    if sys.path[0] == "" or Path(sys.path[0]) == Path.cwd():
         del sys.path[0]
 
     from ipykernel import kernelapp as app


### PR DESCRIPTION
If use `-m` option, sys.path[0] will be absolute path.
Delete sys.path[0] if it's absolute path. Due to PTH109, I use pathlib. 
We cannot start `python3 -m ipykernel_launcher` in the directory which contains queue.py or zmq.py .


```
ipykernel_launcher.py:13:44: PTH109 `os.getcwd()` should be replaced by `Path.cwd()`
```
--- 
How to reproduce. 
```
cd /tmp
git clone https://github.com/ipython/ipykernel.git
python3 -m pip install -e ./ipykernel
mkdir test
cd test
python3 -m ipykernel_launcher # it works
# Ctrl + \ to kill
touch queue.py

python3 -m ipykernel_launcher # error!
```

Error details
```
python3 -m ipykernel_launcher

['/private/tmp/test', '/opt/homebrew/Cellar/python@3.11/3.11.6/Frameworks/Python.framework/Versions/3.11/lib/python311.zip', '/opt/homebrew/Cellar/python@3.11/3.11.6/Frameworks/Python.framework/Versions/3.11/lib/python3.11', '/opt/homebrew/Cellar/python@3.11/3.11.6/Frameworks/Python.framework/Versions/3.11/lib/python3.11/lib-dynload', '/opt/homebrew/lib/python3.11/site-packages', '/private/tmp/ipykernel']
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/opt/homebrew/lib/python3.11/site-packages/ipykernel_launcher.py", line 16, in <module>
    from ipykernel import kernelapp as app
  File "/private/tmp/ipykernel/ipykernel/__init__.py", line 7, in <module>
    from .connect import *
  File "/private/tmp/ipykernel/ipykernel/connect.py", line 12, in <module>
    import jupyter_client
  File "/opt/homebrew/lib/python3.11/site-packages/jupyter_client/__init__.py", line 3, in <module>
    from .asynchronous import AsyncKernelClient
  File "/opt/homebrew/lib/python3.11/site-packages/jupyter_client/asynchronous/__init__.py", line 1, in <module>
    from .client import AsyncKernelClient  # noqa
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/lib/python3.11/site-packages/jupyter_client/asynchronous/client.py", line 11, in <module>
    from ..channels import AsyncZMQSocketChannel, HBChannel
  File "/opt/homebrew/lib/python3.11/site-packages/jupyter_client/channels.py", line 8, in <module>
    from queue import Empty
ImportError: cannot import name 'Empty' from 'queue' (/private/tmp/test/queue.py)
```
