### PR TITLE
Test changing base method to async after #1295

### DIFF
--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -794,7 +794,7 @@ class Kernel(SingletonConfigurable):
             self._aborted_time = time.monotonic()
             self.log.info("Aborting queue")
 
-    def do_execute(
+    async def do_execute(
         self,
         code,
         silent,
@@ -829,7 +829,7 @@ class Kernel(SingletonConfigurable):
         matches = json_clean(matches)
         self.session.send(socket, "complete_reply", matches, parent, ident)
 
-    def do_complete(self, code, cursor_pos):
+    async def do_complete(self, code, cursor_pos):
         """Override in subclasses to find completions."""
         return {
             "matches": [],
@@ -865,7 +865,7 @@ class Kernel(SingletonConfigurable):
         msg = self.session.send(socket, "inspect_reply", reply_content, parent, ident)
         self.log.debug("%s", msg)
 
-    def do_inspect(self, code, cursor_pos, detail_level=0, omit_sections=()):
+    async def do_inspect(self, code, cursor_pos, detail_level=0, omit_sections=()):
         """Override in subclasses to allow introspection."""
         return {"status": "ok", "data": {}, "metadata": {}, "found": False}
 
@@ -889,7 +889,7 @@ class Kernel(SingletonConfigurable):
         msg = self.session.send(socket, "history_reply", reply_content, parent, ident)
         self.log.debug("%s", msg)
 
-    def do_history(
+    async def do_history(
         self,
         hist_access_type,
         output,
@@ -1020,7 +1020,7 @@ class Kernel(SingletonConfigurable):
 
         self.stop()
 
-    def do_shutdown(self, restart):
+    async def do_shutdown(self, restart):
         """Override in subclasses to do things when the frontend shuts down the
         kernel.
         """
@@ -1046,7 +1046,7 @@ class Kernel(SingletonConfigurable):
         reply_msg = self.session.send(socket, "is_complete_reply", reply_content, parent, ident)
         self.log.debug("%s", reply_msg)
 
-    def do_is_complete(self, code):
+    async def do_is_complete(self, code):
         """Override in subclasses to find completions."""
         return {"status": "unknown"}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -192,7 +192,7 @@ filterwarnings= [
   "ignore:unclosed database in <sqlite3.Connection:ResourceWarning",
 
   # ignore deprecated non async during tests:
-  "always:For consistency across implementations, it is recommended that:PendingDeprecationWarning",
+  "error:For consistency across implementations, it is recommended that:PendingDeprecationWarning",
 
 ]
 


### PR DESCRIPTION
This is not meant to be released in 7.0 finale but iss used as a test that:
 - 1. Our test suite is working is eferything is async
 - 2. I'like to think of making a canary release (alpha, or beta) with something similar to get feedback from what we break upstream.