### PR TITLE
Licence :: * trove classifers are deprecated

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ classifiers = [
     "Intended Audience :: Developers",
     "Intended Audience :: System Administrators",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: BSD License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
 ]


### PR DESCRIPTION
It is replaced by License-expression (which is exclusive with license that we used, so can't just replace for now).

https://packaging.python.org/en/latest/specifications/core-metadata/#license-expression