### PR TITLE
properly close OutStream and various fixes

### DIFF
--- a/ipykernel/_version.py
+++ b/ipykernel/_version.py
@@ -1,6 +1,8 @@
 """
 store the current version info of the server.
 """
+from __future__ import annotations
+
 import re
 
 # Version string must appear intact for hatch versioning

--- a/ipykernel/embed.py
+++ b/ipykernel/embed.py
@@ -55,3 +55,4 @@ def embed_kernel(module=None, local_ns=None, **kwargs):
     app.kernel.user_ns = local_ns
     app.shell.set_completer_frame()  # type:ignore[union-attr]
     app.start()
+    app.close()

--- a/ipykernel/inprocess/channels.py
+++ b/ipykernel/inprocess/channels.py
@@ -2,6 +2,7 @@
 
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
+from __future__ import annotations
 
 from jupyter_client.channelsabc import HBChannelABC
 

--- a/ipykernel/iostream.py
+++ b/ipykernel/iostream.py
@@ -595,8 +595,8 @@ class OutStream(TextIOBase):
             self._should_watch = False
             # thread won't wake unless there's something to read
             # writing something after _should_watch will not be echoed
-            os.write(self._original_stdstream_fd, b"\0")
-            if self.watch_fd_thread is not None:
+            if self.watch_fd_thread is not None and self.watch_fd_thread.is_alive():
+                os.write(self._original_stdstream_fd, b"\0")
                 self.watch_fd_thread.join()
             # restore original FDs
             os.dup2(self._original_stdstream_copy, self._original_stdstream_fd)

--- a/ipykernel/kernelapp.py
+++ b/ipykernel/kernelapp.py
@@ -536,8 +536,6 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp, ConnectionFileMix
 
         restores state after init_io
         """
-        if self.closed:
-            return
         stdout, stderr, displayhook = sys.stdout, sys.stderr, sys.displayhook
         sys.stdout, sys.stderr, sys.displayhook = self._original_io
         if finish_displayhook := getattr(displayhook, "finish_displayhook", None):

--- a/ipykernel/kernelapp.py
+++ b/ipykernel/kernelapp.py
@@ -482,11 +482,11 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp, ConnectionFileMix
             if self.no_stdout:
                 if sys.stdout is not None:
                     sys.stdout.flush()
-                sys.stdout = self._blackhole  # type:ignore[misc]
+                sys.stdout = self._blackhole
             if self.no_stderr:
                 if sys.stderr is not None:
                     sys.stderr.flush()
-                sys.stderr = self._blackhole  # type:ignore[misc]
+                sys.stderr = self._blackhole
 
     def init_io(self):
         """Redirect input streams and set a display hook."""
@@ -514,7 +514,7 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp, ConnectionFileMix
                         isinstance(handler, StreamHandler)
                         and (buffer := getattr(handler.stream, "buffer", None))
                         and (fileno := getattr(buffer, "fileno", None))
-                        and fileno() == sys.stderr._original_stdstream_fd
+                        and fileno() == sys.stderr._original_stdstream_fd  # type:ignore[attr-defined]
                     ):
                         self.log.debug("Seeing logger to stderr, rerouting to raw filedescriptor.")
                         io_wrapper = TextIOWrapper(

--- a/ipykernel/kernelapp.py
+++ b/ipykernel/kernelapp.py
@@ -510,13 +510,13 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp, ConnectionFileMix
 
             if hasattr(sys.stderr, "_original_stdstream_copy"):
                 for handler in self.log.handlers:
-                    if (isinstance(handler, StreamHandler)
-                            and (buffer := getattr(handler.stream, "buffer"))
-                            and (fileno := getattr(buffer, "fileno"))
-                            and fileno() == sys.stderr._original_stdstream_fd):
-                        self.log.debug(
-                            "Seeing logger to stderr, rerouting to raw filedescriptor."
-                        )
+                    if (
+                        isinstance(handler, StreamHandler)
+                        and (buffer := handler.stream.buffer)
+                        and (fileno := buffer.fileno)
+                        and fileno() == sys.stderr._original_stdstream_fd
+                    ):
+                        self.log.debug("Seeing logger to stderr, rerouting to raw filedescriptor.")
 
                         handler.stream = TextIOWrapper(
                             FileIO(
@@ -540,18 +540,17 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp, ConnectionFileMix
             return
         stdout, stderr, displayhook = sys.stdout, sys.stderr, sys.displayhook
         sys.stdout, sys.stderr, sys.displayhook = self._original_io
-        if (finish_displayhook := getattr(displayhook, "finish_displayhook",
-                                          None)):
+        if finish_displayhook := getattr(displayhook, "finish_displayhook", None):
             finish_displayhook()
         if hasattr(sys.stderr, "_original_stdstream_copy"):
             for handler in self.log.handlers:
-                if (isinstance(handler, StreamHandler)
-                        and (buffer := getattr(handler.stream, "buffer"))
-                        and (fileno := getattr(buffer, "fileno"))
-                        and fileno() == sys.stderr._original_stdstream_copy):
-                    self.log.debug(
-                        "Seeing logger to raw filedescriptor, rerouting back to stderr"
-                    )
+                if (
+                    isinstance(handler, StreamHandler)
+                    and (buffer := handler.stream.buffer)
+                    and (fileno := buffer.fileno)
+                    and fileno() == sys.stderr._original_stdstream_copy
+                ):
+                    self.log.debug("Seeing logger to raw filedescriptor, rerouting back to stderr")
 
                     handler.stream = TextIOWrapper(
                         FileIO(

--- a/ipykernel/kernelapp.py
+++ b/ipykernel/kernelapp.py
@@ -204,6 +204,10 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp, ConnectionFileMix
         Interrupt this process when the parent is signaled.
         """,
     ).tag(config=True)
+    closed = Bool(
+        True,
+        help="whether this is closed",
+    )
 
     def init_crash_handler(self):
         """Initialize the crash handler."""
@@ -532,6 +536,8 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp, ConnectionFileMix
 
         restores state after init_io
         """
+        if self.closed:
+            return
         stdout, stderr, displayhook = sys.stdout, sys.stderr, sys.displayhook
         sys.stdout, sys.stderr, sys.displayhook = self._original_io
         if (finish_displayhook := getattr(displayhook, "finish_displayhook",

--- a/ipykernel/kernelapp.py
+++ b/ipykernel/kernelapp.py
@@ -559,10 +559,11 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp, ConnectionFileMix
                             "w",
                         )
                     )
-        stderr.close()
-        stdout.close()
+        if hasattr(sys.stderr, "_original_stdstream_copy"):
+            stderr.close()
+        if hasattr(sys.stdout, "_original_stdstream_copy"):
+            stdout.close()
         if self._blackhole:
-            # already closed by above but no harm calling again
             self._blackhole.close()
 
     def patch_io(self):

--- a/ipykernel/pickleutil.py
+++ b/ipykernel/pickleutil.py
@@ -2,6 +2,8 @@
 
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
+from __future__ import annotations
+
 import copy
 import pickle
 import sys

--- a/ipykernel/thread.py
+++ b/ipykernel/thread.py
@@ -1,4 +1,6 @@
 """Base class for threads."""
+from __future__ import annotations
+
 import typing as t
 from threading import Event, Thread
 

--- a/tests/test_kernelapp.py
+++ b/tests/test_kernelapp.py
@@ -31,6 +31,7 @@ def test_blackhole():
     app.no_stderr = True
     app.no_stdout = True
     app.init_blackhole()
+    app.close()
 
 
 def test_start_app():


### PR DESCRIPTION
In order to support proper execution after resuming from an embedded kernel, we have to make sure that we can revert the IO alterations by the kernelapp using the `close()` method. The following fixes were made:
* Call `close` before `embed` returns
* Don't write the extra character on `OutStream` `close()` to pipe for watching thread if it's already dead or missing
* Add new variable `closed` so that "close" can be called multiple times without any error
* Don't use `__stdout__` and `__stderr__` at all
* Keep `blackhole` reference around so that the watching thread's pipe file descriptors do not get accidentally closed when the object is garbage collected (it happens now because it is not stored in `__stdout__`)
* Keep old IO variables and restore them when exiting
* More robust StreamHandler fixup and restore (but I think these should actually be completely removed)

Fixes #1283