### PR TITLE
Backports and extra changes to fix CI on 6.x branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,10 +22,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.8", "3.12"]
+        python-version: ["3.9", "3.12"]
         include:
-          - os: windows-latest
-            python-version: "3.9"
           - os: ubuntu-latest
             python-version: "pypy-3.9"
           - os: macos-latest

--- a/ipykernel/inprocess/ipkernel.py
+++ b/ipykernel/inprocess/ipkernel.py
@@ -193,11 +193,11 @@ class InProcessInteractiveShell(ZMQInteractiveShell):
             gui = self.kernel.gui
         return super().enable_matplotlib(gui)
 
-    def enable_pylab(self, gui=None, import_all=True, welcome_message=False):
+    def enable_pylab(self, gui=None, import_all=True):
         """Activate pylab support at runtime."""
         if not gui:
             gui = self.kernel.gui
-        return super().enable_pylab(gui, import_all, welcome_message)
+        return super().enable_pylab(gui, import_all)
 
 
 InteractiveShellABC.register(InProcessInteractiveShell)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ classifiers = [
     "Intended Audience :: Developers",
     "Intended Audience :: System Administrators",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: BSD License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
     "debugpy>=1.6.5",
     "ipython>=7.23.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,13 +27,13 @@ dependencies = [
     "jupyter_client>=6.1.12",
     "jupyter_core>=4.12,!=5.0.*",
     # For tk event loop support only.
-    "nest_asyncio",
+    "nest_asyncio>=1.4",
     "tornado>=6.1",
     "matplotlib-inline>=0.1",
-    'appnope;platform_system=="Darwin"',
-    "pyzmq>=24",
-    "psutil",
-    "packaging",
+    'appnope>=0.1.2;platform_system=="Darwin"',
+    "pyzmq>=25.0",
+    "psutil>=5.7",
+    "packaging>=22",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,6 @@ cov = [
   "coverage[toml]",
   "pytest-cov",
   "matplotlib",
-  "curio",
   "trio",
 ]
 pyqt5 = ["pyqt5"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,7 +153,6 @@ addopts = [
 ]
 testpaths = [
     "tests",
-    "tests/inprocess"
 ]
 asyncio_mode = "auto"
 timeout = 300

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ docs = [
   "trio"
 ]
 test = [
-    "pytest>=7.0",
+    "pytest>=7.0,<9",
     "pytest-cov",
     "flaky",
     "ipyparallel",

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -7,6 +7,8 @@ import sys
 import tempfile
 from unittest.mock import patch
 
+import pytest
+
 from ipykernel.kernelspec import install
 
 pjoin = os.path.join
@@ -15,7 +17,8 @@ tmp = None
 patchers: list = []
 
 
-def setup():
+@pytest.fixture(autouse=True)
+def _global_setup():
     """setup temporary env for tests"""
     global tmp
     tmp = tempfile.mkdtemp()
@@ -34,9 +37,7 @@ def setup():
 
     # install IPython in the temp home:
     install(user=True)
-
-
-def teardown():
+    yield
     for p in patchers:
         p.stop()
 

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -8,14 +8,13 @@ from .utils import TIMEOUT, execute, flush_channels, start_new_kernel
 KC = KM = None
 
 
-def setup_function():
+@pytest.fixture(autouse=True)
+def _setup_env():
     """start the global kernel (if it isn't running) and return its client"""
     global KM, KC
     KM, KC = start_new_kernel()
     flush_channels(KC)
-
-
-def teardown_function():
+    yield
     assert KC is not None
     assert KM is not None
     KC.stop_channels()

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -27,7 +27,7 @@ def test_async_await():
     assert content["status"] == "ok", content
 
 
-@pytest.mark.parametrize("asynclib", ["asyncio", "trio", "curio"])
+@pytest.mark.parametrize("asynclib", ["asyncio", "trio"])
 def test_async_interrupt(asynclib, request):
     assert KC is not None
     assert KM is not None

--- a/tests/test_eventloop.py
+++ b/tests/test_eventloop.py
@@ -42,14 +42,13 @@ def _get_qt_vers():
 _get_qt_vers()
 
 
-def setup():
+@pytest.fixture(autouse=True)
+def _setup_env():
     """start the global kernel (if it isn't running) and return its client"""
     global KM, KC
     KM, KC = start_new_kernel()
     flush_channels(KC)
-
-
-def teardown():
+    yield
     assert KM is not None
     assert KC is not None
     KC.stop_channels()

--- a/tests/test_message_spec.py
+++ b/tests/test_message_spec.py
@@ -21,7 +21,8 @@ from .utils import TIMEOUT, execute, flush_channels, get_reply, start_global_ker
 KC: BlockingKernelClient = None  # type:ignore
 
 
-def setup():
+@pytest.fixture(autouse=True)
+def _setup_env():
     global KC
     KC = start_global_kernel()
 

--- a/tests/test_start_kernel.py
+++ b/tests/test_start_kernel.py
@@ -14,6 +14,14 @@ if os.name == "nt":
 
 @flaky(max_runs=3)
 def test_ipython_start_kernel_userns():
+    import IPython
+
+    if IPython.version_info > (9, 0):  # noqa:SIM108
+        EXPECTED = "IPythonMainModule"
+    else:
+        # not this since https://github.com/ipython/ipython/pull/14754
+        EXPECTED = "DummyMod"
+
     cmd = dedent(
         """
         from ipykernel.kernelapp import launch_new_instance
@@ -40,7 +48,7 @@ def test_ipython_start_kernel_userns():
         content = msg["content"]
         assert content["found"]
         text = content["data"]["text/plain"]
-        assert "DummyMod" in text
+        assert EXPECTED in text
 
 
 @flaky(max_runs=3)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -28,12 +28,6 @@ def start_new_kernel(**kwargs):
     Integrates with our output capturing for tests.
     """
     kwargs["stderr"] = STDOUT
-    try:
-        import nose
-
-        kwargs["stdout"] = nose.iptest_stdstreams_fileno()
-    except (ImportError, AttributeError):
-        pass
     return manager.start_new_kernel(startup_timeout=STARTUP_TIMEOUT, **kwargs)
 
 
@@ -150,12 +144,6 @@ def new_kernel(argv=None):
     kernel_client: connected KernelClient instance
     """
     kwargs = {"stderr": STDOUT}
-    try:
-        import nose
-
-        kwargs["stdout"] = nose.iptest_stdstreams_fileno()
-    except (ImportError, AttributeError):
-        pass
     if argv is not None:
         kwargs["extra_arguments"] = argv
     return manager.run_kernel(**kwargs)


### PR DESCRIPTION
Backports and extra changes to fix CI on 6.x branch, as part of #1387.

Backported PRs:

- #1229
- #1231
- #1284
- #1348
- #1354
- #1368

Extra changes (single commit each):

- 991068d Remove `welcome_message` argument from `enable_pylab`, it was recently removed from IPython 9 after being deprecated for many years.
- 59db5d3 Drop support for `curio`, it is no longer maintained.
- 6cbb188 Run all tests, only need to specify top-level `tests` directory in `pyproject.toml` for this.

After these changes, CI passes for me locally on both Linux and macOS using CPython 3.12.