### PR TITLE
Remove downstream_check

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -148,20 +148,3 @@ jobs:
         run: |
           cd ${GITHUB_WORKSPACE}/../spyder-kernels
           xvfb-run --auto-servernum ${pythonLocation}/bin/python -m pytest -x -vv -s --full-trace --color=yes spyder_kernels
-
-  downstream_check: # This job does nothing and is only used for the branch protection
-    if: always()
-    needs:
-      - nbclient
-      - ipywidgets
-      - jupyter_client
-      - ipyparallel
-      - jupyter_kernel_test
-      - spyder_kernels
-      - qtconsole
-    runs-on: ubuntu-latest
-    steps:
-      - name: Decide whether the needed jobs succeeded or failed
-        uses: re-actors/alls-green@release/v1
-        with:
-          jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
It says its for branch protection, but branch protection can already requires multiple checks, and it creates an arbitry extra failure, which is anyway ignored as downasrteam is failing on main.

So it's just extra noise IMHO.