### PR TITLE
Use correct `__version__` on `main` branch after branch manipulations

### DIFF
--- a/ipykernel/_version.py
+++ b/ipykernel/_version.py
@@ -5,7 +5,7 @@ store the current version info of the server.
 import re
 
 # Version string must appear intact for hatch versioning
-__version__ = "6.30.0a0"
+__version__ = "7.0.0a1"
 
 # Build up version_info tuple for backwards compatibility
 pattern = r"(?P<major>\d+).(?P<minor>\d+).(?P<patch>\d+)(?P<rest>.*)"


### PR DESCRIPTION
After the branch manipulations a few weeks ago, we need to update the `__version__` to be the latest in the `7.x` series not `6.x` series.

Fixes ipython/ipython#14953.