### PR TITLE
Continue to support `Kernel._parent_ident` for backward compatibility

### DIFF
--- a/docs/api/ipykernel.rst
+++ b/docs/api/ipykernel.rst
@@ -146,12 +146,6 @@ Submodules
    :show-inheritance:
 
 
-.. automodule:: ipykernel.utils
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-
 .. automodule:: ipykernel.zmqshell
    :members:
    :undoc-members:

--- a/docs/api/ipykernel.rst
+++ b/docs/api/ipykernel.rst
@@ -146,6 +146,12 @@ Submodules
    :show-inheritance:
 
 
+.. automodule:: ipykernel.utils
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
 .. automodule:: ipykernel.zmqshell
    :members:
    :undoc-members:

--- a/ipykernel/utils.py
+++ b/ipykernel/utils.py
@@ -1,0 +1,26 @@
+"""Utilities"""
+
+import typing as t
+from collections.abc import Mapping
+
+
+class LazyDict(Mapping[str, t.Any]):
+    """Lazy evaluated read-only dictionary.
+
+    Initialised with a dictionary of key-value pairs where the values are either
+    constants or callables. Callables are evaluated each time the respective item is
+    read.
+    """
+
+    def __init__(self, dict):
+        self._dict = dict
+
+    def __getitem__(self, key):
+        item = self._dict.get(key)
+        return item() if callable(item) else item
+
+    def __len__(self):
+        return len(self._dict)
+
+    def __iter__(self):
+        return iter(self._dict)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ path = "ipykernel/_version.py"
 features = ["docs"]
 [tool.hatch.envs.docs.scripts]
 build = "make -C docs html SPHINXOPTS='-W'"
-api = "sphinx-apidoc -o docs/api -f -E ipykernel tests ipykernel/datapub.py ipykernel/pickleutil.py ipykernel/serialize.py ipykernel/gui ipykernel/pylab"
+api = "sphinx-apidoc -o docs/api -f -E ipykernel tests ipykernel/datapub.py ipykernel/pickleutil.py ipykernel/serialize.py ipykernel/gui ipykernel/pylab ipykernel/utils.py"
 
 [tool.hatch.envs.test]
 features = ["test"]


### PR DESCRIPTION
PR #1414 replaced the private member variable `Kernel._parent_ident` with threadsafe support of separate parent idents per thread (subshell) using `ContextVar`s. This caused a failure downstream in JupyterLab (jupyterlab/jupyterlab#17785) as it reads the private `_parent_ident`. Upon investigation there are a number of downstream projects that read this variable, presumably due to copy-paste-modify of `ipykernel` code to override the behaviour. So rather than break those projects, here I am reintroducing `Kernel._parent_ident` as a shim for backward compatibility that can be called the same way as before. It uses a lazy-evaluated read-only dictionary.

I have also added a new test to check that `Kernel.get_parent` and `Kernel._parent_ident` perform as expected.