### PR TITLE
Replace `@flaky.flaky` decorate with pytest fixture

### DIFF
--- a/tests/inprocess/test_kernelmanager.py
+++ b/tests/inprocess/test_kernelmanager.py
@@ -4,7 +4,6 @@
 import unittest
 
 import pytest
-from flaky import flaky
 
 from ipykernel.inprocess.manager import InProcessKernelManager
 
@@ -21,7 +20,7 @@ class InProcessKernelManagerTestCase(unittest.TestCase):
         if self.km.has_kernel:
             self.km.shutdown_kernel()
 
-    @flaky
+    @pytest.mark.flaky
     def test_interface(self):
         """Does the in-process kernel manager implement the basic KM interface?"""
         km = self.km

--- a/tests/test_embed_kernel.py
+++ b/tests/test_embed_kernel.py
@@ -12,7 +12,6 @@ from contextlib import contextmanager
 from subprocess import PIPE, Popen
 
 import pytest
-from flaky import flaky
 from jupyter_client.blocking.client import BlockingKernelClient
 from jupyter_core import paths
 
@@ -91,7 +90,7 @@ def setup_kernel(cmd):
                 fid.close()
 
 
-@flaky(max_runs=3)
+@pytest.mark.flaky(max_runs=3)
 def test_embed_kernel_basic():
     """IPython.embed_kernel() is basically functional"""
     cmd = "\n".join(
@@ -127,7 +126,7 @@ def test_embed_kernel_basic():
         assert "10" in text
 
 
-@flaky(max_runs=3)
+@pytest.mark.flaky(max_runs=3)
 def test_embed_kernel_namespace():
     """IPython.embed_kernel() inherits calling namespace"""
     cmd = "\n".join(
@@ -166,7 +165,7 @@ def test_embed_kernel_namespace():
         assert not content["found"]
 
 
-@flaky(max_runs=3)
+@pytest.mark.flaky(max_runs=3)
 def test_embed_kernel_reentrant():
     """IPython.embed_kernel() can be called multiple times"""
     cmd = "\n".join(

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -17,7 +17,6 @@ from tempfile import TemporaryDirectory
 import IPython
 import psutil
 import pytest
-from flaky import flaky
 from IPython.paths import locate_profile
 
 from .utils import (
@@ -212,7 +211,7 @@ def test_sys_path_profile_dir():
     assert "" in sys_path
 
 
-@flaky(max_runs=3)
+@pytest.mark.flaky(max_runs=3)
 @pytest.mark.skipif(
     sys.platform == "win32" or (sys.platform == "darwin"),
     reason="subprocess prints fail on Windows and MacOS Python 3.8+",
@@ -244,7 +243,7 @@ def test_subprocess_print():
         _check_master(kc, expected=True, stream="stderr")
 
 
-@flaky(max_runs=3)
+@pytest.mark.flaky(max_runs=3)
 def test_subprocess_noprint():
     """mp.Process without print doesn't trigger iostream mp_mode"""
     with kernel() as kc:
@@ -267,7 +266,7 @@ def test_subprocess_noprint():
         _check_master(kc, expected=True, stream="stderr")
 
 
-@flaky(max_runs=3)
+@pytest.mark.flaky(max_runs=3)
 @pytest.mark.skipif(
     (sys.platform == "win32") or (sys.platform == "darwin"),
     reason="subprocess prints fail on Windows and MacOS Python 3.8+",

--- a/tests/test_start_kernel.py
+++ b/tests/test_start_kernel.py
@@ -2,7 +2,6 @@ import os
 from textwrap import dedent
 
 import pytest
-from flaky import flaky
 
 from .test_embed_kernel import setup_kernel
 
@@ -12,7 +11,7 @@ if os.name == "nt":
     pytest.skip("skipping tests on windows", allow_module_level=True)
 
 
-@flaky(max_runs=3)
+@pytest.mark.flaky(max_runs=3)
 def test_ipython_start_kernel_userns():
     import IPython
 
@@ -51,7 +50,7 @@ def test_ipython_start_kernel_userns():
         assert EXPECTED in text
 
 
-@flaky(max_runs=3)
+@pytest.mark.flaky(max_runs=3)
 def test_ipython_start_kernel_no_userns():
     # Issue #4188 - user_ns should be passed to shell as None, not {}
     cmd = dedent(


### PR DESCRIPTION
Use the `@pytest.mark.flaky` fixture in place of the `@flaky.flaky` decorator, to modernize the code and improve compatibility with other plugins providing the feature such as `pytest-rerunfailures`.

Fixes #1410