### PR TITLE
Fix test_print_to_correct_cell_from_child_thread

### DIFF
--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -105,8 +105,10 @@ def test_print_to_correct_cell_from_child_thread():
             sleep({interval})
 
     def parent_target():
-        Thread(target=child_target).start()
-        sleep({interval * iterations})
+        sleep({interval})
+        thread = Thread(target=child_target)
+        thread.start()
+        thread.join()
 
     Thread(target=parent_target).start()
     """

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -105,8 +105,8 @@ def test_print_to_correct_cell_from_child_thread():
             sleep({interval})
 
     def parent_target():
-        sleep({interval})
         Thread(target=child_target).start()
+        sleep({interval * iterations})
 
     Thread(target=parent_target).start()
     """


### PR DESCRIPTION
The parent thread has to live for the duration of the child thread, otherwise the parent thread exits before the child thread and disappears from the active threads, causing it to be removed from `thread_to_parent` and eventually leading to messages not being routed to the right cell:
https://github.com/ipython/ipykernel/blob/41a965eb35b3364a56e5f1e827d7e3a9580c0213/ipykernel/ipkernel.py#L781-L794
@krassowski Could you confirm? I saw that while working on #1291.