### PR TITLE
Explicitly close memory object streams

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,6 +63,12 @@ class TestSession(Session):
             send_stream, receive_stream = create_memory_object_stream(max_buffer_size=inf)
             self._streams[socket] = {"send": send_stream, "receive": receive_stream}
 
+    def close(self):
+        for streams in self._streams.values():
+            for stream in streams.values():
+                stream.close()
+        self._streams.clear()
+
     def send(self, socket, *args, **kwargs):
         msg = super().send(socket, *args, **kwargs)
         send_stream: MemoryObjectSendStream[Any] = self._streams[socket]["send"]
@@ -102,6 +108,7 @@ class KernelMixin:
 
     def destroy(self):
         self.stop()
+        self.session.close()
         for socket in self.test_sockets:
             socket.close()
         self.context.destroy()


### PR DESCRIPTION
Fixes #1252.

When using anyio `MemoryObjectReceiveStream` and `MemoryObjectSendStream` we must explicitly close them when we have finished with them. This wasn't necessary with anyio 4.3.0 but is with 4.4.0 as otherwise warnings/errors are issued which break our CI.

This is only actually an issue in CI as our only explicit use of memory object streams is in `TestSession`.