### PR TITLE
Fix side effect import for pickleutil

### DIFF
--- a/ipykernel/pickleutil.py
+++ b/ipykernel/pickleutil.py
@@ -10,7 +10,10 @@ import warnings
 from types import FunctionType
 
 # This registers a hook when it's imported
-from ipyparallel.serialize import codeutil  # noqa: F401
+try:
+    from ipyparallel.serialize import codeutil  # noqa: F401
+except ImportError:
+    pass
 from traitlets.log import get_logger
 from traitlets.utils.importstring import import_item
 

--- a/ipykernel/pickleutil.py
+++ b/ipykernel/pickleutil.py
@@ -10,6 +10,7 @@ import warnings
 from types import FunctionType
 
 # This registers a hook when it's imported
+from ipyparallel.serialize import codeutil  # noqa: F401
 from traitlets.log import get_logger
 from traitlets.utils.importstring import import_item
 


### PR DESCRIPTION
The module is deprecated, but we should still keep it working on Windows.