### PR TITLE
Subshells implemented using tornado event loops on 6.x branch

### DIFF
--- a/ipykernel/control.py
+++ b/ipykernel/control.py
@@ -1,32 +1,11 @@
 """A thread for a control channel."""
-from threading import Thread
 
-from tornado.ioloop import IOLoop
-
-CONTROL_THREAD_NAME = "Control"
+from .thread import CONTROL_THREAD_NAME, BaseThread
 
 
-class ControlThread(Thread):
+class ControlThread(BaseThread):
     """A thread for a control channel."""
 
     def __init__(self, **kwargs):
         """Initialize the thread."""
-        Thread.__init__(self, name=CONTROL_THREAD_NAME, **kwargs)
-        self.io_loop = IOLoop(make_current=False)
-        self.pydev_do_not_trace = True
-        self.is_pydev_daemon_thread = True
-
-    def run(self):
-        """Run the thread."""
-        self.name = CONTROL_THREAD_NAME
-        try:
-            self.io_loop.start()
-        finally:
-            self.io_loop.close()
-
-    def stop(self):
-        """Stop the thread.
-
-        This method is threadsafe.
-        """
-        self.io_loop.add_callback(self.io_loop.stop)
+        super().__init__(name=CONTROL_THREAD_NAME, **kwargs)

--- a/ipykernel/kernelapp.py
+++ b/ipykernel/kernelapp.py
@@ -53,6 +53,7 @@ from .heartbeat import Heartbeat
 from .iostream import IOPubThread
 from .ipkernel import IPythonKernel
 from .parentpoller import ParentPollerUnix, ParentPollerWindows
+from .shellchannel import ShellChannelThread
 from .zmqshell import ZMQInteractiveShell
 
 # -----------------------------------------------------------------------------
@@ -143,6 +144,7 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp, ConnectionFileMix
     iopub_socket = Any()
     iopub_thread = Any()
     control_thread = Any()
+    shell_channel_thread = Any()
 
     _ports = Dict()
 
@@ -367,6 +369,11 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp, ConnectionFileMix
             self.control_socket.router_handover = 1
 
         self.control_thread = ControlThread(daemon=True)
+        self.shell_channel_thread = ShellChannelThread(
+            context,
+            self.shell_socket,
+            daemon=True,
+        )
 
     def init_iopub(self, context):
         """Initialize the iopub channel."""
@@ -406,6 +413,10 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp, ConnectionFileMix
             self.log.debug("Closing control thread")
             self.control_thread.stop()
             self.control_thread.join()
+        if self.shell_channel_thread and self.shell_channel_thread.is_alive():
+            self.log.debug("Closing shell channel thread")
+            self.shell_channel_thread.stop()
+            self.shell_channel_thread.join()
 
         if self.debugpy_socket and not self.debugpy_socket.closed:
             self.debugpy_socket.close()
@@ -546,10 +557,17 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp, ConnectionFileMix
 
     def init_kernel(self):
         """Create the Kernel object itself"""
-        shell_stream = ZMQStream(self.shell_socket)
+        if self.shell_channel_thread:
+            shell_stream = ZMQStream(self.shell_socket, self.shell_channel_thread.io_loop)
+        else:
+            shell_stream = ZMQStream(self.shell_socket)
         control_stream = ZMQStream(self.control_socket, self.control_thread.io_loop)
         debugpy_stream = ZMQStream(self.debugpy_socket, self.control_thread.io_loop)
+
         self.control_thread.start()
+        if self.shell_channel_thread:
+            self.shell_channel_thread.start()
+
         kernel_factory = self.kernel_class.instance  # type:ignore[attr-defined]
 
         kernel = kernel_factory(
@@ -560,6 +578,7 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp, ConnectionFileMix
             debug_shell_socket=self.debug_shell_socket,
             shell_stream=shell_stream,
             control_thread=self.control_thread,
+            shell_channel_thread=self.shell_channel_thread,
             iopub_thread=self.iopub_thread,
             iopub_socket=self.iopub_socket,
             stdin_socket=self.stdin_socket,

--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -20,7 +20,7 @@ from datetime import datetime
 from functools import partial
 from signal import SIGINT, SIGTERM, Signals, default_int_handler, signal
 
-from .control import CONTROL_THREAD_NAME
+from .thread import CONTROL_THREAD_NAME
 
 if sys.platform != "win32":
     from signal import SIGKILL
@@ -144,6 +144,7 @@ class Kernel(SingletonConfigurable):
     debug_shell_socket = Any()
 
     control_thread = Any()
+    shell_channel_thread = Any()
     iopub_socket = Any()
     iopub_thread = Any()
     stdin_socket = Any()
@@ -267,6 +268,9 @@ class Kernel(SingletonConfigurable):
         "abort_request",
         "debug_request",
         "usage_request",
+        "create_subshell_request",
+        "delete_subshell_request",
+        "list_subshell_request",
     ]
 
     def __init__(self, **kwargs):
@@ -346,10 +350,29 @@ class Kernel(SingletonConfigurable):
             return False
         return True
 
-    async def dispatch_shell(self, msg):
+    async def dispatch_shell(self, msg, /, stream=None, subshell_id: str | None = None):
         """dispatch shell requests"""
+        if len(msg) == 1 and msg[0].buffer == b"stop aborting":
+            # Dummy "stop aborting" message to stop aborting execute requests on this subshell.
+            # This dummy message implementation allows the subshell to abort messages that are
+            # already queued in the zmq sockets/streams without having to know any of their
+            # details in advance.
+            if subshell_id is None:
+                self._aborting = False
+            else:
+                self.shell_channel_thread.manager.set_subshell_aborting(subshell_id, False)
+            return
+
         if not self.session:
             return
+
+        if self._supports_kernel_subshells:
+            assert threading.current_thread() not in (
+                self.control_thread,
+                self.shell_channel_thread,
+            )
+        else:
+            assert threading.current_thread() == threading.main_thread()
 
         idents, msg = self.session.feed_identities(msg, copy=False)
         try:
@@ -363,11 +386,18 @@ class Kernel(SingletonConfigurable):
         self._publish_status("busy", "shell")
 
         msg_type = msg["header"]["msg_type"]
+        assert msg["header"].get("subshell_id") == subshell_id
+
+        if stream is None:
+            if self._supports_kernel_subshells:
+                stream = self.shell_channel_thread.manager.get_other_stream(subshell_id)
+            else:
+                stream = self.shell_stream
 
         # Only abort execute requests
         if self._aborting and msg_type == "execute_request":
             self._send_abort_reply(self.shell_stream, msg, idents)
-            self._publish_status_and_flush("idle", "shell", self.shell_stream)
+            self._publish_status_and_flush("idle", "shell", stream)
             return
 
         # Print some info about this message and leave a '--->' marker, so it's
@@ -377,7 +407,7 @@ class Kernel(SingletonConfigurable):
         self.log.debug("   Content: %s\n   --->\n   ", msg["content"])
 
         if not self.should_handle(self.shell_stream, msg, idents):
-            self._publish_status_and_flush("idle", "shell", self.shell_stream)
+            self._publish_status_and_flush("idle", "shell", stream)
             return
 
         handler = self.shell_handlers.get(msg_type, None)
@@ -390,7 +420,7 @@ class Kernel(SingletonConfigurable):
             except Exception:
                 self.log.debug("Unable to signal in pre_handler_hook:", exc_info=True)
             try:
-                result = handler(self.shell_stream, idents, msg)
+                result = handler(stream, idents, msg)
                 if inspect.isawaitable(result):
                     await result
             except Exception:
@@ -406,7 +436,7 @@ class Kernel(SingletonConfigurable):
 
         sys.stdout.flush()
         sys.stderr.flush()
-        self._publish_status_and_flush("idle", "shell", self.shell_stream)
+        self._publish_status_and_flush("idle", "shell", stream)
 
     def pre_handler_hook(self):
         """Hook to execute before calling message handler"""
@@ -540,22 +570,79 @@ class Kernel(SingletonConfigurable):
         """register dispatchers for streams"""
         self.io_loop = ioloop.IOLoop.current()
         self.msg_queue: Queue[t.Any] = Queue()
-        self.io_loop.add_callback(self.dispatch_queue)
+        if not self.shell_channel_thread:
+            self.io_loop.add_callback(self.dispatch_queue)
 
         if self.control_stream:
             self.control_stream.on_recv(self.dispatch_control, copy=False)
 
         if self.shell_stream:
-            self.shell_stream.on_recv(
-                partial(
-                    self.schedule_dispatch,
-                    self.dispatch_shell,
-                ),
-                copy=False,
-            )
+            if self.shell_channel_thread:
+                self.shell_channel_thread.manager.set_on_recv_callback(self.shell_main)
+                self.shell_stream.on_recv(self.shell_channel_thread_main, copy=False)
+            else:
+                self.shell_stream.on_recv(
+                    partial(
+                        self.schedule_dispatch,
+                        self.dispatch_shell,
+                    ),
+                    copy=False,
+                )
 
         # publish idle status
         self._publish_status("starting", "shell")
+
+    async def shell_channel_thread_main(self, msg):
+        """Handler for shell messages received on shell_channel_thread"""
+        assert threading.current_thread() == self.shell_channel_thread
+
+        if self.session is None:
+            return
+
+        # deserialize only the header to get subshell_id
+        # Keep original message to send to subshell_id unmodified.
+        _, msg2 = self.session.feed_identities(msg, copy=False)
+        try:
+            msg3 = self.session.deserialize(msg2, content=False, copy=False)
+            subshell_id = msg3["header"].get("subshell_id")
+
+            # Find inproc pair socket to use to send message to correct subshell.
+            subshell_manager = self.shell_channel_thread.manager
+            socket = subshell_manager.get_shell_channel_stream(subshell_id)
+            assert socket is not None
+            socket.send_multipart(msg, copy=False)
+        except Exception:
+            self.log.error("Invalid message", exc_info=True)  # noqa: G201
+
+    async def shell_main(self, subshell_id: str | None, msg):
+        """Handler of shell messages for a single subshell"""
+        if self._supports_kernel_subshells:
+            if subshell_id is None:
+                assert threading.current_thread() == threading.main_thread()
+            else:
+                assert threading.current_thread() not in (
+                    self.shell_channel_thread,
+                    threading.main_thread(),
+                )
+            # Inproc pair socket that this subshell uses to talk to shell channel thread.
+            stream = self.shell_channel_thread.manager.get_other_stream(subshell_id)
+        else:
+            assert subshell_id is None
+            assert threading.current_thread() == threading.main_thread()
+            stream = self.shell_stream
+
+        try:
+            # Whilst executing a shell message, do not accept any other shell messages on the
+            # same subshell, so that cells are run sequentially. Without this we can run multiple
+            # async cells at the same time which would be a nice feature to have but is an API
+            # change.
+            stream.stop_on_recv()
+            await self.dispatch_shell(msg, stream=stream, subshell_id=subshell_id)
+        finally:
+            stream.on_recv(
+                partial(self.shell_main, subshell_id),
+                copy=False,
+            )
 
     def record_ports(self, ports):
         """Record the ports that this kernel is using.
@@ -772,7 +859,8 @@ class Kernel(SingletonConfigurable):
         self.log.debug("%s", reply_msg)
 
         if not silent and reply_msg["content"]["status"] == "error" and stop_on_error:
-            self._abort_queues()
+            subshell_id = parent["header"].get("subshell_id")
+            self._abort_queues(subshell_id)
 
     def do_execute(
         self,
@@ -877,14 +965,18 @@ class Kernel(SingletonConfigurable):
 
     @property
     def kernel_info(self):
-        return {
+        info = {
             "protocol_version": kernel_protocol_version,
             "implementation": self.implementation,
             "implementation_version": self.implementation_version,
             "language_info": self.language_info,
             "banner": self.banner,
             "help_links": self.help_links,
+            "supported_features": [],
         }
+        if self._supports_kernel_subshells:
+            info["supported_features"] = ["kernel subshells"]
+        return info
 
     async def kernel_info_request(self, stream, ident, parent):
         """Handle a kernel info request."""
@@ -971,7 +1063,8 @@ class Kernel(SingletonConfigurable):
             control_io_loop.add_callback(control_io_loop.stop)
 
         self.log.debug("Stopping shell ioloop")
-        if self.shell_stream:
+        self.io_loop.add_callback(self.io_loop.stop)
+        if self.shell_stream and self.shell_stream.io_loop != self.io_loop:
             shell_io_loop = self.shell_stream.io_loop
             shell_io_loop.add_callback(shell_io_loop.stop)
 
@@ -1063,6 +1156,61 @@ class Kernel(SingletonConfigurable):
     async def do_debug_request(self, msg):
         raise NotImplementedError
 
+    async def create_subshell_request(self, socket, ident, parent) -> None:
+        if not self.session:
+            return
+        if not self._supports_kernel_subshells:
+            self.log.error("Subshells are not supported by this kernel")
+            return
+
+        assert threading.current_thread().name == CONTROL_THREAD_NAME
+
+        # This should only be called in the control thread if it exists.
+        # Request is passed to shell channel thread to process.
+        other_socket = self.shell_channel_thread.manager.get_control_other_socket()
+        other_socket.send_json({"type": "create"})
+        reply = other_socket.recv_json()
+        self.session.send(socket, "create_subshell_reply", reply, parent, ident)
+
+    async def delete_subshell_request(self, socket, ident, parent) -> None:
+        if not self.session:
+            return
+        if not self._supports_kernel_subshells:
+            self.log.error("KERNEL SUBSHELLS NOT SUPPORTED")
+            return
+
+        assert threading.current_thread().name == CONTROL_THREAD_NAME
+
+        try:
+            content = parent["content"]
+            subshell_id = content["subshell_id"]
+        except Exception:
+            self.log.error("Got bad msg from parent: %s", parent)
+            return
+
+        # This should only be called in the control thread if it exists.
+        # Request is passed to shell channel thread to process.
+        other_socket = self.shell_channel_thread.manager.get_control_other_socket()
+        other_socket.send_json({"type": "delete", "subshell_id": subshell_id})
+        reply = other_socket.recv_json()
+        self.session.send(socket, "delete_subshell_reply", reply, parent, ident)
+
+    async def list_subshell_request(self, socket, ident, parent) -> None:
+        if not self.session:
+            return
+        if not self._supports_kernel_subshells:
+            self.log.error("Subshells are not supported by this kernel")
+            return
+
+        assert threading.current_thread().name == CONTROL_THREAD_NAME
+
+        # This should only be called in the control thread if it exists.
+        # Request is passed to shell channel thread to process.
+        other_socket = self.shell_channel_thread.manager.get_control_other_socket()
+        other_socket.send_json({"type": "list"})
+        reply = other_socket.recv_json()
+        self.session.send(socket, "list_subshell_reply", reply, parent, ident)
+
     # ---------------------------------------------------------------------------
     # Engine methods (DEPRECATED)
     # ---------------------------------------------------------------------------
@@ -1116,7 +1264,9 @@ class Kernel(SingletonConfigurable):
         if isinstance(msg_ids, str):
             msg_ids = [msg_ids]
         if not msg_ids:
-            self._abort_queues()
+            subshell_id = parent["header"].get("subshell_id")
+            self._abort_queues(subshell_id)
+
         for mid in msg_ids:
             self.aborted.add(str(mid))
 
@@ -1153,11 +1303,33 @@ class Kernel(SingletonConfigurable):
 
     _aborting = Bool(False)
 
-    def _abort_queues(self):
+    def _post_dummy_stop_aborting_message(self, subshell_id: str | None) -> None:
+        """Post a dummy message to the correct subshell that when handled will unset
+        the _aborting flag.
+        """
+        subshell_manager = self.shell_channel_thread.manager
+        socket = subshell_manager.get_shell_channel_stream(subshell_id)
+        assert socket is not None
+
+        msg = b"stop aborting"  # Magic string for dummy message.
+        socket.send(msg, copy=False)
+
+    def _abort_queues(self, subshell_id: str | None = None):
         # while this flag is true,
         # execute requests will be aborted
-        self._aborting = True
+
+        if subshell_id is None:
+            self._aborting = True
+        else:
+            self.shell_channel_thread.manager.set_subshell_aborting(subshell_id, True)
         self.log.info("Aborting queue")
+
+        if self.shell_channel_thread:
+            # Only really need to do this if there are messages already queued
+            self.shell_channel_thread.io_loop.add_callback(
+                self._post_dummy_stop_aborting_message, subshell_id
+            )
+            return
 
         # flush streams, so all currently waiting messages
         # are added to the queue
@@ -1387,3 +1559,7 @@ class Kernel(SingletonConfigurable):
                 self.log.debug("%s", self._shutdown_message)
             if self.control_stream:
                 self.control_stream.flush(zmq.POLLOUT)
+
+    @property
+    def _supports_kernel_subshells(self):
+        return self.shell_channel_thread is not None

--- a/ipykernel/shellchannel.py
+++ b/ipykernel/shellchannel.py
@@ -1,0 +1,46 @@
+"""A thread for a shell channel."""
+
+from typing import Any
+
+import zmq
+
+from .subshell_manager import SubshellManager
+from .thread import SHELL_CHANNEL_THREAD_NAME, BaseThread
+
+
+class ShellChannelThread(BaseThread):
+    """A thread for a shell channel.
+
+    Communicates with shell/subshell threads via pairs of ZMQ inproc sockets.
+    """
+
+    def __init__(
+        self,
+        context: zmq.Context[Any],
+        shell_socket: zmq.Socket[Any],
+        **kwargs,
+    ):
+        """Initialize the thread."""
+        super().__init__(name=SHELL_CHANNEL_THREAD_NAME, **kwargs)
+        self._manager: SubshellManager | None = None
+        self._context = context
+        self._shell_socket = shell_socket
+
+    @property
+    def manager(self) -> SubshellManager:
+        # Lazy initialisation.
+        if self._manager is None:
+            self._manager = SubshellManager(
+                self._context,
+                self,
+                self._shell_socket,
+            )
+        return self._manager
+
+    def run(self) -> None:
+        """Run the thread."""
+        try:
+            super().run()
+        finally:
+            if self._manager:
+                self._manager.close()

--- a/ipykernel/subshell.py
+++ b/ipykernel/subshell.py
@@ -1,0 +1,39 @@
+"""A thread for a subshell."""
+
+from typing import Any
+
+import zmq
+from zmq.eventloop.zmqstream import ZMQStream
+
+from .thread import BaseThread
+from .utils import create_inproc_pair_socket
+
+
+class SubshellThread(BaseThread):
+    """A thread for a subshell."""
+
+    def __init__(
+        self,
+        subshell_id: str,
+        context: zmq.Context[Any],
+        **kwargs,
+    ):
+        """Initialize the thread."""
+        super().__init__(name=f"subshell-{subshell_id}", **kwargs)
+
+        shell_channel_socket = create_inproc_pair_socket(context, subshell_id, True)
+        # io_loop will be current io_loop which is of ShellChannelThread
+        self.shell_channel_stream = ZMQStream(shell_channel_socket)
+
+        subshell_socket = create_inproc_pair_socket(context, subshell_id, False)
+        self.subshell_stream = ZMQStream(subshell_socket, self.io_loop)
+
+        # When aborting flag is set, execute_request messages to this subshell will be aborted.
+        self.aborting = False
+
+    def run(self) -> None:
+        try:
+            super().run()
+        finally:
+            self.subshell_stream.close()
+            self.shell_channel_stream.close()

--- a/ipykernel/subshell_manager.py
+++ b/ipykernel/subshell_manager.py
@@ -1,0 +1,233 @@
+"""Manager of subshells in a kernel."""
+from __future__ import annotations
+
+import json
+import typing as t
+import uuid
+from functools import partial
+from threading import Lock, current_thread, main_thread
+
+import zmq
+from zmq.eventloop.zmqstream import ZMQStream
+
+from .subshell import SubshellThread
+from .thread import SHELL_CHANNEL_THREAD_NAME
+from .utils import create_inproc_pair_socket
+
+if t.TYPE_CHECKING:
+    from .shellchannel import ShellChannelThread
+
+
+class SubshellManager:
+    """A manager of subshells.
+
+    Controls the lifetimes of subshell threads and their associated ZMQ sockets and
+    streams. Runs mostly in the shell channel thread.
+
+    Care needed with threadsafe access here.  All write access to the cache occurs in
+    the shell channel thread so there is only ever one write access at any one time.
+    Reading of cache information can be performed by other threads, so all reads are
+    protected by a lock so that they are atomic.
+
+    Sending reply messages via the shell_socket is wrapped by another lock to protect
+    against multiple subshells attempting to send at the same time.
+    """
+
+    def __init__(
+        self,
+        context: zmq.Context[t.Any],
+        shell_channel_thread: ShellChannelThread,
+        shell_socket: zmq.Socket[t.Any],
+    ):
+        assert current_thread() == main_thread()
+
+        self._context: zmq.Context[t.Any] = context
+        self._shell_channel_thread = shell_channel_thread
+        self._shell_socket = shell_socket
+        self._cache: dict[str, SubshellThread] = {}
+        self._lock_cache = Lock()
+        self._lock_shell_socket = Lock()
+
+        # Inproc pair sockets for control channel and main shell (parent subshell).
+        # Each inproc pair has a "shell_channel" socket used in the shell channel
+        # thread, and an "other" socket used in the other thread.
+        control_shell_channel_socket = create_inproc_pair_socket(self._context, "control", True)
+        self._control_shell_channel_stream = ZMQStream(
+            control_shell_channel_socket, self._shell_channel_thread.io_loop
+        )
+        self._control_shell_channel_stream.on_recv(self._process_control_request, copy=True)
+
+        self._control_other_socket = create_inproc_pair_socket(self._context, "control", False)
+
+        parent_shell_channel_socket = create_inproc_pair_socket(self._context, None, True)
+        self._parent_shell_channel_stream = ZMQStream(
+            parent_shell_channel_socket, self._shell_channel_thread.io_loop
+        )
+        self._parent_shell_channel_stream.on_recv(self._send_on_shell_channel, copy=False)
+
+        # Initialised in set_on_recv_callback
+        self._on_recv_callback: t.Any = None  # Callback for ZMQStream.on_recv for "other" sockets.
+        self._parent_other_stream: ZMQStream | None = None
+
+    def close(self) -> None:
+        """Stop all subshells and close all resources."""
+        assert current_thread().name == SHELL_CHANNEL_THREAD_NAME
+        with self._lock_cache:
+            while True:
+                try:
+                    _, subshell_thread = self._cache.popitem()
+                except KeyError:
+                    break
+                self._stop_subshell(subshell_thread)
+
+        for socket_or_stream in (
+            self._control_shell_channel_stream,
+            self._parent_shell_channel_stream,
+            self._parent_other_stream,
+        ):
+            if socket_or_stream is not None:
+                socket_or_stream.close()
+
+        if self._control_other_socket is not None:
+            self._control_other_socket.close()
+
+    def get_control_other_socket(self) -> zmq.Socket[t.Any]:
+        return self._control_other_socket
+
+    def get_other_stream(self, subshell_id: str | None) -> ZMQStream:
+        """Return the other inproc pair socket for a subshell.
+
+        This socket is accessed from the subshell thread.
+        """
+        if subshell_id is None:
+            assert self._parent_other_stream is not None
+            return self._parent_other_stream
+        with self._lock_cache:
+            return self._cache[subshell_id].subshell_stream
+
+    def get_shell_channel_stream(self, subshell_id: str | None) -> ZMQStream:
+        """Return the stream for the shell channel inproc pair socket for a subshell.
+
+        This stream is accessed from the shell channel thread.
+        """
+        if subshell_id is None:
+            return self._parent_shell_channel_stream
+        with self._lock_cache:
+            return self._cache[subshell_id].shell_channel_stream
+
+    def list_subshell(self) -> list[str]:
+        """Return list of current subshell ids.
+
+        Can be called by any subshell using %subshell magic.
+        """
+        with self._lock_cache:
+            return list(self._cache)
+
+    def set_on_recv_callback(self, on_recv_callback):
+        assert current_thread() == main_thread()
+        self._on_recv_callback = on_recv_callback
+        if not self._parent_other_stream:
+            parent_other_socket = create_inproc_pair_socket(self._context, None, False)
+            self._parent_other_stream = ZMQStream(parent_other_socket)
+            self._parent_other_stream.on_recv(
+                partial(self._on_recv_callback, None),
+                copy=False,
+            )
+
+    def set_subshell_aborting(self, subshell_id: str, aborting: bool) -> None:
+        """Set the aborting flag of the specified subshell."""
+        with self._lock_cache:
+            self._cache[subshell_id].aborting = aborting
+
+    def subshell_id_from_thread_id(self, thread_id: int) -> str | None:
+        """Return subshell_id of the specified thread_id.
+
+        Raises RuntimeError if thread_id is not the main shell or a subshell.
+
+        Only used by %subshell magic so does not have to be fast/cached.
+        """
+        with self._lock_cache:
+            if thread_id == main_thread().ident:
+                return None
+            for id, subshell in self._cache.items():
+                if subshell.ident == thread_id:
+                    return id
+            msg = f"Thread id {thread_id!r} does not correspond to a subshell of this kernel"
+            raise RuntimeError(msg)
+
+    def _create_subshell(self) -> str:
+        """Create and start a new subshell thread."""
+        assert current_thread().name == SHELL_CHANNEL_THREAD_NAME
+
+        subshell_id = str(uuid.uuid4())
+        subshell_thread = SubshellThread(subshell_id, self._context)
+
+        with self._lock_cache:
+            assert subshell_id not in self._cache
+            self._cache[subshell_id] = subshell_thread
+
+        subshell_thread.subshell_stream.on_recv(
+            partial(self._on_recv_callback, subshell_id),
+            copy=False,
+        )
+        subshell_thread.shell_channel_stream.on_recv(self._send_on_shell_channel, copy=False)
+
+        subshell_thread.start()
+        return subshell_id
+
+    def _delete_subshell(self, subshell_id: str) -> None:
+        """Delete subshell identified by subshell_id.
+
+        Raises key error if subshell_id not in cache.
+        """
+        assert current_thread().name == SHELL_CHANNEL_THREAD_NAME
+
+        with self._lock_cache:
+            subshell_threwad = self._cache.pop(subshell_id)
+
+        self._stop_subshell(subshell_threwad)
+
+    def _process_control_request(
+        self,
+        request: list[t.Any],
+    ) -> None:
+        """Process a control request message received on the control inproc
+        socket and return the reply.  Runs in the shell channel thread.
+        """
+        assert current_thread().name == SHELL_CHANNEL_THREAD_NAME
+
+        try:
+            decoded = json.loads(request[0])
+            type = decoded["type"]
+            reply: dict[str, t.Any] = {"status": "ok"}
+
+            if type == "create":
+                reply["subshell_id"] = self._create_subshell()
+            elif type == "delete":
+                subshell_id = decoded["subshell_id"]
+                self._delete_subshell(subshell_id)
+            elif type == "list":
+                reply["subshell_id"] = self.list_subshell()
+            else:
+                msg = f"Unrecognised message type {type!r}"
+                raise RuntimeError(msg)
+        except BaseException as err:
+            reply = {
+                "status": "error",
+                "evalue": str(err),
+            }
+
+        self._control_shell_channel_stream.send_json(reply)
+
+    def _send_on_shell_channel(self, msg) -> None:
+        assert current_thread().name == SHELL_CHANNEL_THREAD_NAME
+        with self._lock_shell_socket:
+            self._shell_socket.send_multipart(msg)
+
+    def _stop_subshell(self, subshell_thread: SubshellThread) -> None:
+        """Stop a subshell thread and close all of its resources."""
+        assert current_thread().name == SHELL_CHANNEL_THREAD_NAME
+
+        if subshell_thread.is_alive():
+            subshell_thread.stop()
+            subshell_thread.join()

--- a/ipykernel/thread.py
+++ b/ipykernel/thread.py
@@ -1,0 +1,32 @@
+"""Base class for threads."""
+from threading import Thread
+
+from tornado.ioloop import IOLoop
+
+CONTROL_THREAD_NAME = "Control"
+SHELL_CHANNEL_THREAD_NAME = "Shell channel"
+
+
+class BaseThread(Thread):
+    """Base class for threads."""
+
+    def __init__(self, **kwargs):
+        """Initialize the thread."""
+        super().__init__(**kwargs)
+        self.io_loop = IOLoop(make_current=False)
+        self.pydev_do_not_trace = True
+        self.is_pydev_daemon_thread = True
+
+    def run(self) -> None:
+        """Run the thread."""
+        try:
+            self.io_loop.start()
+        finally:
+            self.io_loop.close()
+
+    def stop(self) -> None:
+        """Stop the thread.
+
+        This method is threadsafe.
+        """
+        self.io_loop.add_callback(self.io_loop.stop)

--- a/ipykernel/utils.py
+++ b/ipykernel/utils.py
@@ -1,0 +1,21 @@
+from typing import Any
+
+import zmq
+
+
+def create_inproc_pair_socket(
+    context: zmq.Context[Any], name: str | None, shell_channel_end: bool
+) -> zmq.Socket[Any]:
+    """Create and return a single ZMQ inproc pair socket."""
+    address = get_inproc_socket_address(name)
+    socket: zmq.Socket[Any] = context.socket(zmq.PAIR)
+    if shell_channel_end:
+        socket.bind(address)
+    else:
+        socket.connect(address)
+    return socket
+
+
+def get_inproc_socket_address(name: str | None) -> str:
+    full_name = f"subshell-{name}" if name else "subshell"
+    return f"inproc://{full_name}"

--- a/tests/test_subshells.py
+++ b/tests/test_subshells.py
@@ -1,0 +1,260 @@
+"""Test kernel subshells."""
+
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License.
+import platform
+import time
+
+import pytest
+from jupyter_client.blocking.client import BlockingKernelClient
+
+from .utils import TIMEOUT, get_replies, get_reply, new_kernel
+
+# Helpers
+
+
+def create_subshell_helper(kc: BlockingKernelClient):
+    msg = kc.session.msg("create_subshell_request")
+    kc.control_channel.send(msg)
+    msg_id = msg["header"]["msg_id"]
+    reply = get_reply(kc, msg_id, TIMEOUT, channel="control")
+    return reply["content"]
+
+
+def delete_subshell_helper(kc: BlockingKernelClient, subshell_id: str):
+    msg = kc.session.msg("delete_subshell_request", {"subshell_id": subshell_id})
+    kc.control_channel.send(msg)
+    msg_id = msg["header"]["msg_id"]
+    reply = get_reply(kc, msg_id, TIMEOUT, channel="control")
+    return reply["content"]
+
+
+def list_subshell_helper(kc: BlockingKernelClient):
+    msg = kc.session.msg("list_subshell_request")
+    kc.control_channel.send(msg)
+    msg_id = msg["header"]["msg_id"]
+    reply = get_reply(kc, msg_id, TIMEOUT, channel="control")
+    return reply["content"]
+
+
+def execute_request(kc: BlockingKernelClient, code: str, subshell_id: str | None):
+    msg = kc.session.msg("execute_request", {"code": code})
+    msg["header"]["subshell_id"] = subshell_id
+    kc.shell_channel.send(msg)
+    return msg
+
+
+def execute_request_subshell_id(
+    kc: BlockingKernelClient, code: str, subshell_id: str | None, terminator: str = "\n"
+):
+    msg = execute_request(kc, code, subshell_id)
+    msg_id = msg["msg_id"]
+    stdout = ""
+    while True:
+        msg = kc.get_iopub_msg()
+        # Get the stream messages corresponding to msg_id
+        if (
+            msg["msg_type"] == "stream"
+            and msg["parent_header"]["msg_id"] == msg_id
+            and msg["content"]["name"] == "stdout"
+        ):
+            stdout += msg["content"]["text"]
+            if stdout.endswith(terminator):
+                break
+    return stdout.strip()
+
+
+def execute_thread_count(kc: BlockingKernelClient) -> int:
+    code = "import threading as t; print(t.active_count())"
+    return int(execute_request_subshell_id(kc, code, None))
+
+
+def execute_thread_ids(kc: BlockingKernelClient, subshell_id: str | None = None) -> tuple[str, str]:
+    code = "import threading as t; print(t.get_ident(), t.main_thread().ident)"
+    return execute_request_subshell_id(kc, code, subshell_id).split()
+
+
+# Tests
+
+
+def test_supported():
+    with new_kernel() as kc:
+        msg_id = kc.kernel_info()
+        reply = get_reply(kc, msg_id, TIMEOUT)
+        assert "supported_features" in reply["content"]
+        assert "kernel subshells" in reply["content"]["supported_features"]
+
+
+def test_subshell_id_lifetime():
+    with new_kernel() as kc:
+        assert list_subshell_helper(kc)["subshell_id"] == []
+        subshell_id = create_subshell_helper(kc)["subshell_id"]
+        assert list_subshell_helper(kc)["subshell_id"] == [subshell_id]
+        delete_subshell_helper(kc, subshell_id)
+        assert list_subshell_helper(kc)["subshell_id"] == []
+
+
+def test_thread_counts():
+    with new_kernel() as kc:
+        nthreads = execute_thread_count(kc)
+
+        subshell_id = create_subshell_helper(kc)["subshell_id"]
+        nthreads2 = execute_thread_count(kc)
+        assert nthreads2 > nthreads
+
+        delete_subshell_helper(kc, subshell_id)
+        nthreads3 = execute_thread_count(kc)
+        assert nthreads3 == nthreads
+
+
+def test_thread_ids():
+    with new_kernel() as kc:
+        subshell_id = create_subshell_helper(kc)["subshell_id"]
+
+        thread_id, main_thread_id = execute_thread_ids(kc)
+        assert thread_id == main_thread_id
+
+        thread_id, main_thread_id = execute_thread_ids(kc, subshell_id)
+        assert thread_id != main_thread_id
+
+        delete_subshell_helper(kc, subshell_id)
+
+
+@pytest.mark.parametrize("are_subshells", [(False, True), (True, False), (True, True)])
+@pytest.mark.parametrize("overlap", [True, False])
+def test_run_concurrently_sequence(are_subshells, overlap, request):
+    if request.config.getvalue("--cov"):
+        pytest.skip("Skip time-sensitive subshell tests if measuring coverage")
+
+    with new_kernel() as kc:
+        subshell_ids = [
+            create_subshell_helper(kc)["subshell_id"] if is_subshell else None
+            for is_subshell in are_subshells
+        ]
+
+        # Import time module before running time-sensitive subshell code
+        # and use threading.Barrier to synchronise start of subshell code.
+        execute_request_subshell_id(
+            kc, "import threading as t, time; b=t.Barrier(2); print('ok')", None
+        )
+
+        sleep = 0.5
+        if overlap:
+            codes = [
+                f"b.wait(); start0=True; end0=False; time.sleep({sleep}); end0=True",
+                f"b.wait(); time.sleep({sleep / 2}); assert start0; assert not end0; time.sleep({sleep}); assert end0",
+            ]
+        else:
+            codes = [
+                f"b.wait(); start0=True; end0=False; time.sleep({sleep}); assert end1",
+                f"b.wait(); time.sleep({sleep / 2}); assert start0; assert not end0; end1=True",
+            ]
+
+        msgs = []
+        for subshell_id, code in zip(subshell_ids, codes):
+            msg = kc.session.msg("execute_request", {"code": code})
+            msg["header"]["subshell_id"] = subshell_id
+            kc.shell_channel.send(msg)
+            msgs.append(msg)
+
+        replies = get_replies(kc, [msg["msg_id"] for msg in msgs])
+
+        for subshell_id in subshell_ids:
+            if subshell_id:
+                delete_subshell_helper(kc, subshell_id)
+
+        for reply in replies:
+            assert reply["content"]["status"] == "ok", reply
+
+
+def test_create_while_execute():
+    with new_kernel() as kc:
+        # Send request to execute code on main subshell.
+        msg = kc.session.msg("execute_request", {"code": "import time; time.sleep(0.05)"})
+        kc.shell_channel.send(msg)
+
+        # Create subshell via control channel.
+        control_msg = kc.session.msg("create_subshell_request")
+        kc.control_channel.send(control_msg)
+        control_reply = get_reply(kc, control_msg["header"]["msg_id"], TIMEOUT, channel="control")
+        subshell_id = control_reply["content"]["subshell_id"]
+        control_date = control_reply["header"]["date"]
+
+        # Get result message from main subshell.
+        shell_date = get_reply(kc, msg["msg_id"])["header"]["date"]
+
+        delete_subshell_helper(kc, subshell_id)
+
+        assert control_date < shell_date
+
+
+@pytest.mark.skipif(
+    platform.python_implementation() == "PyPy",
+    reason="does not work on PyPy",
+)
+def test_shutdown_with_subshell():
+    # Based on test_kernel.py::test_shutdown
+    with new_kernel() as kc:
+        km = kc.parent
+        subshell_id = create_subshell_helper(kc)["subshell_id"]
+        assert list_subshell_helper(kc)["subshell_id"] == [subshell_id]
+        kc.shutdown()
+        for _ in range(100):  # 10 s timeout
+            if km.is_alive():
+                time.sleep(0.1)
+            else:
+                break
+        assert not km.is_alive()
+
+
+@pytest.mark.parametrize("are_subshells", [(False, True)])
+def test_execute_stop_on_error(are_subshells):
+    # Based on test_message_spec.py::test_execute_stop_on_error, testing that exception
+    # in one subshell aborts execution queue in that subshell but not others.
+    with new_kernel() as kc:
+        subshell_ids = [
+            create_subshell_helper(kc)["subshell_id"] if is_subshell else None
+            for is_subshell in are_subshells
+        ]
+
+        msg_ids = []
+
+        # msg = execute_request(kc, "print('ok')", subshell_ids[0])
+        msg = execute_request(
+            kc, "import asyncio; await asyncio.sleep(1); raise ValueError()", subshell_ids[0]
+        )
+        msg_ids.append(msg["msg_id"])
+        msg = execute_request(kc, "print('hello')", subshell_ids[0])
+        msg_ids.append(msg["msg_id"])
+        msg = execute_request(kc, "print('goodbye')", subshell_ids[0])
+        msg_ids.append(msg["msg_id"])
+
+        msg = execute_request(kc, "import time; time.sleep(1.5)", subshell_ids[1])
+        msg_ids.append(msg["msg_id"])
+        msg = execute_request(kc, "print('other')", subshell_ids[1])
+        msg_ids.append(msg["msg_id"])
+
+        replies = get_replies(kc, msg_ids)
+
+        assert replies[0]["parent_header"]["subshell_id"] == subshell_ids[0]
+        assert replies[1]["parent_header"]["subshell_id"] == subshell_ids[0]
+        assert replies[2]["parent_header"]["subshell_id"] == subshell_ids[0]
+        assert replies[3]["parent_header"]["subshell_id"] == subshell_ids[1]
+        assert replies[4]["parent_header"]["subshell_id"] == subshell_ids[1]
+
+        assert replies[0]["content"]["status"] == "error"
+        assert replies[1]["content"]["status"] == "aborted"
+        assert replies[2]["content"]["status"] == "aborted"
+        assert replies[3]["content"]["status"] == "ok"
+        assert replies[4]["content"]["status"] == "ok"
+
+        # Check abort is cleared.
+        msg = execute_request(kc, "print('check')", subshell_ids[0])
+        reply = get_reply(kc, msg["msg_id"])
+        assert reply["parent_header"]["subshell_id"] == subshell_ids[0]
+        assert reply["content"]["status"] == "ok"
+
+        # Cleanup
+        for subshell_id in subshell_ids:
+            if subshell_id:
+                delete_subshell_helper(kc, subshell_id)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -62,6 +62,28 @@ def get_reply(kc, msg_id, timeout=TIMEOUT, channel="shell"):
     return reply
 
 
+def get_replies(kc, msg_ids: list[str], timeout=TIMEOUT, channel="shell"):
+    # Get replies which may arrive in any order as they may be running on different subshells.
+    # Replies are returned in the same order as the msg_ids, not in the order of arrival.
+    t0 = time()
+    count = 0
+    replies = [None] * len(msg_ids)
+    while count < len(msg_ids):
+        get_msg = getattr(kc, f"get_{channel}_msg")
+        reply = get_msg(timeout=timeout)
+        try:
+            msg_id = reply["parent_header"]["msg_id"]
+            replies[msg_ids.index(msg_id)] = reply
+            count += 1
+        except ValueError:
+            # Allow debugging ignored replies
+            print(f"Ignoring reply not to any of {msg_ids}: {reply}")
+        t1 = time()
+        timeout -= t1 - t0
+        t0 = t1
+    return replies
+
+
 def execute(code="", kc=None, **kwargs):
     """wrapper for doing common steps for validating an execution request"""
     from .test_message_spec import validate_message


### PR DESCRIPTION
This is an implementation of subshells on the `6.x` branch, as highlighted in #1387.

It is based on the implementation on the `main` branch except that it is built on the existing tornado io_loops rather than `anyio`. The architecture of classes, threads and zmq sockets is the same, with pairs of sockets used for communication between threads. The implementation is simpler as rather than using `anyio` tasks and task queues, we use `ZMQStream`s which call an `on_recv` callback whenever a message is received on the contained socket.

From other projects' point of the view the major change here is not subshells, which don't have to be used, but it is the addition of a new thread to receive messages on the shell channel, which are routed to the appropriate subshell (or main shell thread). This makes it more responsive, and could potentially cause different behaviour in downstream projects depending on how it is used.

Although this is based on the `6.x` branch there has been some discussion about whether this might be released as `6.30.0` or as `7.0.0`.

This passes CI for me locally on both linux and macOS, we'll have to see what problems arise in CI. 