### PR TITLE
Manually reset interrupt evemt

### DIFF
--- a/ipykernel/parentpoller.py
+++ b/ipykernel/parentpoller.py
@@ -121,6 +121,7 @@ class ParentPollerWindows(Thread):
 
             if WAIT_OBJECT_0 <= result < len(handles):
                 handle = handles[result - WAIT_OBJECT_0]
+                ctypes.windll.kernel32.ResetEvent(handle)  # type:ignore[attr-defined]
 
                 if handle == self.interrupt_handle:
                     # check if signal handler is callable


### PR DESCRIPTION
Manually reset interrupt event at the receiver end rather than relying on auto reset. This makes it possible for other waiting receivers to be signaled.
In particular, C Python modules running on Windows on a Jupyter Kernel can be interrupted via "Interrupt kernel" without requiring to send the "Interrupt kernel" signal twice as currently happens (see more detailed description in the PR to the `jupyter_client repo).