### PR TITLE
Move mypy disablinging error codes on a per-file basis

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,11 +131,61 @@ build = [
 [tool.mypy]
 files = "ipykernel"
 strict = true
+#disable_error_code = [ "import-not-found"]
 disable_error_code = ["no-untyped-def", "no-untyped-call", "import-not-found"]
 enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]
 follow_imports = "normal"
-pretty = true
+#pretty = true
 warn_unreachable = true
+
+[[tool.mypy.overrides]]
+module = [
+    "ipykernel._eventloop_macos",
+    "ipykernel.comm.comm",
+    "ipykernel.comm.manager",
+    "ipykernel.compiler",
+    "ipykernel.connect",
+    "ipykernel.control",
+    "ipykernel.datapub",
+    "ipykernel.debugger",
+    "ipykernel.displayhook",
+    "ipykernel.embed",
+    "ipykernel.eventloops",
+    "ipykernel.gui.gtk3embed",
+    "ipykernel.gui.gtkembed",
+    "ipykernel.heartbeat",
+    "ipykernel.inprocess.blocking",
+    "ipykernel.inprocess.channels",
+    "ipykernel.inprocess.client",
+    "ipykernel.inprocess.ipkernel",
+    "ipykernel.inprocess.manager",
+    "ipykernel.inprocess.session",
+    "ipykernel.inprocess.socket",
+    "ipykernel.iostream",
+    "ipykernel.ipkernel",
+    "ipykernel.jsonutil",
+    "ipykernel.kernelapp",
+    "ipykernel.kernelbase",
+    "ipykernel.log",
+    "ipykernel.parentpoller",
+    "ipykernel.pickleutil",
+    "ipykernel.serialize",
+    "ipykernel.shellchannel",
+    "ipykernel.subshell",
+    "ipykernel.subshell_manager",
+    "ipykernel.thread",
+    "ipykernel.trio_runner",
+    "ipykernel.zmqshell"
+]
+#check_untyped_defs = false
+#disallow_incomplete_defs = false
+#disallow_untyped_calls = false
+#disallow_untyped_decorators = false
+#disallow_untyped_defs = false
+#ignore_missing_imports = true
+#follow_untyped_imports = false
+
+
 
 [tool.pytest.ini_options]
 minversion = "6.0"


### PR DESCRIPTION
This makes is way easier to renanble mypy on a single file, or duplicate this entry en reenable a single type of checks.

This means that new files will also be checked by mypy.