### PR TITLE
Ignore or fix most of the remaining ruff 0.9.6 errors

### DIFF
--- a/ipykernel/datapub.py
+++ b/ipykernel/datapub.py
@@ -30,7 +30,7 @@ warnings.warn(
 class ZMQDataPublisher(Configurable):
     """A zmq data publisher."""
 
-    topic = topic = CBytes(b"datapub")
+    topic = CBytes(b"datapub")
     session = Instance(Session, allow_none=True)
     pub_socket = Any(allow_none=True)
     parent_header = Dict({})

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -277,6 +277,9 @@ ignore = [
   "PTH123",
   # use `X | Y` for type annotations, this does not works for dynamic getting type hints on older python
   "UP007",
+  "UP031", # Use format specifiers instead of percent format
+  "PT023", # Use `@pytest.mark.skip` over `@pytest.mark.skip()`
+  "PT001", # autofixable: Use `@pytest.fixture` over `@pytest.fixture()`
 ]
 unfixable = [
   # Don't touch print statements


### PR DESCRIPTION
Mostly those are not real error, and  should allow us to update ruff without major noises/code changes.

- There are a lot of `%` formatting, moving to f- would be good but a churn, 
and 
- ruff 0.2.0 prefers fixture without `()`, so I can't apply the patch without current pre-commit to complain.
