### PR TITLE
Add 20 min timeout dowstream ipyparallel

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -56,6 +56,7 @@ jobs:
 
   ipyparallel:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Main branch test was cancelled after 6h, which is a waste of resources.