### PR TITLE
Use supported_features=['debugger'] in kernel info reply

### DIFF
--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -895,7 +895,7 @@ class Kernel(SingletonConfigurable):
             "language_info": self.language_info,
             "banner": self.banner,
             "help_links": self.help_links,
-            "supported_features": supported_features
+            "supported_features": supported_features,
         }
 
     async def kernel_info_request(self, socket, ident, parent):

--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -891,6 +891,12 @@ class Kernel(SingletonConfigurable):
         }
         if self._supports_kernel_subshells:
             info["supported_features"] = ["kernel subshells"]
+
+        from .debugger import _is_debugpy_available
+
+        if _is_debugpy_available:
+            info["supported_features"].append("debugger")
+
         return info
 
     async def kernel_info_request(self, socket, ident, parent):

--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -880,24 +880,23 @@ class Kernel(SingletonConfigurable):
 
     @property
     def kernel_info(self):
-        info = {
+        from .debugger import _is_debugpy_available
+
+        supported_features: list[str] = []
+        if self._supports_kernel_subshells:
+            supported_features.append("kernel subshells")
+        if _is_debugpy_available:
+            supported_features.append("debugger")
+
+        return {
             "protocol_version": kernel_protocol_version,
             "implementation": self.implementation,
             "implementation_version": self.implementation_version,
             "language_info": self.language_info,
             "banner": self.banner,
             "help_links": self.help_links,
-            "supported_features": [],
+            "supported_features": supported_features
         }
-        if self._supports_kernel_subshells:
-            info["supported_features"] = ["kernel subshells"]
-
-        from .debugger import _is_debugpy_available
-
-        if _is_debugpy_available:
-            info["supported_features"].append("debugger")
-
-        return info
 
     async def kernel_info_request(self, socket, ident, parent):
         """Handle a kernel info request."""

--- a/tests/test_debugger.py
+++ b/tests/test_debugger.py
@@ -96,6 +96,17 @@ def test_debug_initialize(kernel):
         assert reply == {}
 
 
+def test_supported_features(kernel_with_debug):
+    kernel_with_debug.kernel_info()
+    reply = kernel_with_debug.get_shell_msg(timeout=TIMEOUT)
+    supported_features = reply["content"]["supported_features"]
+
+    if debugpy:
+        assert "debugger" in supported_features
+    else:
+        assert "debugger" not in supported_features
+
+
 def test_attach_debug(kernel_with_debug):
     reply = wait_for_debug_request(
         kernel_with_debug, "evaluate", {"expression": "'a' + 'b'", "context": "repl"}


### PR DESCRIPTION
[JEP92](https://github.com/jupyter/enhancement-proposals/pull/92/files) added support for optional features to be included in kernel info reply messages via the `supported_features` attribute, with subshells and debugger being examples. We are already using it for subshells, this PR also adds `debugger` to the list of `supported_features` if `debugpy` is importable.

Corresponding documentation PR in `jupyter_client` for messaging protocol is jupyter/jupyter_client#1045.

This replaces the use of `kernel_info_reply['debugger']` which should be considered deprecated but cannot be removed until downstream libraries adopt reading the `supported_features` rather than `debugger` attribute directly.