### PR TITLE
TQDM workaround due to unresponsive maintainer

### DIFF
--- a/ipykernel/zmqshell.py
+++ b/ipykernel/zmqshell.py
@@ -34,7 +34,6 @@ from IPython.utils.process import arg_split, system  # type:ignore[attr-defined]
 from jupyter_client.session import Session, extract_header
 from jupyter_core.paths import jupyter_runtime_dir
 from traitlets import Any, CBool, CBytes, Dict, Instance, Type, default, observe
-from traitlets.config import Config
 
 from ipykernel import connect_qtconsole, get_connection_file, get_connection_info
 from ipykernel.displayhook import ZMQShellDisplayHook

--- a/ipykernel/zmqshell.py
+++ b/ipykernel/zmqshell.py
@@ -483,9 +483,7 @@ class ZMQInteractiveShell(InteractiveShell):
         # don't like it but we have few other choices.
         # See https://github.com/tqdm/tqdm/pull/1628
         if "IPKernelApp" not in self.config:
-            self.config["IPKernelApp"] = Config(
-                {"tqdm": "dummy value for https://github.com/tqdm/tqdm/pull/1628"}
-            )
+            self.config.IPKernelApp.tqdm = "dummy value for https://github.com/tqdm/tqdm/pull/1628"
 
     displayhook_class = Type(ZMQShellDisplayHook)
     display_pub_class = Type(ZMQDisplayPublisher)


### PR DESCRIPTION
`tqdm` has an incorrect detection of ZMQInteractiveShell when launch via a scheduler that bypass IPKernelApp. Think of JupyterHub cluster spawners and co.

As of end of Feb 2025, the maintainer has been unresponsive for 5 months, to our fix, so we implement a workaround. I don't like it but we have few other choices.

See https://github.com/tqdm/tqdm/pull/1628