### PR TITLE
Detect parent change in more cases on unix

### DIFF
--- a/ipykernel/kernelapp.py
+++ b/ipykernel/kernelapp.py
@@ -220,7 +220,7 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp, ConnectionFileMix
             # PID 1 (init) is special and will never go away,
             # only be reassigned.
             # Parent polling doesn't work if ppid == 1 to start with.
-            self.poller = ParentPollerUnix()
+            self.poller = ParentPollerUnix(parent_pid=self.parent_handle)
 
     def _try_bind_socket(self, s, port):
         iface = f"{self.transport}://{self.ip}"


### PR DESCRIPTION
New behaviour: poll getppid and exit if this value is no longer equal to the original parent pid.

For backwards compatibility: keep old behaviour when parent_pid is 0 or not given.

Parentpoller only watches for parent change to pid 1 (init), but in modern linux environments processes are usually reparented to the systemd user session process. In this situation, ipykernel never noticies that its parent has exited.

jupyter-client already sets JPY_PARENT_PID with the pid of the parent process. We could trust this environment variable directly, but in this change, it is only used if it is equal to the actual parent id when the poller starts. (A side effect: if the parent dies quickly enough, ipykernel does not notice.)

Fixes #517 