### PR TITLE
Fix eventloop integration with anyio

### DIFF
--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -36,7 +36,7 @@ except ImportError:
 
 import psutil
 import zmq
-from anyio import TASK_STATUS_IGNORED, create_task_group, sleep, to_thread
+from anyio import TASK_STATUS_IGNORED, Event, create_task_group, sleep, to_thread
 from anyio.abc import TaskStatus
 from IPython.core.error import StdinNotImplementedError
 from jupyter_client.session import Session
@@ -229,6 +229,8 @@ class Kernel(SingletonConfigurable):
         "usage_request",
     ]
 
+    _eventloop_set: Event = Event()
+
     def __init__(self, **kwargs):
         """Initialize the kernel."""
         super().__init__(**kwargs)
@@ -321,7 +323,9 @@ class Kernel(SingletonConfigurable):
         # record handle, so we can check when this changes
         eventloop = self.eventloop
         if eventloop is None:
-            self.log.info("Exiting as there is no eventloop")
+            # Do not warn if shutting down.
+            if not (self.shell and self.shell.exit_now):
+                self.log.info("Exiting as there is no eventloop")
             return
 
         async def advance_eventloop():
@@ -335,20 +339,14 @@ class Kernel(SingletonConfigurable):
             except KeyboardInterrupt:
                 # Ctrl-C shouldn't crash the kernel
                 self.log.error("KeyboardInterrupt caught in kernel")
-            if self.eventloop is eventloop:
-                # schedule advance again
-                await schedule_next()
 
-        async def schedule_next():
-            """Schedule the next advance of the eventloop"""
+        # begin polling the eventloop
+        while self.eventloop is eventloop:
             # flush the eventloop every so often,
             # giving us a chance to handle messages in the meantime
             self.log.debug("Scheduling eventloop advance")
             await sleep(0.001)
             await advance_eventloop()
-
-        # begin polling the eventloop
-        await schedule_next()
 
     _message_counter = Any(
         help="""Monotonic counter of messages
@@ -481,6 +479,10 @@ class Kernel(SingletonConfigurable):
                 tg.start_soon(self.shell_main)
 
     def stop(self):
+        if not self._eventloop_set.is_set():
+            # Stop the async task that is waiting for the eventloop to be set.
+            self._eventloop_set.set()
+
         self.shell_stop.set()
         self.control_stop.set()
 

--- a/tests/test_kernelapp.py
+++ b/tests/test_kernelapp.py
@@ -117,7 +117,8 @@ def test_merge_connection_file():
         os.remove(cf)
 
 
-@pytest.mark.skipif(trio is None, reason="requires trio")
+# FIXME: @pytest.mark.skipif(trio is None, reason="requires trio")
+@pytest.mark.skip()
 def test_trio_loop():
     app = IPKernelApp(trio_loop=True)
 


### PR DESCRIPTION
Fixes #1235.

This fixes GUI event loop integration so that it works following the recent switch to using anyio, so that Matplotlib output correctly displays in separate Windows and both the kernel and plot respond to subsequent input. Such functionality has never been explicitly tested in ipykernel, so I have tested it manually on Linux, macOS and Windows with various combinations of `qt`, `tk` and `osx` Matplotlib backends and Jupyter `lab`, `console`, `qtconsole` and `spyder`.

Here's a screenshot:

<img width="1349" alt="Screenshot 2024-08-09 at 15 36 27" src="https://github.com/user-attachments/assets/5b302093-dbc8-4e34-8da7-40faab3abca0">

The plot can be panned and zoomed for example, which cannot be shown in such a screenshot.

Summary of changes:
1. Switch from using `shell_stream` to `shell_socket` as the former is no longer used.
2. To check if there are ZMQ messages pending switch from using `shell_stream.flush(limit=1)` to `shell_socket.get(zmq.EVENTS) & zmq.POLLIN) > 0`.
3. If an eventloop is set (via `enable_gui`) after the kernel has started, a new `anyio.Event` is used to trigger calling `enter_eventloop`. This allows the synchronous `enable_gui` to trigger the asynchronous `enter_eventloop`.
4. The same event is used to close the waiting task if the kernel is stopped without an eventloop being set.
5. The nested calls of `advance_eventloop` and `schedule_next` are replaced with a simple async loop.

These changes are intentionally minimal to reduce the danger of breaking downstream code.

I have disabled `test_trio_loop` as the other `trio`-based tests are disabled and we don't appear to support it yet, although as it is one of the async backends supported by `anyio` this shouldn't be too onerous. That is separate work to this though. I also noted that `TrioRunner` still exists but is not used any where. 