### PR TITLE
Remove link to numfocus for funding.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,6 @@ dependencies = [
 [project.urls]
 Homepage = "https://ipython.org"
 Documentation = "https://ipykernel.readthedocs.io"
-Funding = "https://numfocus.org/donate"
 Source = "https://github.com/ipython/ipykernel"
 Tracker = "https://github.com/ipython/ipykernel/issues"
 


### PR DESCRIPTION
We are not affiliated anymore with NF