### PR TITLE
Correctly handle with_cell_id in async do_execute

### DIFF
--- a/ipykernel/ipkernel.py
+++ b/ipykernel/ipkernel.py
@@ -382,7 +382,7 @@ class IPythonKernel(KernelBase):
                 store_history=store_history,
                 silent=silent,
             )
-            if with_cell_id:
+            if with_cell_id and with_cell_id["cell_id"]:
                 kwargs.update(cell_id=cell_id)
 
             if should_run_async(


### PR DESCRIPTION
This fixes the minimum dependency tests following the switch to AnyIO (#1079).

In `IPythonKernel.do_execute` we determine if `cell_id` is supported using
```python
with_cell_id = _accepts_parameters(run_cell, ["cell_id"])
```
or similar. This returns a dict, either `{"cell_id", True}` or `{"cell_id", False}`.

But when testing this we use
```python
if with_cell_id:
```
which gives the correct answer if `cell_id` is supported but the wrong one otherwise. It needs to be
```python
if with_cell_id and with_cell_id["cell_id"]:
```
instead, which is all this PR does.

It happened to work for IPython >= 8.3.0 because of ipython/ipython#13600 so that `cell_id` is always accepted, but failed for IPython <= 8.2.0.