### PR TITLE
Try to debug non-closed iopub socket

### DIFF
--- a/ipykernel/kernelapp.py
+++ b/ipykernel/kernelapp.py
@@ -427,7 +427,7 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp, ConnectionFileMix
         if self.debug_shell_socket and not self.debug_shell_socket.closed:
             self.debug_shell_socket.close()
 
-        for channel in ("shell", "control", "stdin", "iopub"):
+        for channel in ("shell", "control", "stdin"):
             self.log.debug("Closing %s channel", channel)
             socket = getattr(self, channel + "_socket", None)
             if socket and not socket.closed:

--- a/ipykernel/kernelapp.py
+++ b/ipykernel/kernelapp.py
@@ -427,7 +427,7 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp, ConnectionFileMix
         if self.debug_shell_socket and not self.debug_shell_socket.closed:
             self.debug_shell_socket.close()
 
-        for channel in ("shell", "control", "stdin"):
+        for channel in ("shell", "control", "stdin", "iopub"):
             self.log.debug("Closing %s channel", channel)
             socket = getattr(self, channel + "_socket", None)
             if socket and not socket.closed:

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -22,11 +22,16 @@ from .utils import TemporaryWorkingDirectory
 
 @pytest.fixture(scope="module", autouse=True)
 def _enable_tracemalloc():
-    import tracemalloc
-
-    tracemalloc.start()
+    try:
+        import tracemalloc
+    except ModuleNotFoundError:
+        # pypy
+        tracemalloc = None
+    if tracemalloc is not None:
+        tracemalloc.start()
     yield
-    tracemalloc.stop()
+    if tracemalloc is not None:
+        tracemalloc.stop()
 
 
 sample_info: dict = {

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -19,6 +19,16 @@ from ipykernel.kernelapp import IPKernelApp
 
 from .utils import TemporaryWorkingDirectory
 
+
+@pytest.fixture(scope="module", autouse=True)
+def _enable_tracemalloc():
+    import tracemalloc
+
+    tracemalloc.start()
+    yield
+    tracemalloc.stop()
+
+
 sample_info: dict = {
     "ip": "1.2.3.4",
     "transport": "ipc",


### PR DESCRIPTION
We sometime get

```
 FAILED tests/test_connect.py::test_port_bind_failure_gives_up_retries - pytest.PytestUnraisableExceptionWarning: Exception ignored in: <function Socket.__del__ at 0x7efe22e4d760>

  Traceback (most recent call last):
    File "/opt/hostedtoolcache/Python/3.12.9/x64/lib/python3.12/site-packages/zmq/sugar/socket.py", line 185, in __del__
      warn(
  ResourceWarning: Unclosed socket <zmq.asyncio.Socket(zmq.PUB) at 0x7efe1eb32820><F48>
```


This adds a tracemalloc fixture for the crashing test module in order to try to narrow that down. I'm thorn between restart the tests here until we have the failure; or merge and see once we get the error in another PR and then remove the fixture once we've fund the culprit.

--- 

The only zmq.PUB I can find is iopub, and we don't seem to be closing it

In addition : should app be a contextmanager ?
And should the atexit close registring be replaced with a weakref finalizer ?



