### PR TITLE
Eventloop scheduling improvements for stop_on_error_timeout and schedule_next

### DIFF
--- a/ipykernel/eventloops.py
+++ b/ipykernel/eventloops.py
@@ -118,11 +118,7 @@ def _notify_stream_qt(kernel):
     # so we start in a clean state ensuring that any new i/o events will notify.
     # schedule first call on the eventloop as soon as it's running,
     # so we don't block here processing events
-    if not hasattr(kernel, "_qt_timer"):
-        kernel._qt_timer = QtCore.QTimer(kernel.app)
-        kernel._qt_timer.setSingleShot(True)
-        kernel._qt_timer.timeout.connect(process_stream_events)
-    kernel._qt_timer.start(0)
+    QtCore.QTimer.singleShot(0, process_stream_events)
 
 
 @register_integration("qt", "qt5", "qt6")

--- a/ipykernel/eventloops.py
+++ b/ipykernel/eventloops.py
@@ -587,6 +587,10 @@ def enable_gui(gui, kernel=None):
         # User wants to turn off integration; clear any evidence if Qt was the last one.
         if hasattr(kernel, "app"):
             delattr(kernel, "app")
+        if hasattr(kernel, "_qt_notifier"):
+            delattr(kernel, "_qt_notifier")
+        if hasattr(kernel, "_qt_timer"):
+            delattr(kernel, "_qt_timer")
     else:
         if gui.startswith("qt"):
             # Prepare the kernel here so any exceptions are displayed in the client.

--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -1211,7 +1211,7 @@ class Kernel(SingletonConfigurable):
             # after stop_on_error_timeout, returning to the main io_loop and letting
             # the call_later fire.
             if self.eventloop is not None and hasattr(self.eventloop, "_schedule_exit"):
-                self.eventloop._schedule_exit(self.stop_on_error_timeout)
+                self.eventloop._schedule_exit(self.stop_on_error_timeout + 0.01)
         else:
             schedule_stop_aborting()
 


### PR DESCRIPTION
Fixes #1202 by introducing a timed exit to the Tk (on Linux) and Qt (on Windows and Linux) eventloops so `schedule_stop_aborting` can fire after `stop_on_error_timeout` in the kernel's main `io_loop`.

This only affects the eventloops specified, as the others periodically hand control back to the kernel, but Tk (on Linux) and Qt normally wait for a ZMQ socket event to go back to the kernel. The `stop_on_error_timeout` does not fire a socket event, so the timer does not expire and future events are aborted when they should not.

The proposed solution introduces an optional `_schedule_exit` method to eventloops that need it, and makes sure it is called if an eventloop exit is needed for the `stop_on_error_timeout` to fire.