### PR TITLE
Pin sphinx to resolve docs build failures

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ Tracker = "https://github.com/ipython/ipykernel/issues"
 docs = [
   # Sphinx pinned until `sphinx-autodoc-typehints` issue is resolved:
   # https://github.com/tox-dev/sphinx-autodoc-typehints/issues/523
-  "sphinx<=8.2.0",
+  "sphinx<8.2.0",
   "myst_parser",
   "pydata_sphinx_theme",
   "sphinxcontrib_github_alt",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,9 @@ Tracker = "https://github.com/ipython/ipykernel/issues"
 
 [project.optional-dependencies]
 docs = [
-  "sphinx",
+  # Sphinx pinned until `sphinx-autodoc-typehints` issue is resolved:
+  # https://github.com/tox-dev/sphinx-autodoc-typehints/issues/523
+  "sphinx<=8.2.0",
   "myst_parser",
   "pydata_sphinx_theme",
   "sphinxcontrib_github_alt",


### PR DESCRIPTION
- as seen in https://github.com/ipython/ipykernel/pull/1322
- as tracked in https://github.com/tox-dev/sphinx-autodoc-typehints/issues/523