### PR TITLE
Run Mypy by default.

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -56,6 +56,7 @@ jobs:
 
   ipyparallel:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,13 +44,19 @@ repos:
     hooks:
       - id: mypy
         files: ipykernel
-        args: ["--install-types", "--non-interactive"]
+        args: []
         additional_dependencies:
           [
             "traitlets>=5.13",
             "ipython>=8.16.1",
             "jupyter_client>=8.5",
             "appnope",
+            "types-Pygments",
+            "types-colorama",
+            "types-decorator",
+            "types-psutil",
+            "types-pycurl",
+            "types-python-dateutil",
           ]
 
   - repo: https://github.com/adamchainz/blacken-docs

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,11 +40,10 @@ repos:
         types_or: [yaml, html, json]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: "v1.8.0"
+    rev: "v1.11.0"
     hooks:
       - id: mypy
         files: ipykernel
-        stages: [manual]
         args: ["--install-types", "--non-interactive"]
         additional_dependencies:
           [

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,6 +57,16 @@ repos:
             "types-psutil",
             "types-pycurl",
             "types-python-dateutil",
+            "PyQt5",
+            "anyio",
+            "cloudpickle",
+            "comm",
+            "debugpy",
+            "dill",
+            "nest_asyncio",
+            "numpy",
+            "packaging",
+            "trio",
           ]
 
   - repo: https://github.com/adamchainz/blacken-docs

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,7 +40,7 @@ repos:
         types_or: [yaml, html, json]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: "v1.11.0"
+    rev: "v1.12.0"
     hooks:
       - id: mypy
         files: ipykernel

--- a/ipykernel/comm/comm.py
+++ b/ipykernel/comm/comm.py
@@ -9,7 +9,7 @@ from warnings import warn
 
 import comm.base_comm
 import traitlets.config
-from traitlets import Bool, Bytes, Instance, Unicode, default
+from traitlets import Bool, Instance, Unicode, default
 
 from ipykernel.jsonutil import json_clean
 from ipykernel.kernelbase import Kernel
@@ -50,18 +50,18 @@ class Comm(BaseComm, traitlets.config.LoggingConfigurable):
     """Class for communicating between a Frontend and a Kernel"""
 
     kernel = Instance("ipykernel.kernelbase.Kernel", allow_none=True)  # type:ignore[assignment]
-    comm_id = Unicode()
-    primary = Bool(True, help="Am I the primary or secondary Comm?")
+    comm_id = Unicode()  # type: ignore[assignment]
+    primary = Bool(True, help="Am I the primary or secondary Comm?")  # type: ignore[assignment]
 
-    target_name = Unicode("comm")
-    target_module = Unicode(
+    target_name = Unicode("comm")  # type: ignore[assignment]
+    target_module = Unicode(  # type: ignore[assignment]
         None,
         allow_none=True,
         help="""requirejs module from
         which to load comm target.""",
     )
 
-    topic = Bytes()
+    topic: bytes
 
     @default("kernel")
     def _default_kernel(self):

--- a/ipykernel/comm/comm.py
+++ b/ipykernel/comm/comm.py
@@ -16,7 +16,7 @@ from ipykernel.kernelbase import Kernel
 
 
 # this is the class that will be created if we do comm.create_comm
-class BaseComm(comm.base_comm.BaseComm):  # type:ignore[misc]
+class BaseComm(comm.base_comm.BaseComm):
     """The base class for comms."""
 
     kernel: Optional["Kernel"] = None
@@ -90,7 +90,7 @@ class Comm(BaseComm, traitlets.config.LoggingConfigurable):
         kernel = kwargs.pop("kernel", None)
         if target_name:
             kwargs["target_name"] = target_name
-        BaseComm.__init__(self, data=data, metadata=metadata, buffers=buffers, **kwargs)  # type:ignore[call-arg]
+        BaseComm.__init__(self, data=data, metadata=metadata, buffers=buffers, **kwargs)
         # only re-add kernel if explicitly provided
         if had_kernel:
             kwargs["kernel"] = kernel

--- a/ipykernel/comm/manager.py
+++ b/ipykernel/comm/manager.py
@@ -14,7 +14,7 @@ from .comm import Comm
 logger = logging.getLogger("ipykernel.comm")
 
 
-class CommManager(comm.base_comm.CommManager, traitlets.config.LoggingConfigurable):  # type:ignore[misc]
+class CommManager(comm.base_comm.CommManager, traitlets.config.LoggingConfigurable):
     """A comm manager."""
 
     kernel = traitlets.Instance("ipykernel.kernelbase.Kernel")

--- a/ipykernel/comm/manager.py
+++ b/ipykernel/comm/manager.py
@@ -8,6 +8,7 @@ import logging
 import comm.base_comm
 import traitlets
 import traitlets.config
+from typing import Dict, Any
 
 from .comm import Comm
 
@@ -18,8 +19,8 @@ class CommManager(comm.base_comm.CommManager, traitlets.config.LoggingConfigurab
     """A comm manager."""
 
     kernel = traitlets.Instance("ipykernel.kernelbase.Kernel")
-    comms = traitlets.Dict()
-    targets = traitlets.Dict()
+    comms: Dict[Any, Any]
+    targets: Dict[str, Any]
 
     def __init__(self, **kwargs):
         """Initialize the manager."""
@@ -33,7 +34,7 @@ class CommManager(comm.base_comm.CommManager, traitlets.config.LoggingConfigurab
         # but we should let the base class create the comm with comm.create_comm in a major release
         content = msg["content"]
         comm_id = content["comm_id"]
-        target_name = content["target_name"]
+        target_name: str = content["target_name"]
         f = self.targets.get(target_name, None)
         comm = Comm(
             comm_id=comm_id,

--- a/ipykernel/datapub.py
+++ b/ipykernel/datapub.py
@@ -13,7 +13,7 @@ from ipykernel.jsonutil import json_clean
 
 try:
     # available since ipyparallel 5.0.0
-    from ipyparallel.serialize import serialize_object
+    from ipyparallel.serialize import serialize_object  # type: ignore[import-not-found]
 except ImportError:
     # Deprecated since ipykernel 4.3.0
     from ipykernel.serialize import serialize_object

--- a/ipykernel/debugger.py
+++ b/ipykernel/debugger.py
@@ -21,7 +21,7 @@ from .compiler import get_file_name, get_tmp_directory, get_tmp_hash_seed
 
 try:
     # This import is required to have the next ones working...
-    from debugpy.server import api  # noqa: F401
+    from debugpy.server import api  # type: ignore[import-untyped]# noqa: F401
 
     from _pydevd_bundle import (  # type:ignore[import-not-found]
         pydevd_frame_utils,
@@ -119,9 +119,10 @@ class DebugpyMessageQueue:
         self.tcp_buffer = ""
         self._reset_tcp_pos()
         self.event_callback = event_callback
-        self.message_send_stream, self.message_receive_stream = create_memory_object_stream[dict](
-            max_buffer_size=inf
-        )
+        (
+            self.message_send_stream,
+            self.message_receive_stream,
+        ) = create_memory_object_stream[dict[t.Any, t.Any]](max_buffer_size=inf)
         self.log = log
 
     def _reset_tcp_pos(self):
@@ -344,9 +345,10 @@ class Debugger:
         self.is_started = False
         self.event_callback = event_callback
         self.just_my_code = just_my_code
-        self.stopped_send_stream, self.stopped_receive_stream = create_memory_object_stream[dict](
-            max_buffer_size=inf
-        )
+        (
+            self.stopped_send_stream,
+            self.stopped_receive_stream,
+        ) = create_memory_object_stream[dict[t.Any, t.Any]](max_buffer_size=inf)
 
         self.started_debug_handlers = {}
         for msg_type in Debugger.started_debug_msg_types:

--- a/ipykernel/debugger.py
+++ b/ipykernel/debugger.py
@@ -23,8 +23,10 @@ try:
     # This import is required to have the next ones working...
     from debugpy.server import api  # noqa: F401
 
-    from _pydevd_bundle import pydevd_frame_utils  # isort: skip
-    from _pydevd_bundle.pydevd_suspended_frames import (  # isort: skip
+    from _pydevd_bundle import (  # type:ignore[import-not-found]
+        pydevd_frame_utils,
+    )  #  isort: skip
+    from _pydevd_bundle.pydevd_suspended_frames import (  # type:ignore[import-not-found] # isort: skip
         SuspendedFramesManager,
         _FramesTracker,
     )
@@ -70,7 +72,7 @@ class _DummyPyDB:
 
     def __init__(self):
         """Init."""
-        from _pydevd_bundle.pydevd_api import PyDevdAPI
+        from _pydevd_bundle.pydevd_api import PyDevdAPI  # type: ignore[import-not-found]
 
         self.variable_presentation = PyDevdAPI.VariablePresentation()
 

--- a/ipykernel/eventloops.py
+++ b/ipykernel/eventloops.py
@@ -279,7 +279,7 @@ def loop_tk(kernel):
     else:
         import asyncio
 
-        import nest_asyncio
+        import nest_asyncio  # type: ignore [import-untyped]
 
         nest_asyncio.apply()
 

--- a/ipykernel/eventloops.py
+++ b/ipykernel/eventloops.py
@@ -172,7 +172,7 @@ def _loop_wx(app):
 def loop_wx(kernel):
     """Start a kernel with wx event loop support."""
 
-    import wx
+    import wx  # type: ignore[import-not-found]
 
     # Wx uses milliseconds
     poll_interval = int(1000 * kernel._poll_interval)
@@ -515,19 +515,19 @@ def set_qt_api_env_from_gui(gui):
                 os.environ["QT_API"] = "pyqt5"
             except ImportError:
                 try:
-                    import PySide2  # noqa: F401
+                    import PySide2  # type: ignore[import-not-found] #noqa: F401
 
                     os.environ["QT_API"] = "pyside2"
                 except ImportError:
                     os.environ["QT_API"] = "pyqt5"
         elif gui == "qt6":
             try:
-                import PyQt6  # noqa: F401
+                import PyQt6  #  type: ignore[import-not-found] #noqa: F401
 
                 os.environ["QT_API"] = "pyqt6"
             except ImportError:
                 try:
-                    import PySide6  # noqa: F401
+                    import PySide6  #  type: ignore[import-not-found] # noqa: F401
 
                     os.environ["QT_API"] = "pyside6"
                 except ImportError:

--- a/ipykernel/gui/gtk3embed.py
+++ b/ipykernel/gui/gtk3embed.py
@@ -15,11 +15,11 @@ import sys
 import warnings
 
 # Third-party
-import gi
+import gi  # type: ignore[import-not-found]
 
 gi.require_version("Gdk", "3.0")
 gi.require_version("Gtk", "3.0")
-from gi.repository import GObject, Gtk  # noqa: E402
+from gi.repository import GObject, Gtk  # type: ignore[import-not-found] # noqa: E402
 
 warnings.warn(
     "The Gtk3 event loop for ipykernel is deprecated", category=DeprecationWarning, stacklevel=2

--- a/ipykernel/gui/gtkembed.py
+++ b/ipykernel/gui/gtkembed.py
@@ -15,8 +15,8 @@ import sys
 import warnings
 
 # Third-party
-import gobject
-import gtk
+import gobject  # type: ignore[import-not-found]
+import gtk  # type: ignore[import-not-found]
 
 warnings.warn(
     "The Gtk3 event loop for ipykernel is deprecated", category=DeprecationWarning, stacklevel=2

--- a/ipykernel/inprocess/blocking.py
+++ b/ipykernel/inprocess/blocking.py
@@ -68,6 +68,7 @@ class BlockingInProcessStdInChannel(BlockingInProcessChannel):
             _raw_input = self.client.kernel._sys_raw_input
             prompt = msg["content"]["prompt"]
             print(prompt, end="", file=sys.__stdout__)
+            assert sys.__stdout__ is not None
             sys.__stdout__.flush()
             self.client.input(_raw_input())
 

--- a/ipykernel/inprocess/client.py
+++ b/ipykernel/inprocess/client.py
@@ -55,7 +55,7 @@ class InProcessKernelClient(KernelClient):
 
         return BlockingInProcessKernelClient
 
-    def get_connection_info(self):
+    def get_connection_info(self):  # type:ignore [override]
         """Get the connection info for the client."""
         d = super().get_connection_info()
         d["kernel"] = self.kernel  # type:ignore[assignment]
@@ -100,13 +100,14 @@ class InProcessKernelClient(KernelClient):
     # Methods for sending specific messages
     # -------------------------------------
 
-    async def execute(
+    async def execute(  # type:ignore[override]
         self,
-        code,
-        silent=False,
-        store_history=True,
+        code: str,
+        silent: bool = False,
+        store_history: bool = True,
         user_expressions=None,
         allow_stdin=None,
+        stop_on_error: bool = True,
     ):
         """Execute code on the client."""
         if allow_stdin is None:

--- a/ipykernel/inprocess/client.py
+++ b/ipykernel/inprocess/client.py
@@ -55,7 +55,7 @@ class InProcessKernelClient(KernelClient):
 
         return BlockingInProcessKernelClient
 
-    def get_connection_info(self):  # type: ignore[override]
+    def get_connection_info(self):
         """Get the connection info for the client."""
         d = super().get_connection_info()
         d["kernel"] = self.kernel  # type:ignore[assignment]
@@ -100,7 +100,7 @@ class InProcessKernelClient(KernelClient):
     # Methods for sending specific messages
     # -------------------------------------
 
-    async def execute(  # type: ignore[override]
+    async def execute(
         self,
         code,
         silent=False,

--- a/ipykernel/inprocess/client.py
+++ b/ipykernel/inprocess/client.py
@@ -55,7 +55,7 @@ class InProcessKernelClient(KernelClient):
 
         return BlockingInProcessKernelClient
 
-    def get_connection_info(self):
+    def get_connection_info(self):  # type: ignore[override]
         """Get the connection info for the client."""
         d = super().get_connection_info()
         d["kernel"] = self.kernel  # type:ignore[assignment]
@@ -100,8 +100,13 @@ class InProcessKernelClient(KernelClient):
     # Methods for sending specific messages
     # -------------------------------------
 
-    async def execute(
-        self, code, silent=False, store_history=True, user_expressions=None, allow_stdin=None
+    async def execute(  # type: ignore[override]
+        self,
+        code,
+        silent=False,
+        store_history=True,
+        user_expressions=None,
+        allow_stdin=None,
     ):
         """Execute code on the client."""
         if allow_stdin is None:

--- a/ipykernel/inprocess/ipkernel.py
+++ b/ipykernel/inprocess/ipkernel.py
@@ -82,7 +82,9 @@ class InProcessKernel(IPythonKernel):
         with self._redirected_io():
             await super().execute_request(stream, ident, parent)
 
-    async def start(self, *, task_status: TaskStatus = TASK_STATUS_IGNORED) -> None:
+    async def start(
+        self, *, task_status: TaskStatus[None] = TASK_STATUS_IGNORED
+    ) -> None:
         """Override registration of dispatchers for streams."""
         if self.shell:
             self.shell.exit_now = False

--- a/ipykernel/inprocess/manager.py
+++ b/ipykernel/inprocess/manager.py
@@ -46,7 +46,7 @@ class InProcessKernelManager(KernelManager):
     # --------------------------------------------------------------------------
 
     async def start_kernel(  # type: ignore[explicit-override, override]
-        self, *, task_status: TaskStatus = TASK_STATUS_IGNORED, **kwds: Any
+        self, *, task_status: TaskStatus[None] = TASK_STATUS_IGNORED, **kwds: Any
     ) -> None:
         """Start the kernel."""
         from ipykernel.inprocess.ipkernel import InProcessKernel
@@ -65,7 +65,7 @@ class InProcessKernelManager(KernelManager):
         now: bool = False,
         newports: bool = False,
         *,
-        task_status: TaskStatus = TASK_STATUS_IGNORED,
+        task_status: TaskStatus[None] = TASK_STATUS_IGNORED,
         **kw: Any,
     ) -> None:
         """Restart the kernel."""

--- a/ipykernel/inprocess/session.py
+++ b/ipykernel/inprocess/session.py
@@ -2,7 +2,7 @@ from jupyter_client.session import Session as _Session
 
 
 class Session(_Session):
-    async def recv(self, socket, copy=True):  # type: ignore [override]
+    async def recv(self, socket, copy=True):
         return await socket.recv_multipart()
 
     def send(

--- a/ipykernel/inprocess/session.py
+++ b/ipykernel/inprocess/session.py
@@ -2,7 +2,7 @@ from jupyter_client.session import Session as _Session
 
 
 class Session(_Session):
-    async def recv(self, socket, copy=True):
+    async def recv(self, socket, copy=True):  # type:ignore[override]
         return await socket.recv_multipart()
 
     def send(

--- a/ipykernel/inprocess/session.py
+++ b/ipykernel/inprocess/session.py
@@ -2,7 +2,7 @@ from jupyter_client.session import Session as _Session
 
 
 class Session(_Session):
-    async def recv(self, socket, copy=True):
+    async def recv(self, socket, copy=True):  # type: ignore [override]
         return await socket.recv_multipart()
 
     def send(

--- a/ipykernel/inprocess/socket.py
+++ b/ipykernel/inprocess/socket.py
@@ -9,6 +9,7 @@ import zmq
 import zmq.asyncio
 from anyio import create_memory_object_stream
 from traitlets import HasTraits, Instance
+from typing import Any
 
 # -----------------------------------------------------------------------------
 # Dummy socket class
@@ -32,12 +33,12 @@ class DummySocket(HasTraits):
         self.is_shell = is_shell
         self.on_recv = None
         if is_shell:
-            self.in_send_stream, self.in_receive_stream = create_memory_object_stream[dict](
-                max_buffer_size=inf
-            )
-            self.out_send_stream, self.out_receive_stream = create_memory_object_stream[dict](
-                max_buffer_size=inf
-            )
+            self.in_send_stream, self.in_receive_stream = create_memory_object_stream[
+                dict[Any, Any]
+            ](max_buffer_size=inf)
+            self.out_send_stream, self.out_receive_stream = create_memory_object_stream[
+                dict[Any, Any]
+            ](max_buffer_size=inf)
 
     def put(self, msg):
         self.in_send_stream.send_nowait(msg)

--- a/ipykernel/ipkernel.py
+++ b/ipykernel/ipkernel.py
@@ -246,7 +246,9 @@ class IPythonKernel(KernelBase):
         while True:
             await self.debugger.handle_stopped_event()
 
-    async def start(self, *, task_status: TaskStatus = TASK_STATUS_IGNORED) -> None:
+    async def start(
+        self, *, task_status: TaskStatus[None] = TASK_STATUS_IGNORED
+    ) -> None:
         """Start the kernel."""
         if self.shell:
             self.shell.exit_now = False

--- a/ipykernel/ipkernel.py
+++ b/ipykernel/ipkernel.py
@@ -641,7 +641,7 @@ class IPythonKernel(KernelBase):
     def do_apply(self, content, bufs, msg_id, reply_metadata):
         """Handle an apply request."""
         try:
-            from ipyparallel.serialize import serialize_object, unpack_apply_message
+            from ipyparallel.serialize import serialize_object, unpack_apply_message  # type: ignore[import-not-found]
         except ImportError:
             from .serialize import serialize_object, unpack_apply_message
 

--- a/ipykernel/kernelapp.py
+++ b/ipykernel/kernelapp.py
@@ -261,7 +261,7 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp, ConnectionFileMix
                     raise
         return None
 
-    def write_connection_file(self):
+    def write_connection_file(self):  # type:ignore[override]
         """write connection info to JSON file"""
         cf = self.abs_connection_file
         connection_info = dict(

--- a/ipykernel/kernelapp.py
+++ b/ipykernel/kernelapp.py
@@ -261,7 +261,7 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp, ConnectionFileMix
                     raise
         return None
 
-    def write_connection_file(self):  # type: ignore[override]
+    def write_connection_file(self):
         """write connection info to JSON file"""
         cf = self.abs_connection_file
         connection_info = dict(

--- a/ipykernel/kernelapp.py
+++ b/ipykernel/kernelapp.py
@@ -261,7 +261,7 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp, ConnectionFileMix
                     raise
         return None
 
-    def write_connection_file(self):
+    def write_connection_file(self):  # type: ignore[override]
         """write connection info to JSON file"""
         cf = self.abs_connection_file
         connection_info = dict(

--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -233,6 +233,14 @@ class Kernel(SingletonConfigurable):
     ]
 
     _eventloop_set: Event = Event()
+    control_handlers: Dict[
+        str,
+        t.Callable[[zmq.asyncio.Socket, list[bytes], str], t.Awaitable[t.Any]]
+        |
+        # I think this one should be deprecated, and we should check the handlers are
+        # coroutine functions.
+        t.Callable[[zmq.asyncio.Socket, list[bytes], str], t.Any],
+    ]
 
     def __init__(self, **kwargs):
         """Initialize the kernel."""

--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -539,7 +539,9 @@ class Kernel(SingletonConfigurable):
     def post_handler_hook(self):
         """Hook to execute after calling message handler"""
 
-    async def start(self, *, task_status: TaskStatus = TASK_STATUS_IGNORED) -> None:
+    async def start(
+        self, *, task_status: TaskStatus[None] = TASK_STATUS_IGNORED
+    ) -> None:
         """Process messages on shell and control channels"""
         async with create_task_group() as tg:
             self.control_stop = threading.Event()

--- a/ipykernel/parentpoller.py
+++ b/ipykernel/parentpoller.py
@@ -99,7 +99,7 @@ class ParentPollerWindows(Thread):
         try:
             from _winapi import INFINITE, WAIT_OBJECT_0  # type:ignore[attr-defined]
         except ImportError:
-            from _subprocess import INFINITE, WAIT_OBJECT_0
+            from _subprocess import INFINITE, WAIT_OBJECT_0  # type: ignore[import-not-found]
 
         # Build the list of handle to listen on.
         handles = []

--- a/ipykernel/pickleutil.py
+++ b/ipykernel/pickleutil.py
@@ -76,7 +76,7 @@ def use_dill():
     adds support for object methods and closures to serialization.
     """
     # import dill causes most of the magic
-    import dill
+    import dill  # type: ignore[import-untyped]
 
     # dill doesn't work with cPickle,
     # tell the two relevant modules to use plain pickle
@@ -100,7 +100,7 @@ def use_cloudpickle():
 
     adds support for object methods and closures to serialization.
     """
-    import cloudpickle
+    import cloudpickle  # type: ignore[import-untyped]
 
     global pickle  # noqa: PLW0603
     pickle = cloudpickle

--- a/ipykernel/pickleutil.py
+++ b/ipykernel/pickleutil.py
@@ -11,7 +11,9 @@ from types import FunctionType
 
 # This registers a hook when it's imported
 try:
-    from ipyparallel.serialize import codeutil  # noqa: F401
+    from ipyparallel.serialize import (  #  type: ignore[import-not-found]
+        codeutil,
+    )  # noqa: F401,
 except ImportError:
     pass
 from traitlets.log import get_logger

--- a/ipykernel/serialize.py
+++ b/ipykernel/serialize.py
@@ -9,7 +9,7 @@ from itertools import chain
 
 try:
     # available since ipyparallel 5.0.0
-    from ipyparallel.serialize.canning import (
+    from ipyparallel.serialize.canning import (  # type: ignore[import-not-found]
         CannedObject,
         can,
         can_sequence,
@@ -18,7 +18,7 @@ try:
         uncan,
         uncan_sequence,
     )
-    from ipyparallel.serialize.serialize import PICKLE_PROTOCOL
+    from ipyparallel.serialize.serialize import PICKLE_PROTOCOL  # type: ignore[import-not-found]
 except ImportError:
     # Deprecated since ipykernel 4.3.0
     from ipykernel.pickleutil import (

--- a/ipykernel/trio_runner.py
+++ b/ipykernel/trio_runner.py
@@ -50,7 +50,7 @@ class TrioRunner:
             async with trio.open_nursery() as nursery:
                 # TODO This hack prevents the nursery from cancelling all child
                 # tasks when an uncaught exception occurs, but it's ugly.
-                nursery._add_exc = log_nursery_exc
+                nursery._add_exc = log_nursery_exc  # type: ignore [method-assign]
                 builtins.GLOBAL_NURSERY = nursery  # type:ignore[attr-defined]
                 await trio.sleep_forever()
 

--- a/ipykernel/trio_runner.py
+++ b/ipykernel/trio_runner.py
@@ -65,7 +65,7 @@ class TrioRunner:
             self._cell_cancel_scope = trio.CancelScope()
             with self._cell_cancel_scope:
                 return await coro
-            self._cell_cancel_scope = None  # type:ignore[unreachable]
+            self._cell_cancel_scope = None
             return None
 
         return trio.from_thread.run(loc, async_fn, trio_token=self._trio_token)

--- a/ipykernel/zmqshell.py
+++ b/ipykernel/zmqshell.py
@@ -636,12 +636,12 @@ class ZMQInteractiveShell(InteractiveShell):
             self.data_pub.set_parent(parent)
         try:
             stdout = sys.stdout
-            stdout.set_parent(parent)
+            stdout.set_parent(parent)  # type: ignore[attr-defined]
         except AttributeError:
             pass
         try:
             stderr = sys.stderr
-            stderr.set_parent(parent)
+            stderr.set_parent(parent)  # type: ignore[attr-defined]
         except AttributeError:
             pass
 

--- a/ipykernel/zmqshell.py
+++ b/ipykernel/zmqshell.py
@@ -82,8 +82,11 @@ class ZMQDisplayPublisher(DisplayPublisher):
         self,
         data,
         metadata=None,
+        source=None,
+        *,
         transient=None,
         update=False,
+        **kwargs,
     ):
         """Publish a display-data message
 
@@ -516,7 +519,7 @@ class ZMQInteractiveShell(InteractiveShell):
 
     # Over ZeroMQ, GUI control isn't done with PyOS_InputHook as there is no
     # interactive input being read; we provide event loop support in ipkernel
-    def enable_gui(self, gui):
+    def enable_gui(self, gui):  # type:ignore[override]
         """Enable a given guil."""
         from .eventloops import enable_gui as real_enable_gui
 
@@ -636,12 +639,12 @@ class ZMQInteractiveShell(InteractiveShell):
             self.data_pub.set_parent(parent)
         try:
             stdout = sys.stdout
-            stdout.set_parent(parent)  # type: ignore[attr-defined]
+            stdout.set_parent(parent)  # type: ignore[union-attr]
         except AttributeError:
             pass
         try:
             stderr = sys.stderr
-            stderr.set_parent(parent)  # type: ignore[attr-defined]
+            stderr.set_parent(parent)  # type: ignore[union-attr]
         except AttributeError:
             pass
 

--- a/ipykernel/zmqshell.py
+++ b/ipykernel/zmqshell.py
@@ -78,7 +78,7 @@ class ZMQDisplayPublisher(DisplayPublisher):
             self._thread_local.hooks = []
         return self._thread_local.hooks
 
-    def publish(
+    def publish(  # type:ignore[override]
         self,
         data,
         metadata=None,
@@ -516,7 +516,7 @@ class ZMQInteractiveShell(InteractiveShell):
 
     # Over ZeroMQ, GUI control isn't done with PyOS_InputHook as there is no
     # interactive input being read; we provide event loop support in ipkernel
-    def enable_gui(self, gui):
+    def enable_gui(self, gui):  # type:ignore[override]
         """Enable a given guil."""
         from .eventloops import enable_gui as real_enable_gui
 
@@ -635,11 +635,13 @@ class ZMQInteractiveShell(InteractiveShell):
         if hasattr(self, "_data_pub"):
             self.data_pub.set_parent(parent)
         try:
-            sys.stdout.set_parent(parent)  # type:ignore[attr-defined]
+            stdout = sys.stdout
+            stdout.set_parent(parent)  # type:ignore[union-attr]
         except AttributeError:
             pass
         try:
-            sys.stderr.set_parent(parent)  # type:ignore[attr-defined]
+            stderr = sys.stderr
+            stderr.set_parent(parent)  # type:ignore[union-attr]
         except AttributeError:
             pass
 

--- a/ipykernel/zmqshell.py
+++ b/ipykernel/zmqshell.py
@@ -78,7 +78,7 @@ class ZMQDisplayPublisher(DisplayPublisher):
             self._thread_local.hooks = []
         return self._thread_local.hooks
 
-    def publish(  # type:ignore[override]
+    def publish(
         self,
         data,
         metadata=None,
@@ -402,7 +402,7 @@ class KernelMagics(Magics):
         # %qtconsole should imply bind_kernel for engines:
         # FIXME: move to ipyparallel Kernel subclass
         if "ipyparallel" in sys.modules:
-            from ipyparallel import bind_kernel
+            from ipyparallel import bind_kernel  # type: ignore[import-not-found]
 
             bind_kernel()
 
@@ -516,7 +516,7 @@ class ZMQInteractiveShell(InteractiveShell):
 
     # Over ZeroMQ, GUI control isn't done with PyOS_InputHook as there is no
     # interactive input being read; we provide event loop support in ipkernel
-    def enable_gui(self, gui):  # type:ignore[override]
+    def enable_gui(self, gui):
         """Enable a given guil."""
         from .eventloops import enable_gui as real_enable_gui
 
@@ -636,12 +636,12 @@ class ZMQInteractiveShell(InteractiveShell):
             self.data_pub.set_parent(parent)
         try:
             stdout = sys.stdout
-            stdout.set_parent(parent)  # type:ignore[union-attr]
+            stdout.set_parent(parent)
         except AttributeError:
             pass
         try:
             stderr = sys.stderr
-            stderr.set_parent(parent)  # type:ignore[union-attr]
+            stderr.set_parent(parent)
         except AttributeError:
             pass
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,11 +131,52 @@ build = [
 [tool.mypy]
 files = "ipykernel"
 strict = true
-disable_error_code = ["no-untyped-def", "no-untyped-call", "import-not-found"]
 enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]
-follow_imports = "normal"
-pretty = true
 warn_unreachable = true
+
+[[tool.mypy.overrides]]
+module = [
+    "ipykernel.inprocess.manager",
+    "ipykernel.inprocess.ipkernel",
+    "ipykernel.inprocess.blocking",
+    "ipykernel.inprocess.client",
+    "ipykernel.inprocess.session",
+    "ipykernel.datapub",
+    "ipykernel.embed",
+    "ipykernel.kernelapp",
+    "ipykernel.pickleutil",
+    "ipykernel.ipkernel",
+    "ipykernel.zmqshell",
+    "ipykernel._eventloop_macos",
+    "ipykernel.comm.comm",
+    "ipykernel.comm.manager",
+    "ipykernel.compiler",
+    "ipykernel.connect",
+    "ipykernel.control",
+    "ipykernel.debugger",
+    "ipykernel.displayhook",
+    "ipykernel.eventloops",
+    "ipykernel.gui.gtk3embed",
+    "ipykernel.gui.gtkembed",
+    "ipykernel.heartbeat",
+    "ipykernel.inprocess.channels",
+    "ipykernel.inprocess.socket",
+    "ipykernel.iostream",
+    "ipykernel.jsonutil",
+    "ipykernel.kernelbase",
+    "ipykernel.log",
+    "ipykernel.parentpoller",
+    "ipykernel.serialize",
+    "ipykernel.shellchannel",
+    "ipykernel.subshell",
+    "ipykernel.thread",
+    "ipykernel.trio_runner",
+    ]
+disallow_untyped_defs = false
+disallow_incomplete_defs = false
+check_untyped_defs = true
+disallow_untyped_calls = false
+
 
 [tool.pytest.ini_options]
 minversion = "6.0"


### PR DESCRIPTION
Otherwise the types annotations are less usefull, even with ruff.

Ignore/fix types errors.

Also the mypy config was way to lax, ignoring errors project wide intead of per-file. 
This make it much stricter and only ignore error on each file, so this types of errors are still confined, and it is easy-ish, to make it a bit more stricter progressively