### PR TITLE
Make our own mock kernel methods async

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -168,7 +168,7 @@ class MockKernel(KernelMixin, Kernel):  # type:ignore
         self.shell = MagicMock()
         super().__init__(*args, **kwargs)
 
-    def do_execute(
+    async def do_execute(
         self, code, silent, store_history=True, user_expressions=None, allow_stdin=False
     ):
         if not silent:


### PR DESCRIPTION
As we are recommending upstream to use asyn, mught as well do it ourselves a well.

Plus this makes sure our test suite tests async