### PR TITLE
Remove direct use of asyncio

### DIFF
--- a/ipykernel/iostream.py
+++ b/ipykernel/iostream.py
@@ -3,7 +3,6 @@
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-import asyncio
 import atexit
 import contextvars
 import io
@@ -99,7 +98,6 @@ class IOPubThread:
         self._event_pipes: Dict[threading.Thread, Any] = {}
         self._event_pipe_gc_lock: threading.Lock = threading.Lock()
         self._event_pipe_gc_seconds: float = 10
-        self._event_pipe_gc_task: Optional[asyncio.Task[Any]] = None
         self._setup_event_pipe()
         tasks = [self._handle_event, self._run_event_pipe_gc]
         if pipe:

--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -4,7 +4,6 @@
 # Distributed under the terms of the Modified BSD License.
 from __future__ import annotations
 
-import asyncio
 import inspect
 import itertools
 import logging
@@ -1258,7 +1257,7 @@ class Kernel(SingletonConfigurable):
                     delay,
                     children,
                 )
-                await asyncio.sleep(delay)
+                await sleep(delay)
 
     async def _at_shutdown(self):
         """Actions taken at shutdown by the kernel, called by python's atexit."""


### PR DESCRIPTION
There are still direct references to `asyncio`:
- in [eventloops.py](https://github.com/ipython/ipykernel/blob/main/ipykernel/eventloops.py),
- in [kernelapp.py](https://github.com/ipython/ipykernel/blob/main/ipykernel/kernelapp.py),
- in [pyzmq](https://github.com/zeromq/pyzmq/issues/1827).