### PR TITLE
Reinstate ipyparallel downstream tests

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -56,7 +56,6 @@ jobs:
           test_command: "pytest -vv -raXxs -W default --durations 10 --color=yes -k 'not (test_input_request or signal_kernel_subprocess)'"
 
   ipyparallel:
-    if: false
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:


### PR DESCRIPTION
With the merging of ipython/ipyparallel#947 into the `ipyparallel` `main` branch,, we can re-enable the downstream `ipyparallel` tests here.