### PR TITLE
[Bugfix] Set shell idle when message skipped by "should_handle" in "dispatch_shell"

### DIFF
--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -592,7 +592,7 @@ class Kernel(SingletonConfigurable):
             parent=parent or self.get_parent(channel),
             ident=self._topic("status"),
         )
-    
+
     def _publish_status_and_flush(self, status, channel, stream, parent=None):
         """send status on IOPub and flush specified stream to ensure reply is sent before handling the next reply"""
         self._publish_status(status, channel, parent)

--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -384,6 +384,7 @@ class Kernel(SingletonConfigurable):
         self.log.debug("   Content: %s\n   --->\n   ", msg["content"])
 
         if not self.should_handle(self.shell_stream, msg, idents):
+            self._publish_status("idle", "shell")
             return
 
         handler = self.shell_handlers.get(msg_type, None)

--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -292,13 +292,6 @@ class Kernel(SingletonConfigurable):
         self._do_exec_accepted_params = _accepts_parameters(
             self.do_execute, ["cell_meta", "cell_id"]
         )
-    
-    def _publish_status_and_flush(self, status, channel, stream):
-        self._publish_status(status, channel)
-        # flush to ensure reply is sent before
-        # handling the next request
-        if stream:
-            stream.flush(zmq.POLLOUT)
 
     async def dispatch_control(self, msg):
         # Ensure only one control message is processed at a time
@@ -599,6 +592,12 @@ class Kernel(SingletonConfigurable):
             parent=parent or self.get_parent(channel),
             ident=self._topic("status"),
         )
+    
+    def _publish_status_and_flush(self, status, channel, stream, parent=None):
+        """send status on IOPub and flush specified stream to ensure reply is sent before handling the next reply"""
+        self._publish_status(status, channel, parent)
+        if stream:
+            stream.flush(zmq.POLLOUT)
 
     def _publish_debug_event(self, event):
         if not self.session:


### PR DESCRIPTION
In the current "dispatch_shell", if we fail the "should_handle" check during execution, we will not send any message to ioPub indicating shell status. For a client waiting for an "idle" status update, this could block the state machine and cause a hang command. This PR fixes the bug by publishing an "idle" status when the "should_handle" check fails.