### PR TITLE
Drop support for Python 3.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,10 +22,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.8", "3.12"]
+        python-version: ["3.9", "3.12"]
         include:
-          - os: windows-latest
-            python-version: "3.9"
           - os: ubuntu-latest
             python-version: "pypy-3.9"
           - os: macos-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
     "debugpy>=1.8.1",
     "ipython>=7.23.1",


### PR DESCRIPTION
Drop support for Python 3.8 as it reached end-of-life on 2024-10-07.