### PR TITLE
Improve robustness of subshell concurrency tests

### DIFF
--- a/tests/test_subshells.py
+++ b/tests/test_subshells.py
@@ -137,7 +137,7 @@ def test_run_concurrently_sequence(are_subshells, overlap):
         # Import time module before running time-sensitive subshell code.
         execute_request_subshell_id(kc, "import time; print('ok')", None)
 
-        sleep = 0.1
+        sleep = 0.2
         if overlap:
             codes = [
                 f"start0=True; end0=False; time.sleep({sleep}); end0=True",


### PR DESCRIPTION
Improve robustness of subshell concurrency tests. This is difficult to do as the tests run reliably fine on my dev machine so I am looking at what could theoretically improve the situation and trying it out in CI.

I have moved the `import time` to before starting the time-sensitive subshell code as this should be better than importing it in one subshell (taking an unknown amount of time) or importing it in both subshells at the same time (GIL contention?). If this is not sufficient I could add some threaded synchronisation to the start of the subshell test code to remove any timing variability in sending/receiving zmq messages.