### PR TITLE
Remove bad pipe message log

### DIFF
--- a/ipykernel/iostream.py
+++ b/ipykernel/iostream.py
@@ -215,7 +215,7 @@ class IOPubThread:
         if not self._pipe_flag or not self._is_master_process():
             return
         if msg[0] != self._pipe_uuid:
-            print("Bad pipe message: %s", msg, file=sys.__stderr__)
+            # print("Bad pipe message: %s", msg, file=sys.__stderr__)
             return
         self.send_multipart(msg[1:])
 


### PR DESCRIPTION
This PR is aimed to remove a log when IOPubThread received a mismatch uuid message.

These mismatch messages appear to originate from some firewall and network related components. Jupyter users don't seem to need this information, however it is displayed on the UX.

I search ["Bad pipe message"](https://github.com/search?q=%22Bad+pipe+message%22&type=code) in whole github repos and there are many ipynb files contains this error.

Some similar issue:
https://github.com/spyder-ide/spyder/issues/20591
https://github.com/ipython/ipykernel/issues/1107