### PR TITLE
Try pinning anyio <= 4.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "pyzmq>=25.0",
     "psutil>=5.7",
     "packaging>=22",
-    "anyio>=4.0.0",
+    "anyio>=4.0.0,<=4.3.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
I am seeing test failures locally using `anyio 4.4.0` whereas with `4.3.0` there are none. Here trying out pinning `anyio` to see how that affects CI.