### PR TITLE
Always use ZMQ stream not socket in dispatch_shell

### DIFF
--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -418,7 +418,7 @@ class Kernel(SingletonConfigurable):
         assert msg["header"].get("subshell_id") == subshell_id
 
         if self._supports_kernel_subshells:
-            stream = self.shell_channel_thread.manager.get_subshell_to_shell_channel_socket(
+            stream = self.shell_channel_thread.manager.get_subshell_to_shell_channel_stream(
                 subshell_id
             )
         else:

--- a/ipykernel/subshell.py
+++ b/ipykernel/subshell.py
@@ -24,7 +24,7 @@ class SubshellThread(BaseThread):
         super().__init__(name=f"subshell-{subshell_id}", **kwargs)
 
         self.shell_channel_to_subshell = SocketPair(context, subshell_id)
-        self.subshell_to_shell_channel = SocketPair(context, subshell_id + "-reverse")
+        self.subshell_to_shell_channel = SocketPair(context, subshell_id + "-reverse", self.io_loop)
 
         # When aborting flag is set, execute_request messages to this subshell will be aborted.
         self.aborting = False


### PR DESCRIPTION
Currently using a ZMQ socket not stream here:
https://github.com/ipython/ipykernel/blob/39d4c74a7eda3029b2c1bb3533c724f6b8f8f494/ipykernel/kernelbase.py#L421

which can cause problems downstream (e.g. in `qtconsole`, `jupyterlab`) when a stream is expected rather than a socket. So here switching to using a stream. This uses an optional `SocketPair.from_stream` which is only used for the main/subshell to shell channel socket pairs.