### PR TITLE
Fix OutStream hooks not being called

### DIFF
--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -118,6 +118,25 @@ async def test_outstream(anyio_backend, iopub_thread):
         assert stream.writable()
 
 
+async def test_outstream_hooks(anyio_backend, iopub_thread):
+    session = Session()
+
+    stream = OutStream(session, iopub_thread, "stdout")
+
+    with stream:
+        hook_called = False
+
+        def hook(msg):
+            nonlocal hook_called
+            hook_called = True
+            return msg
+
+        stream.register_hook(hook)
+        stream.write("hi")
+        stream.flush()
+        assert hook_called
+
+
 @pytest.mark.anyio()
 async def test_event_pipe_gc(iopub_thread):
     session = Session(key=b"abc")


### PR DESCRIPTION
#1110 introduced `OutStream` hooks, which are [stored in a thread-local variable](https://github.com/ipython/ipykernel/blob/700c26f29126d2ced5480f0314642b12cff0d493/ipykernel/iostream.py#L733) and [invoked in `_flush`](https://github.com/ipython/ipykernel/blob/700c26f29126d2ced5480f0314642b12cff0d493/ipykernel/iostream.py#L651). However, since `_flush` [usually runs in a background thread](https://github.com/ipython/ipykernel/blob/700c26f29126d2ced5480f0314642b12cff0d493/ipykernel/iostream.py#L611), the hooks only work when registered from this thread.

This PR makes it so that the hooks are accessed from the thread which calls `flush`, which I assume is the expected behavior.