### PR TITLE
Cache separate headers on subshell threads

### DIFF
--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -16,6 +16,7 @@ import time
 import typing as t
 import uuid
 import warnings
+from contextvars import ContextVar
 from datetime import datetime
 from functools import partial
 from signal import SIGINT, SIGTERM, Signals, default_int_handler, signal
@@ -194,8 +195,10 @@ class Kernel(SingletonConfigurable):
 
     # track associations with current request
     _allow_stdin = Bool(False)
-    _parents: Dict[str, t.Any] = Dict({"shell": {}, "control": {}})
-    _parent_ident = Dict({"shell": b"", "control": b""})
+    _control_parent: Dict[str, t.Any] = Dict({})
+    _control_parent_ident: bytes = b""
+    _shell_parent: ContextVar[dict[str, Any]]
+    _shell_parent_ident: ContextVar[bytes]
 
     @property
     def _parent_header(self):
@@ -298,6 +301,14 @@ class Kernel(SingletonConfigurable):
         self._do_exec_accepted_params = _accepts_parameters(
             self.do_execute, ["cell_meta", "cell_id"]
         )
+
+        self._control_parent = {}
+        self._control_parent_ident = b""
+
+        self._shell_parent = ContextVar("shell_parent")
+        self._shell_parent.set({})
+        self._shell_parent_ident = ContextVar("shell_parent_ident")
+        self._shell_parent_ident.set(b"")
 
     async def dispatch_control(self, msg):
         """Dispatch a control request, ensuring only one message is processed at a time."""
@@ -721,8 +732,12 @@ class Kernel(SingletonConfigurable):
         The parent identity is used to route input_request messages
         on the stdin channel.
         """
-        self._parent_ident[channel] = ident
-        self._parents[channel] = parent
+        if channel == "control":
+            self._control_parent_ident = ident
+            self._control_parent = parent
+        else:
+            self._shell_parent_ident.set(ident)
+            self._shell_parent.set(parent)
 
     def get_parent(self, channel=None):
         """Get the parent request associated with a channel.
@@ -747,7 +762,9 @@ class Kernel(SingletonConfigurable):
             else:
                 channel = "shell"
 
-        return self._parents.get(channel, {})
+        if channel == "control":
+            return self._control_parent
+        return self._shell_parent.get()
 
     def send_response(
         self,
@@ -1408,7 +1425,7 @@ class Kernel(SingletonConfigurable):
             )
         return self._input_request(
             prompt,
-            self._parent_ident["shell"],
+            self._shell_parent_ident.get(),
             self.get_parent("shell"),
             password=True,
         )
@@ -1425,7 +1442,7 @@ class Kernel(SingletonConfigurable):
             raise StdinNotImplementedError(msg)
         return self._input_request(
             str(prompt),
-            self._parent_ident["shell"],
+            self._shell_parent_ident.get(),
             self.get_parent("shell"),
             password=False,
         )


### PR DESCRIPTION
This fixes a bug in the caching of received message headers at various places in the code which are later used for reply or iopub messages. The existing code on `main` branch assumes that the shell processes a single request at a time so that the cached header is valid until that request is replied to, but now of course there can be multiple subshells in different threads executing code concurrently.

The solution is to cache a different header per subshell, or to be more precise a different header per thread. This is accomplished using a [ContextVar](https://docs.python.org/3/library/contextvars.html) which is essentially thread-local storage that also supports asynchronous execution.  We are already using a `ContextVar` at https://github.com/ipython/ipykernel/blob/4c218005f790057f44a2af0be29d33018572490a/ipykernel/iostream.py#L454
so it is already a dependency of `ipykernel`.

I found this whilst debugging use of `ipympl` in `jupyterlab`, trying to create multiple `matplotlib` plots using the option of one subshell per comm-target (the default option). The best way to view this bug is to use [kernelspy](https://github.com/jupyterlab-contrib/jupyterlab-kernelspy) as it shows that in this scenerio some messages (e.g. some idle status messages) have the wrong parent header and are therefore displayed in the wrong section of the `kernelspy` output.

All new `parent_header` attributes are private (leading underscore). Where they were previously public I have added a public `parent_header` getter to extract the appropriate value from the `ContextVar` so that downstream libraries that have been reading the `parent_header` in the main shelll should have the same functionality as before.