### PR TITLE
Suggest to make implementations of some function always return awaitable

### DIFF
--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -60,7 +60,7 @@ from .iostream import OutStream
 _AWAITABLE_MESSAGE: str = (
     "For consistency across implementations, it is recommended that `{func_name}`"
     " either be a coroutine function (`async def`) or return an awaitable object"
-    " (like a Future). It might become a requirement in the future."
+    " (like an `asyncio.Future`). It might become a requirement in the future."
     " Coroutine functions and awaitables have been supported since"
     " ipykernel 6.0 (2021)."
 )

--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -57,6 +57,14 @@ from ipykernel.jsonutil import json_clean
 from ._version import kernel_protocol_version
 from .iostream import OutStream
 
+_AWAITABLE_MESSAGE: str = (
+    "For consistency across implementations, it is recommended that `{func_name}`"
+    " either be a coroutine function (`async def`) or return an awaitable object"
+    " (like a Future). It might become a requirement in the future."
+    " Coroutine functions and awaitables have been supported since"
+    " ipykernel 6.0 (2021)."
+)
+
 
 def _accepts_parameters(meth, param_names):
     parameters = inspect.signature(meth).parameters
@@ -742,6 +750,12 @@ class Kernel(SingletonConfigurable):
 
         if inspect.isawaitable(reply_content):
             reply_content = await reply_content
+        else:
+            warnings.warn(
+                _AWAITABLE_MESSAGE.format(func_name="execute_request"),
+                PendingDeprecationWarning,
+                stacklevel=1,
+            )
 
         # Flush output before sending the reply.
         if sys.stdout is not None:
@@ -802,6 +816,12 @@ class Kernel(SingletonConfigurable):
         matches = self.do_complete(code, cursor_pos)
         if inspect.isawaitable(matches):
             matches = await matches
+        else:
+            warnings.warn(
+                _AWAITABLE_MESSAGE.format(func_name="do_complete"),
+                PendingDeprecationWarning,
+                stacklevel=1,
+            )
 
         matches = json_clean(matches)
         self.session.send(socket, "complete_reply", matches, parent, ident)
@@ -830,6 +850,12 @@ class Kernel(SingletonConfigurable):
         )
         if inspect.isawaitable(reply_content):
             reply_content = await reply_content
+        else:
+            warnings.warn(
+                _AWAITABLE_MESSAGE.format(func_name="do_inspect"),
+                PendingDeprecationWarning,
+                stacklevel=1,
+            )
 
         # Before we send this object over, we scrub it for JSON usage
         reply_content = json_clean(reply_content)
@@ -849,6 +875,12 @@ class Kernel(SingletonConfigurable):
         reply_content = self.do_history(**content)
         if inspect.isawaitable(reply_content):
             reply_content = await reply_content
+        else:
+            warnings.warn(
+                _AWAITABLE_MESSAGE.format(func_name="do_history"),
+                PendingDeprecationWarning,
+                stacklevel=1,
+            )
 
         reply_content = json_clean(reply_content)
         msg = self.session.send(socket, "history_reply", reply_content, parent, ident)
@@ -966,6 +998,12 @@ class Kernel(SingletonConfigurable):
         content = self.do_shutdown(parent["content"]["restart"])
         if inspect.isawaitable(content):
             content = await content
+        else:
+            warnings.warn(
+                _AWAITABLE_MESSAGE.format(func_name="do_shutdown"),
+                PendingDeprecationWarning,
+                stacklevel=1,
+            )
         self.session.send(socket, "shutdown_reply", content, parent, ident=ident)
         # same content, but different msg_id for broadcasting on IOPub
         self._shutdown_message = self.session.msg("shutdown_reply", content, parent)
@@ -990,6 +1028,12 @@ class Kernel(SingletonConfigurable):
         reply_content = self.do_is_complete(code)
         if inspect.isawaitable(reply_content):
             reply_content = await reply_content
+        else:
+            warnings.warn(
+                _AWAITABLE_MESSAGE.format(func_name="do_is_complete"),
+                PendingDeprecationWarning,
+                stacklevel=1,
+            )
         reply_content = json_clean(reply_content)
         reply_msg = self.session.send(socket, "is_complete_reply", reply_content, parent, ident)
         self.log.debug("%s", reply_msg)
@@ -1006,6 +1050,12 @@ class Kernel(SingletonConfigurable):
         reply_content = self.do_debug_request(content)
         if inspect.isawaitable(reply_content):
             reply_content = await reply_content
+        else:
+            warnings.warn(
+                _AWAITABLE_MESSAGE.format(func_name="do_debug_request"),
+                PendingDeprecationWarning,
+                stacklevel=1,
+            )
         reply_content = json_clean(reply_content)
         reply_msg = self.session.send(socket, "debug_reply", reply_content, parent, ident)
         self.log.debug("%s", reply_msg)

--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -62,7 +62,7 @@ _AWAITABLE_MESSAGE: str = (
     " either be a coroutine function (`async def`) or return an awaitable object"
     " (like an `asyncio.Future`). It might become a requirement in the future."
     " Coroutine functions and awaitables have been supported since"
-    " ipykernel 6.0 (2021)."
+    " ipykernel 6.0 (2021). {target} does not seem to return an awaitable"
 )
 
 
@@ -752,7 +752,9 @@ class Kernel(SingletonConfigurable):
             reply_content = await reply_content
         else:
             warnings.warn(
-                _AWAITABLE_MESSAGE.format(func_name="execute_request"),
+                _AWAITABLE_MESSAGE.format(
+                    func_name="do_execute", target=self.do_execute
+                ),
                 PendingDeprecationWarning,
                 stacklevel=1,
             )
@@ -818,7 +820,9 @@ class Kernel(SingletonConfigurable):
             matches = await matches
         else:
             warnings.warn(
-                _AWAITABLE_MESSAGE.format(func_name="do_complete"),
+                _AWAITABLE_MESSAGE.format(
+                    func_name="do_complete", target=self.do_complete
+                ),
                 PendingDeprecationWarning,
                 stacklevel=1,
             )
@@ -852,7 +856,9 @@ class Kernel(SingletonConfigurable):
             reply_content = await reply_content
         else:
             warnings.warn(
-                _AWAITABLE_MESSAGE.format(func_name="do_inspect"),
+                _AWAITABLE_MESSAGE.format(
+                    func_name="do_inspect", target=self.do_inspect
+                ),
                 PendingDeprecationWarning,
                 stacklevel=1,
             )
@@ -877,7 +883,9 @@ class Kernel(SingletonConfigurable):
             reply_content = await reply_content
         else:
             warnings.warn(
-                _AWAITABLE_MESSAGE.format(func_name="do_history"),
+                _AWAITABLE_MESSAGE.format(
+                    func_name="do_history", target=self.do_history
+                ),
                 PendingDeprecationWarning,
                 stacklevel=1,
             )
@@ -1000,7 +1008,9 @@ class Kernel(SingletonConfigurable):
             content = await content
         else:
             warnings.warn(
-                _AWAITABLE_MESSAGE.format(func_name="do_shutdown"),
+                _AWAITABLE_MESSAGE.format(
+                    func_name="do_shutdown", target=self.do_shutdown
+                ),
                 PendingDeprecationWarning,
                 stacklevel=1,
             )
@@ -1030,7 +1040,9 @@ class Kernel(SingletonConfigurable):
             reply_content = await reply_content
         else:
             warnings.warn(
-                _AWAITABLE_MESSAGE.format(func_name="do_is_complete"),
+                _AWAITABLE_MESSAGE.format(
+                    func_name="do_is_complete", target=self.do_is_complete
+                ),
                 PendingDeprecationWarning,
                 stacklevel=1,
             )
@@ -1052,7 +1064,9 @@ class Kernel(SingletonConfigurable):
             reply_content = await reply_content
         else:
             warnings.warn(
-                _AWAITABLE_MESSAGE.format(func_name="do_debug_request"),
+                _AWAITABLE_MESSAGE.format(
+                    func_name="do_debug_request", target=self.do_debug_request
+                ),
                 PendingDeprecationWarning,
                 stacklevel=1,
             )

--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -752,9 +752,7 @@ class Kernel(SingletonConfigurable):
             reply_content = await reply_content
         else:
             warnings.warn(
-                _AWAITABLE_MESSAGE.format(
-                    func_name="do_execute", target=self.do_execute
-                ),
+                _AWAITABLE_MESSAGE.format(func_name="do_execute", target=self.do_execute),
                 PendingDeprecationWarning,
                 stacklevel=1,
             )
@@ -820,9 +818,7 @@ class Kernel(SingletonConfigurable):
             matches = await matches
         else:
             warnings.warn(
-                _AWAITABLE_MESSAGE.format(
-                    func_name="do_complete", target=self.do_complete
-                ),
+                _AWAITABLE_MESSAGE.format(func_name="do_complete", target=self.do_complete),
                 PendingDeprecationWarning,
                 stacklevel=1,
             )
@@ -856,9 +852,7 @@ class Kernel(SingletonConfigurable):
             reply_content = await reply_content
         else:
             warnings.warn(
-                _AWAITABLE_MESSAGE.format(
-                    func_name="do_inspect", target=self.do_inspect
-                ),
+                _AWAITABLE_MESSAGE.format(func_name="do_inspect", target=self.do_inspect),
                 PendingDeprecationWarning,
                 stacklevel=1,
             )
@@ -883,9 +877,7 @@ class Kernel(SingletonConfigurable):
             reply_content = await reply_content
         else:
             warnings.warn(
-                _AWAITABLE_MESSAGE.format(
-                    func_name="do_history", target=self.do_history
-                ),
+                _AWAITABLE_MESSAGE.format(func_name="do_history", target=self.do_history),
                 PendingDeprecationWarning,
                 stacklevel=1,
             )
@@ -1008,9 +1000,7 @@ class Kernel(SingletonConfigurable):
             content = await content
         else:
             warnings.warn(
-                _AWAITABLE_MESSAGE.format(
-                    func_name="do_shutdown", target=self.do_shutdown
-                ),
+                _AWAITABLE_MESSAGE.format(func_name="do_shutdown", target=self.do_shutdown),
                 PendingDeprecationWarning,
                 stacklevel=1,
             )
@@ -1040,9 +1030,7 @@ class Kernel(SingletonConfigurable):
             reply_content = await reply_content
         else:
             warnings.warn(
-                _AWAITABLE_MESSAGE.format(
-                    func_name="do_is_complete", target=self.do_is_complete
-                ),
+                _AWAITABLE_MESSAGE.format(func_name="do_is_complete", target=self.do_is_complete),
                 PendingDeprecationWarning,
                 stacklevel=1,
             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -192,7 +192,7 @@ filterwarnings= [
   "ignore:unclosed database in <sqlite3.Connection:ResourceWarning",
 
   # ignore deprecated non async during tests:
-  "ignore:For consistency across implementations, it is recommended that:PendingDeprecationWarning",
+  "always:For consistency across implementations, it is recommended that:PendingDeprecationWarning",
 
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -190,6 +190,10 @@ filterwarnings= [
 
   # ignore unclosed sqlite in traits
   "ignore:unclosed database in <sqlite3.Connection:ResourceWarning",
+
+  # ignore deprecated non async during tests:
+  "ignore:For consistency across implementations, it is recommended that:PendingDeprecationWarning",
+
 ]
 
 [tool.coverage.report]


### PR DESCRIPTION
See discussion in #1272; It is not deprecated, but being able to always know you can (and must) await should be simpler in the long run.

Deprecating now is not the point, but I want to cover our bases, so that we are more confident later when and if we want to enforce those await.

In particular many of those branches are not covered in our tests – and I don't even know wether they were ever taken;

After changing some of the base methods to be async, it breaks qtconsole, spyder kernel and a few things– so only emitting warnings for now.

A few other things use the `if awaitable(...):` pattern but are a bit more complicated, and some do not date back to 2021, so those will be dealt with separately.