### PR TITLE
fix mixture of sync/async sockets in IOPubThread

### DIFF
--- a/ipykernel/inprocess/ipkernel.py
+++ b/ipykernel/inprocess/ipkernel.py
@@ -6,6 +6,7 @@
 import logging
 import sys
 from contextlib import contextmanager
+from typing import cast
 
 from anyio import TASK_STATUS_IGNORED
 from anyio.abc import TaskStatus
@@ -146,7 +147,8 @@ class InProcessKernel(IPythonKernel):
                 assert frontend is not None
                 frontend.iopub_channel.call_handlers(msg)
 
-        self.iopub_thread.socket.on_recv = callback
+        iopub_socket = cast(DummySocket, self.iopub_thread.socket)
+        iopub_socket.on_recv = callback
 
     # ------ Trait initializers -----------------------------------------------
 

--- a/ipykernel/inprocess/socket.py
+++ b/ipykernel/inprocess/socket.py
@@ -63,3 +63,6 @@ class DummySocket(HasTraits):
         assert timeout == 0
         statistics = self.in_receive_stream.statistics()
         return statistics.current_buffer_used != 0
+
+    def close(self):
+        pass

--- a/ipykernel/iostream.py
+++ b/ipykernel/iostream.py
@@ -94,7 +94,7 @@ class IOPubThread:
         self.socket: zmq.Socket[bytes] | None = zmq.Socket(socket)
         if self.socket.context is None:
             # bug in pyzmq, shadow socket doesn't always inherit context attribute
-            self.socket.context = socket.context
+            self.socket.context = socket.context  # type:ignore[unreachable]
         self._context = socket.context
 
         self.background_socket = BackgroundSocket(self)

--- a/ipykernel/iostream.py
+++ b/ipykernel/iostream.py
@@ -167,7 +167,7 @@ class IOPubThread:
         *all* waiting events are processed in order.
         """
         # create async wrapper within coroutine
-        pipe_in = zmq.asyncio.Socket.shadow(self._pipe_in0)
+        pipe_in = zmq.asyncio.Socket(self._pipe_in0)
         try:
             while True:
                 await pipe_in.recv()

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -15,7 +15,7 @@ import zmq
 import zmq.asyncio
 from jupyter_client.session import Session
 
-from ipykernel.iostream import MASTER, BackgroundSocket, IOPubThread, OutStream
+from ipykernel.iostream import _PARENT, BackgroundSocket, IOPubThread, OutStream
 
 
 @pytest.fixture()
@@ -73,7 +73,7 @@ async def test_io_thread(anyio_backend, iopub_thread):
     ctx1, pipe = thread._setup_pipe_out()
     pipe.close()
     thread._pipe_in1.close()
-    thread._check_mp_mode = lambda: MASTER
+    thread._check_mp_mode = lambda: _PARENT
     thread._really_send([b"hi"])
     ctx1.destroy()
     thread.stop()

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -32,10 +32,10 @@ from .utils import (
 )
 
 
-def _check_master(kc, expected=True, stream="stdout"):
+def _check_main(kc, expected=True, stream="stdout"):
     execute(kc=kc, code="import sys")
     flush_channels(kc)
-    msg_id, content = execute(kc=kc, code="print(sys.%s._is_master_process())" % stream)
+    msg_id, content = execute(kc=kc, code="print(sys.%s._is_main_process())" % stream)
     stdout, stderr = assemble_output(kc.get_iopub_msg)
     assert stdout.strip() == repr(expected)
 
@@ -56,7 +56,7 @@ def test_simple_print():
         stdout, stderr = assemble_output(kc.get_iopub_msg)
         assert stdout == "hi\n"
         assert stderr == ""
-        _check_master(kc, expected=True)
+        _check_main(kc, expected=True)
 
 
 def test_print_to_correct_cell_from_thread():
@@ -168,7 +168,7 @@ def test_capture_fd():
         stdout, stderr = assemble_output(iopub)
         assert stdout == "capsys\n"
         assert stderr == ""
-        _check_master(kc, expected=True)
+        _check_main(kc, expected=True)
 
 
 @pytest.mark.skip(reason="Currently don't capture during test as pytest does its own capturing")
@@ -182,7 +182,7 @@ def test_subprocess_peek_at_stream_fileno():
         stdout, stderr = assemble_output(iopub)
         assert stdout == "CAP1\nCAP2\n"
         assert stderr == ""
-        _check_master(kc, expected=True)
+        _check_main(kc, expected=True)
 
 
 def test_sys_path():
@@ -218,7 +218,7 @@ def test_sys_path_profile_dir():
 def test_subprocess_print():
     """printing from forked mp.Process"""
     with new_kernel() as kc:
-        _check_master(kc, expected=True)
+        _check_main(kc, expected=True)
         flush_channels(kc)
         np = 5
         code = "\n".join(
@@ -238,8 +238,8 @@ def test_subprocess_print():
         for n in range(np):
             assert stdout.count(str(n)) == 1, stdout
         assert stderr == ""
-        _check_master(kc, expected=True)
-        _check_master(kc, expected=True, stream="stderr")
+        _check_main(kc, expected=True)
+        _check_main(kc, expected=True, stream="stderr")
 
 
 @flaky(max_runs=3)
@@ -261,8 +261,8 @@ def test_subprocess_noprint():
         assert stdout == ""
         assert stderr == ""
 
-        _check_master(kc, expected=True)
-        _check_master(kc, expected=True, stream="stderr")
+        _check_main(kc, expected=True)
+        _check_main(kc, expected=True, stream="stderr")
 
 
 @flaky(max_runs=3)
@@ -287,8 +287,8 @@ def test_subprocess_error():
         assert stdout == ""
         assert "ValueError" in stderr
 
-        _check_master(kc, expected=True)
-        _check_master(kc, expected=True, stream="stderr")
+        _check_main(kc, expected=True)
+        _check_main(kc, expected=True, stream="stderr")
 
 
 # raw_input tests


### PR DESCRIPTION
all sockets are explicitly sync until/except we are in the coroutines that will await them, whereas there was an ambiguous mixture of sync and async sockets before

- consistent behavior of send for child pipe and main process sockets
- avoids unsafe assumption that send is greedy on async sockets
- avoids potential issues creating async objects in one thread, then using them in another in a different event loop
- always creates/uses the right types, regardless of input socket
- address some typing lint

found while working on https://github.com/ipython/ipyparallel/issues/895