### PR TITLE
Stop support for Python 3.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,10 +22,10 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.9", "3.13"]
+        python-version: ["3.10", "3.13"]
         include:
           - os: ubuntu-latest
-            python-version: "pypy-3.9"
+            python-version: "pypy-3.10"
           - os: macos-latest
             python-version: "3.10"
           - os: ubuntu-latest

--- a/ipykernel/ipkernel.py
+++ b/ipykernel/ipkernel.py
@@ -160,10 +160,7 @@ class IPythonKernel(KernelBase):
         self._new_threads_parent_header = {}
         self._initialize_thread_hooks()
 
-        if hasattr(gc, "callbacks"):
-            # while `gc.callbacks` exists since Python 3.3, pypy does not
-            # implement it even as of 3.9.
-            gc.callbacks.append(self._clean_thread_parent_frames)
+        gc.callbacks.append(self._clean_thread_parent_frames)
 
     help_links = List(
         [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "debugpy>=1.8.1",
     "ipython>=7.23.1",


### PR DESCRIPTION
New major version are a good time to drop support for older versions. I thihnk 3.9 should not be an issue, I woudl argue for removal of 3.10 as well.