### PR TITLE
Re-enable skipped debugger test

### DIFF
--- a/tests/test_debugger.py
+++ b/tests/test_debugger.py
@@ -197,7 +197,6 @@ f(2, 3)"""
     assert msg["content"]["body"]["reason"] == "breakpoint"
 
 
-@pytest.mark.skipif(sys.version_info >= (3, 10), reason="TODO Does not work on Python 3.10")
 def test_breakpoint_in_cell_with_leading_empty_lines(kernel_with_debug):
     code = """
 def f(a, b):


### PR DESCRIPTION
One of the tests in `test_debugger.py` has been skipped for python >= 3.10 since it was added (#829). The test runs and passes fine for me on Ubuntu using python 3.10.1 and 3.10.13, so here I am re-enabling it to run it on the whole CI matrix.