### PR TITLE
socket must be None, not shell_socket for default shell

### DIFF
--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -412,7 +412,7 @@ class Kernel(SingletonConfigurable):
         else:
             assert subshell_id is None
             assert threading.current_thread() == threading.main_thread()
-            socket = self.shell_socket
+            socket = None
 
         async with create_task_group() as tg:
             tg.start_soon(self.process_shell, socket)


### PR DESCRIPTION
`process_shell_message` has

```python
assert socket is None
```

for the default subshell, so passing `shell_socket` here results in:

```python
socket = self.shell_socket
...
assert socket is None
socket = self.shell_socket
```