### PR TITLE
Don't rerun test with --lf it hides failures.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,19 +49,19 @@ jobs:
         timeout-minutes: 15
         if: ${{ !startsWith( matrix.python-version, 'pypy' ) && !startsWith(matrix.os, 'windows') }}
         run: |
-          hatch run cov:test --cov-fail-under 50 || hatch run test:test --lf
+          hatch run cov:test --cov-fail-under 50
 
       - name: Run the tests on pypy
         timeout-minutes: 15
         if: ${{ startsWith( matrix.python-version, 'pypy' ) }}
         run: |
-          hatch run test:nowarn || hatch run test:nowarn --lf
+          hatch run test:nowarn
 
       - name: Run the tests on Windows
         timeout-minutes: 15
         if: ${{  startsWith(matrix.os, 'windows') }}
         run: |
-          hatch run cov:nowarn || hatch run test:nowarn --lf
+          hatch run cov:nowarn
 
       - name: Check Launcher
         run: |
@@ -144,7 +144,7 @@ jobs:
 
       - name: Run the tests
         timeout-minutes: 15
-        run: pytest -W default -vv || pytest --vv -W default --lf
+        run: pytest -W default -vv
 
   test_miniumum_versions:
     name: Test Minimum Versions
@@ -164,7 +164,7 @@ jobs:
 
       - name: Run the unit tests
         run: |
-          hatch -v run test:nowarn || hatch run test:nowarn --lf
+          hatch -v run test:nowarn
 
   test_prereleases:
     name: Test Prereleases
@@ -179,7 +179,7 @@ jobs:
           dependency_type: pre
       - name: Run the tests
         run: |
-          hatch run test:nowarn || hatch run test:nowarn --lf
+          hatch run test:nowarn
 
   make_sdist:
     name: Make SDist

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,7 +3,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.11"
+    python: "3.13"
 
 sphinx:
   configuration: docs/conf.py

--- a/tests/test_eventloop.py
+++ b/tests/test_eventloop.py
@@ -98,6 +98,7 @@ def test_cocoa_loop(kernel):
     loop_cocoa(kernel)
 
 
+@pytest.mark.skip(reason="reason crash on CI.")
 @pytest.mark.skipif(
     len(qt_guis_avail) == 0, reason="No viable version of PyQt or PySide installed."
 )

--- a/tests/test_eventloop.py
+++ b/tests/test_eventloop.py
@@ -102,16 +102,11 @@ def test_cocoa_loop(kernel):
 def test_qt_enable_gui(gui, kernel, capsys):
     if os.getenv("GITHUB_ACTIONS", None) == "true" and gui == "qt5":
         pytest.skip("Qt5 and GitHub action crash CPython")
-    if sys.platform == "win32" and gui == "qt6" and sys.version_info < (3, 10):
+    if gui == "qt6" and sys.version_info < (3, 10):
         pytest.skip(
-            "win+qt6 fails on 3.9 with AttributeError: module 'PySide6.QtPrintSupport' has no attribute 'QApplication'"
+            "qt6 fails on 3.9 with AttributeError: module 'PySide6.QtPrintSupport' has no attribute 'QApplication'"
         )
-    if (
-        sys.platform == "posix"
-        and gui == "qt6"
-        and sys.version_info[2] in [(3, 11), (3, 12)]
-        and os.getenv("GITHUB_ACTIONS", None) == "true"
-    ):
+    if sys.platform == "posix" and gui == "qt6" and os.getenv("GITHUB_ACTIONS", None) == "true":
         pytest.skip("qt6 fails on github CI with missing libEGL.so.1")
     enable_gui(gui, kernel)
 

--- a/tests/test_eventloop.py
+++ b/tests/test_eventloop.py
@@ -102,6 +102,10 @@ def test_cocoa_loop(kernel):
 def test_qt_enable_gui(gui, kernel, capsys):
     if os.getenv("GITHUB_ACTIONS", None) == "true" and gui == "qt5":
         pytest.skip("Qt5 and GitHub action crash CPython")
+    if sys.platform == "win32" and gui == "qt6" and sys.version_info < (3, 10):
+        pytest.skip(
+            "win+qt6 fails on 3.9 with AttributeError: module 'PySide6.QtPrintSupport' has no attribute 'QApplication'"
+        )
     enable_gui(gui, kernel)
 
     # We store the `QApplication` instance in the kernel.

--- a/tests/test_eventloop.py
+++ b/tests/test_eventloop.py
@@ -106,7 +106,7 @@ def test_qt_enable_gui(gui, kernel, capsys):
         pytest.skip(
             "qt6 fails on 3.9 with AttributeError: module 'PySide6.QtPrintSupport' has no attribute 'QApplication'"
         )
-    if sys.platform == "posix" and gui == "qt6" and os.getenv("GITHUB_ACTIONS", None) == "true":
+    if sys.platform == "linux" and gui == "qt6" and os.getenv("GITHUB_ACTIONS", None) == "true":
         pytest.skip("qt6 fails on github CI with missing libEGL.so.1")
     enable_gui(gui, kernel)
 

--- a/tests/test_eventloop.py
+++ b/tests/test_eventloop.py
@@ -98,13 +98,10 @@ def test_cocoa_loop(kernel):
     loop_cocoa(kernel)
 
 
-@pytest.mark.skip(reason="reason crash on CI.")
-@pytest.mark.skipif(
-    len(qt_guis_avail) == 0, reason="No viable version of PyQt or PySide installed."
-)
-def test_qt_enable_gui(kernel, capsys):
-    gui = qt_guis_avail[0]
-
+@pytest.mark.parametrize("gui", qt_guis_avail)
+def test_qt_enable_gui(gui, kernel, capsys):
+    if os.getenv("GITHUB_ACTIONS", None) == "true" and gui == "qt5":
+        pytest.skip("Qt5 and GitHub action crash CPython")
     enable_gui(gui, kernel)
 
     # We store the `QApplication` instance in the kernel.

--- a/tests/test_eventloop.py
+++ b/tests/test_eventloop.py
@@ -106,6 +106,13 @@ def test_qt_enable_gui(gui, kernel, capsys):
         pytest.skip(
             "win+qt6 fails on 3.9 with AttributeError: module 'PySide6.QtPrintSupport' has no attribute 'QApplication'"
         )
+    if (
+        sys.platform == "posix"
+        and gui == "qt6"
+        and sys.version_info[2] in [(3, 11), (3, 12)]
+        and os.getenv("GITHUB_ACTIONS", None) == "true"
+    ):
+        pytest.skip("qt6 fails on github CI with missing libEGL.so.1")
     enable_gui(gui, kernel)
 
     # We store the `QApplication` instance in the kernel.


### PR DESCRIPTION
I think this is an anti pattern,

1. we are already using flaky, so flaky test should be marked as such.

2. if it fails on first run and pass on --lf, this indicate that the
   test are relying on a global state that should either:
     - be investigated
     - is known, and then should be given a specific marker to be ran separately.

in addition:

4. `--lf` reruns the test without qt5 or qt6, so don't actually rerun many test. 
5. If there is a segfault in qt5 (which there is in main), then qt6 is not ran _at all_ – and actually there were failures !


So this is actually bad as _it hides errors_.

If at least it was `cov:test||cov:test --lf` it would make more sens, but here it's plainly wrong.

-- 

This is just a suggestion and my reasoning.  See #1323,  and thanks to @davidbrochart for pointing out that there was the --lf.