### PR TITLE
Fix use of "%matplotlib osx"

### DIFF
--- a/ipykernel/_eventloop_macos.py
+++ b/ipykernel/_eventloop_macos.py
@@ -17,7 +17,6 @@ void_p = ctypes.c_void_p
 objc.objc_getClass.restype = void_p
 objc.sel_registerName.restype = void_p
 objc.objc_msgSend.restype = void_p
-objc.objc_msgSend.argtypes = [void_p, void_p]
 
 msg = objc.objc_msgSend
 
@@ -80,11 +79,25 @@ kCFRunLoopCommonModes = void_p.in_dll(CoreFoundation, "kCFRunLoopCommonModes")
 
 def _NSApp():
     """Return the global NSApplication instance (NSApp)"""
+    objc.objc_msgSend.argtypes = [void_p, void_p]
     return msg(C("NSApplication"), n("sharedApplication"))
 
 
 def _wake(NSApp):
     """Wake the Application"""
+    objc.objc_msgSend.argtypes = [
+        void_p,
+        void_p,
+        void_p,
+        void_p,
+        void_p,
+        void_p,
+        void_p,
+        void_p,
+        void_p,
+        void_p,
+        void_p,
+    ]
     event = msg(
         C("NSEvent"),
         n(
@@ -101,6 +114,7 @@ def _wake(NSApp):
         0,  # data1
         0,  # data2
     )
+    objc.objc_msgSend.argtypes = [void_p, void_p, void_p, void_p]
     msg(NSApp, n("postEvent:atStart:"), void_p(event), True)
 
 
@@ -113,7 +127,9 @@ def stop(timer=None, loop=None):
     NSApp = _NSApp()
     # if NSApp is not running, stop CFRunLoop directly,
     # otherwise stop and wake NSApp
+    objc.objc_msgSend.argtypes = [void_p, void_p]
     if msg(NSApp, n("isRunning")):
+        objc.objc_msgSend.argtypes = [void_p, void_p, void_p]
         msg(NSApp, n("stop:"), NSApp)
         _wake(NSApp)
     else:
@@ -148,6 +164,7 @@ def mainloop(duration=1):
     _triggered.clear()
     NSApp = _NSApp()
     _stop_after(duration)
+    objc.objc_msgSend.argtypes = [void_p, void_p]
     msg(NSApp, n("run"))
     if not _triggered.is_set():
         # app closed without firing callback,


### PR DESCRIPTION
Fixes #1124 which is that the use of `%matplotlib osx` crashes `ipykernel` and downstream libraries whereas `ipython` is fine.

The fix is to specify the `argtypes` of each `objc_msgSend` call just before the call. This is consistent with how `ipython` successfully handles it. I have tested this manually using `spyder` and `jupyter console`, `qtconsole`, `lab` and `nbclassic`: using `ipykernel 6.29.4` (the latest release) they all crash, using this branch they all work as expected.

This PR is opened against the `6.x` branch rather than `main` as issue #1235 means it is not possible to test any `matplotlib` GUI loops on `main`. It would be good to get this into a release (6.29.5?) as soon as possible and not have to wait for #1235 and the other AnyIO fallout issues to be fixed beforehand. This PR will therefore need to be forward ported to `main`.

There is no explicit test for this as you need to actually render a macos window to trigger the failure, and this is not an easy thing to do on headless CI. Essentially this functionality sits in the grey area between `matplotlib` and `ipython/ipykernel/jupyter` rather than in any individual project.