### PR TITLE
minor code reformating valid ruff 0.9.6

### DIFF
--- a/ipykernel/connect.py
+++ b/ipykernel/connect.py
@@ -133,8 +133,8 @@ def connect_qtconsole(
 
 
 __all__ = [
-    "write_connection_file",
+    "connect_qtconsole",
     "get_connection_file",
     "get_connection_info",
-    "connect_qtconsole",
+    "write_connection_file",
 ]

--- a/ipykernel/iostream.py
+++ b/ipykernel/iostream.py
@@ -501,11 +501,13 @@ class OutStream(TextIOBase):
         self._local = local()
 
         if (
-            watchfd
-            and (
-                (sys.platform.startswith("linux") or sys.platform.startswith("darwin"))
-                # Pytest set its own capture. Don't redirect from within pytest.
-                and ("PYTEST_CURRENT_TEST" not in os.environ)
+            (
+                watchfd
+                and (
+                    (sys.platform.startswith("linux") or sys.platform.startswith("darwin"))
+                    # Pytest set its own capture. Don't redirect from within pytest.
+                    and ("PYTEST_CURRENT_TEST" not in os.environ)
+                )
             )
             # allow forcing watchfd (mainly for tests)
             or watchfd == "force"

--- a/tests/test_message_spec.py
+++ b/tests/test_message_spec.py
@@ -34,7 +34,6 @@ def _setup_env():
 
 
 class Reference(HasTraits):
-
     """
     Base class for message spec specification testing.
 

--- a/tests/test_subshells.py
+++ b/tests/test_subshells.py
@@ -147,12 +147,12 @@ def test_run_concurrently_sequence(are_subshells, overlap):
         if overlap:
             codes = [
                 f"b.wait(); start0=True; end0=False; time.sleep({sleep}); end0=True",
-                f"b.wait(); time.sleep({sleep/2}); assert start0; assert not end0; time.sleep({sleep}); assert end0",
+                f"b.wait(); time.sleep({sleep / 2}); assert start0; assert not end0; time.sleep({sleep}); assert end0",
             ]
         else:
             codes = [
                 f"b.wait(); start0=True; end0=False; time.sleep({sleep}); assert end1",
-                f"b.wait(); time.sleep({sleep/2}); assert start0; assert not end0; end1=True",
+                f"b.wait(); time.sleep({sleep / 2}); assert start0; assert not end0; end1=True",
             ]
 
         msgs = []


### PR DESCRIPTION
This is some reformatting that is valid with ruff 0.2.0 and 0.9.6, so would ease the ruff update.