### PR TITLE
Reinstate jupyter_client downstream tests with exclusions

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -41,7 +41,6 @@ jobs:
           test_command: pytest -vv -raXxs -W default --durations 10 --color=yes
 
   jupyter_client:
-    if: false
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -54,6 +53,7 @@ jobs:
         uses: jupyterlab/maintainer-tools/.github/actions/downstream-test@v1
         with:
           package_name: jupyter_client
+          test_command: "pytest -vv -raXxs -W default --durations 10 --color=yes"
 
   ipyparallel:
     if: false

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -53,7 +53,7 @@ jobs:
         uses: jupyterlab/maintainer-tools/.github/actions/downstream-test@v1
         with:
           package_name: jupyter_client
-          test_command: "pytest -vv -raXxs -W default --durations 10 --color=yes"
+          test_command: "pytest -vv -raXxs -W default --durations 10 --color=yes -k 'not test_input_request'"
 
   ipyparallel:
     if: false

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -53,7 +53,7 @@ jobs:
         uses: jupyterlab/maintainer-tools/.github/actions/downstream-test@v1
         with:
           package_name: jupyter_client
-          test_command: "pytest -vv -raXxs -W default --durations 10 --color=yes -k 'not test_input_request'"
+          test_command: "pytest -vv -raXxs -W default --durations 10 --color=yes -k 'not (test_input_request or signal_kernel_subprocess)'"
 
   ipyparallel:
     if: false


### PR DESCRIPTION
Try reinstating the `jupyter_client` downstream tests but with exclusions, until the appropriate PRs are merged downstream - see #1422.