### PR TITLE
Remove control queue

### DIFF
--- a/ipykernel/inprocess/ipkernel.py
+++ b/ipykernel/inprocess/ipkernel.py
@@ -88,9 +88,6 @@ class InProcessKernel(IPythonKernel):
     def _abort_queues(self):
         """The in-process kernel doesn't abort requests."""
 
-    async def _flush_control_queue(self):
-        """No need to flush control queues for in-process"""
-
     def _input_request(self, prompt, ident, parent, password=False):
         # Flush output before making the request.
         self.raw_input_str = None

--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -498,7 +498,7 @@ class Kernel(SingletonConfigurable):
 
         if self.control_thread is None and self.control_stream is not None:
             # If there isn't a separate control thread then this main thread handles both shell
-            # and control messages. Before processing a shell message need to flush all control
+            # and control messages. Before processing a shell message we need to flush all control
             # messages and allow them all to be processed.
             await asyncio.sleep(0)
             self.control_stream.flush()

--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -269,9 +269,6 @@ class Kernel(SingletonConfigurable):
         "usage_request",
     ]
 
-    # Flag to ensure a single control request is processed at a time.
-    _block_control = False
-
     def __init__(self, **kwargs):
         """Initialize the kernel."""
         super().__init__(**kwargs)
@@ -298,17 +295,8 @@ class Kernel(SingletonConfigurable):
 
     async def dispatch_control(self, msg):
         # Ensure only one control message is processed at a time
-        while self._block_control:
-            await asyncio.sleep(0)
-
-        self._block_control = True
-
-        try:
+        async with asyncio.Lock():
             await self.process_control(msg)
-        except:
-            raise
-        finally:
-            self._block_control = False
 
     async def process_control(self, msg):
         """dispatch control requests"""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,14 +24,14 @@ dependencies = [
     "ipython>=7.23.1",
     "comm>=0.1.1",
     "traitlets>=5.4.0",
-    "jupyter_client>=6.1.12",
+    "jupyter_client>=8.0.0",
     "jupyter_core>=4.12,!=5.0.*",
     # For tk event loop support only.
     "nest_asyncio",
-    "tornado>=6.1",
+    "tornado>=6.2",
     "matplotlib-inline>=0.1",
     'appnope;platform_system=="Darwin"',
-    "pyzmq>=24",
+    "pyzmq>=25",
     "psutil",
     "packaging",
 ]

--- a/tests/test_ipkernel_direct.py
+++ b/tests/test_ipkernel_direct.py
@@ -164,41 +164,29 @@ def test_dispatch_debugpy(ipkernel: IPythonKernel) -> None:
 
 async def test_start(ipkernel: IPythonKernel) -> None:
     shell_future: asyncio.Future = asyncio.Future()
-    control_future: asyncio.Future = asyncio.Future()
 
     async def fake_dispatch_queue():
         shell_future.set_result(None)
 
-    async def fake_poll_control_queue():
-        control_future.set_result(None)
-
     ipkernel.dispatch_queue = fake_dispatch_queue  # type:ignore
-    ipkernel.poll_control_queue = fake_poll_control_queue  # type:ignore
     ipkernel.start()
     ipkernel.debugpy_stream = None
     ipkernel.start()
     await ipkernel.process_one(False)
     await shell_future
-    await control_future
 
 
 async def test_start_no_debugpy(ipkernel: IPythonKernel) -> None:
     shell_future: asyncio.Future = asyncio.Future()
-    control_future: asyncio.Future = asyncio.Future()
 
     async def fake_dispatch_queue():
         shell_future.set_result(None)
 
-    async def fake_poll_control_queue():
-        control_future.set_result(None)
-
     ipkernel.dispatch_queue = fake_dispatch_queue  # type:ignore
-    ipkernel.poll_control_queue = fake_poll_control_queue  # type:ignore
     ipkernel.debugpy_stream = None
     ipkernel.start()
 
     await shell_future
-    await control_future
 
 
 def test_create_comm():

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -10,6 +10,7 @@ import signal
 import subprocess
 import sys
 import time
+from datetime import datetime, timedelta
 from subprocess import Popen
 from tempfile import TemporaryDirectory
 
@@ -595,6 +596,43 @@ def test_control_thread_priority():
     # comparing first to last ought to be enough, since queues preserve order
     # use <= in case of very-fast handling and/or low resolution timers
     assert control_dates[-1] <= shell_dates[0]
+
+
+def test_sequential_control_messages():
+    with new_kernel() as kc:
+        msg_id = kc.execute("import time")
+        get_reply(kc, msg_id)
+
+        # Send multiple messages on the control channel.
+        # Using execute messages to vary duration.
+        sleeps = [0.6, 0.3, 0.1]
+
+        # Prepare messages
+        msgs = [
+            kc.session.msg("execute_request", {"code": f"time.sleep({sleep})"}) for sleep in sleeps
+        ]
+        msg_ids = [msg["header"]["msg_id"] for msg in msgs]
+
+        # Submit messages
+        for msg in msgs:
+            kc.control_channel.send(msg)
+
+        # Get replies
+        replies = [get_reply(kc, msg_id, channel="control") for msg_id in msg_ids]
+
+        # Check messages are processed in order, one at a time, and of a sensible duration.
+        previous_end = None
+        for reply, sleep in zip(replies, sleeps):
+            start = datetime.fromisoformat(reply["metadata"]["started"])
+            end = reply["header"]["date"]
+            if isinstance(end, str):
+                end = datetime.fromisoformat(end)
+
+            if previous_end is not None:
+                assert start > previous_end
+            previous_end = end
+
+            assert end >= start + timedelta(seconds=sleep)
 
 
 def _child():

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -623,7 +623,13 @@ def test_sequential_control_messages():
         # Check messages are processed in order, one at a time, and of a sensible duration.
         previous_end = None
         for reply, sleep in zip(replies, sleeps):
-            start = datetime.fromisoformat(reply["metadata"]["started"])
+            start_str = reply["metadata"]["started"]
+            if sys.version_info[:2] < (3, 11) and start_str.endswith("Z"):
+                # Python < 3.11 doesn't support "Z" suffix in datetime.fromisoformat,
+                # so use alternative timezone format.
+                # https://github.com/python/cpython/issues/80010
+                start_str = start_str[:-1] + "+00:00"
+            start = datetime.fromisoformat(start_str)
             end = reply["header"]["date"]  # Already a datetime
 
             if previous_end is not None:

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -624,9 +624,7 @@ def test_sequential_control_messages():
         previous_end = None
         for reply, sleep in zip(replies, sleeps):
             start = datetime.fromisoformat(reply["metadata"]["started"])
-            end = reply["header"]["date"]
-            if isinstance(end, str):
-                end = datetime.fromisoformat(end)
+            end = reply["header"]["date"]  # Already a datetime
 
             if previous_end is not None:
                 assert start > previous_end


### PR DESCRIPTION
Currently when the control channel receives a message on the control stream, it puts it in a `tornado.queues.Queue`, and messages are popped off the queue one a time to be handled using `process_control`. I don't think the queue is necessary as the ZMQ socket/stream queues messages itself.

This PR removes the control queue, simplifying the code. The functions `_flush_control_queue` and `poll_control_queue` are removed as there is no queue to flush or poll. I assume the latter is considered public by its naming convention, but I don't know if any downstream libraries will be relying on its existence.

There are other queues used for the control channel and debugger that I have not looked at yet.

I have ensured that only one control message is handled at a time, to preserve the current behaviour. This uses a boolean flag in `dispatch_control`. This is a little strange as the use of `ZMQStream.on_recv` allows us to concurrently handle multiple control messages that we then have to suppress. There is future work to be done here to perhaps use the ZMQ socket rather than the stream, and jupyter-server/jupyter_server#1362 and jupyter/jupyter_client#997 are relevant.