### PR TITLE
Backports from `anyio` (old `main`) branch to `main` branch

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,32 @@
+name: nightly build and upload
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+
+defaults:
+  run:
+    shell: bash -eux {0}
+
+jobs:
+  build:
+    runs-on: "ubuntu-latest"
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.12"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Base Setup
+        uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+
+      - name: Build
+        run: |
+          python -m build
+      - name: Upload wheel
+        uses: scientific-python/upload-nightly-action@82396a2ed4269ba06c6b2988bb4fd568ef3c3d6b # 0.6.1
+        with:
+          artifacts_path: dist
+          anaconda_nightly_upload_token: ${{secrets.UPLOAD_TOKEN}}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -24,6 +24,7 @@ jobs:
 
       - name: Build
         run: |
+          python -m pip install build
           python -m build
       - name: Upload wheel
         uses: scientific-python/upload-nightly-action@82396a2ed4269ba06c6b2988bb4fd568ef3c3d6b # 0.6.1

--- a/examples/embedding/inprocess_qtconsole.py
+++ b/examples/embedding/inprocess_qtconsole.py
@@ -1,11 +1,12 @@
 """An in-process qt console app."""
 import os
-import sys
 
 import tornado
 from IPython.lib import guisupport
 from qtconsole.inprocess import QtInProcessKernelManager
 from qtconsole.rich_ipython_widget import RichIPythonWidget
+
+assert tornado.version_info >= (6, 1)
 
 
 def print_process_id():
@@ -13,42 +14,11 @@ def print_process_id():
     print("Process ID is:", os.getpid())
 
 
-def init_asyncio_patch():
-    """set default asyncio policy to be compatible with tornado
-    Tornado 6 (at least) is not compatible with the default
-    asyncio implementation on Windows
-    Pick the older SelectorEventLoopPolicy on Windows
-    if the known-incompatible default policy is in use.
-    do this as early as possible to make it a low priority and overridable
-    ref: https://github.com/tornadoweb/tornado/issues/2608
-    FIXME: if/when tornado supports the defaults in asyncio,
-           remove and bump tornado requirement for py38
-    """
-    if (
-        sys.platform.startswith("win")
-        and sys.version_info >= (3, 8)
-        and tornado.version_info < (6, 1)
-    ):
-        import asyncio
-
-        try:
-            from asyncio import WindowsProactorEventLoopPolicy, WindowsSelectorEventLoopPolicy
-        except ImportError:
-            pass
-            # not affected
-        else:
-            if type(asyncio.get_event_loop_policy()) is WindowsProactorEventLoopPolicy:
-                # WindowsProactorEventLoopPolicy is not compatible with tornado 6
-                # fallback to the pre-3.8 default of Selector
-                asyncio.set_event_loop_policy(WindowsSelectorEventLoopPolicy())
-
-
 def main():
     """The main entry point."""
     # Print the ID of the main process
     print_process_id()
 
-    init_asyncio_patch()
     app = guisupport.get_app_qt4()
 
     # Create an in-process kernel

--- a/ipykernel/inprocess/ipkernel.py
+++ b/ipykernel/inprocess/ipkernel.py
@@ -91,8 +91,10 @@ class InProcessKernel(IPythonKernel):
     def _input_request(self, prompt, ident, parent, password=False):
         # Flush output before making the request.
         self.raw_input_str = None
-        sys.stderr.flush()
-        sys.stdout.flush()
+        if sys.stdout is not None:
+            sys.stdout.flush()
+        if sys.stderr is not None:
+            sys.stderr.flush()
 
         # Send the input request.
         content = json_clean(dict(prompt=prompt, password=password))

--- a/ipykernel/kernelapp.py
+++ b/ipykernel/kernelapp.py
@@ -666,7 +666,7 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp, ConnectionFileMix
                where asyncio.ProactorEventLoop supports add_reader and friends.
 
         """
-        if sys.platform.startswith("win") and sys.version_info >= (3, 8):
+        if sys.platform.startswith("win"):
             import asyncio
 
             try:

--- a/ipykernel/kernelapp.py
+++ b/ipykernel/kernelapp.py
@@ -220,7 +220,7 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp, ConnectionFileMix
             # PID 1 (init) is special and will never go away,
             # only be reassigned.
             # Parent polling doesn't work if ppid == 1 to start with.
-            self.poller = ParentPollerUnix()
+            self.poller = ParentPollerUnix(parent_pid=self.parent_handle)
 
     def _try_bind_socket(self, s, port):
         iface = f"{self.transport}://{self.ip}"

--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -333,8 +333,10 @@ class Kernel(SingletonConfigurable):
             except Exception:
                 self.log.error("Exception in control handler:", exc_info=True)  # noqa: G201
 
-        sys.stdout.flush()
-        sys.stderr.flush()
+        if sys.stdout is not None:
+            sys.stdout.flush()
+        if sys.stderr is not None:
+            sys.stderr.flush()
         self._publish_status_and_flush("idle", "control", self.control_stream)
 
     def should_handle(self, stream, msg, idents):
@@ -438,8 +440,10 @@ class Kernel(SingletonConfigurable):
                 except Exception:
                     self.log.debug("Unable to signal in post_handler_hook:", exc_info=True)
 
-        sys.stdout.flush()
-        sys.stderr.flush()
+        if sys.stdout is not None:
+            sys.stdout.flush()
+        if sys.stderr is not None:
+            sys.stderr.flush()
         self._publish_status_and_flush("idle", "shell", stream)
 
     def pre_handler_hook(self):
@@ -844,8 +848,10 @@ class Kernel(SingletonConfigurable):
             reply_content = await reply_content
 
         # Flush output before sending the reply.
-        sys.stdout.flush()
-        sys.stderr.flush()
+        if sys.stdout is not None:
+            sys.stdout.flush()
+        if sys.stderr is not None:
+            sys.stderr.flush()
         # FIXME: on rare occasions, the flush doesn't seem to make it to the
         # clients... This seems to mitigate the problem, but we definitely need
         # to better understand what's going on.
@@ -1242,8 +1248,10 @@ class Kernel(SingletonConfigurable):
         reply_content, result_buf = self.do_apply(content, bufs, msg_id, md)
 
         # flush i/o
-        sys.stdout.flush()
-        sys.stderr.flush()
+        if sys.stdout is not None:
+            sys.stdout.flush()
+        if sys.stderr is not None:
+            sys.stderr.flush()
 
         md = self.finish_metadata(parent, md, reply_content)
         if not self.session:
@@ -1441,8 +1449,10 @@ class Kernel(SingletonConfigurable):
 
     def _input_request(self, prompt, ident, parent, password=False):
         # Flush output before making the request.
-        sys.stderr.flush()
-        sys.stdout.flush()
+        if sys.stdout is not None:
+            sys.stdout.flush()
+        if sys.stderr is not None:
+            sys.stderr.flush()
 
         # flush the stdin socket, to purge stale replies
         while True:

--- a/tests/test_eventloop.py
+++ b/tests/test_eventloop.py
@@ -7,7 +7,6 @@ import threading
 import time
 
 import pytest
-import tornado
 
 from ipykernel.eventloops import (
     enable_gui,
@@ -16,7 +15,7 @@ from ipykernel.eventloops import (
     loop_tk,
 )
 
-from .utils import execute, flush_channels, start_new_kernel
+from .utils import flush_channels, start_new_kernel
 
 KC = KM = None
 
@@ -59,25 +58,6 @@ async_code = """
 from tests._asyncio_utils import async_func
 async_func()
 """
-
-
-@pytest.mark.skipif(tornado.version_info < (5,), reason="only relevant on tornado 5")
-def test_asyncio_interrupt():
-    assert KM is not None
-    assert KC is not None
-    flush_channels(KC)
-    msg_id, content = execute("%gui asyncio", KC)
-    assert content["status"] == "ok", content
-
-    flush_channels(KC)
-    msg_id, content = execute(async_code, KC)
-    assert content["status"] == "ok", content
-
-    KM.interrupt_kernel()
-
-    flush_channels(KC)
-    msg_id, content = execute(async_code, KC)
-    assert content["status"] == "ok"
 
 
 windows_skip = pytest.mark.skipif(os.name == "nt", reason="causing failures on windows")

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -212,7 +212,7 @@ def test_sys_path_profile_dir():
 
 @flaky(max_runs=3)
 @pytest.mark.skipif(
-    sys.platform == "win32" or (sys.platform == "darwin" and sys.version_info >= (3, 8)),
+    sys.platform == "win32" or (sys.platform == "darwin"),
     reason="subprocess prints fail on Windows and MacOS Python 3.8+",
 )
 def test_subprocess_print():
@@ -267,7 +267,7 @@ def test_subprocess_noprint():
 
 @flaky(max_runs=3)
 @pytest.mark.skipif(
-    sys.platform == "win32" or (sys.platform == "darwin" and sys.version_info >= (3, 8)),
+    (sys.platform == "win32") or (sys.platform == "darwin"),
     reason="subprocess prints fail on Windows and MacOS Python 3.8+",
 )
 def test_subprocess_error():

--- a/tests/test_kernel_direct.py
+++ b/tests/test_kernel_direct.py
@@ -130,8 +130,7 @@ async def test_process_control(kernel):
 
 def test_should_handle(kernel):
     msg = kernel.session.msg("debug_request", {})
-    kernel.aborted.add(msg["header"]["msg_id"])
-    assert not kernel.should_handle(kernel.control_stream, msg, [])
+    assert kernel.should_handle(kernel.control_stream, msg, []) is True
 
 
 async def test_dispatch_shell(kernel):


### PR DESCRIPTION
Backports cherry-picked from `anyio` (old `main`) branch to `main` branch:

- #1247
- #1271
- #1276
- #1273
- #1282
-