### PR TITLE
Store display outputs in history for `%notebook` magic

### DIFF
--- a/ipykernel/zmqshell.py
+++ b/ipykernel/zmqshell.py
@@ -35,7 +35,7 @@ from IPython.utils import openpy
 from IPython.utils.process import arg_split, system  # type:ignore[attr-defined]
 from jupyter_client.session import Session, extract_header
 from jupyter_core.paths import jupyter_runtime_dir
-from traitlets import Any, CBool, CBytes, Instance, Type, default, observe
+from traitlets import Any, CBool, CBytes, Instance, default, observe
 
 from ipykernel import connect_qtconsole, get_connection_file, get_connection_info
 from ipykernel.displayhook import ZMQShellDisplayHook
@@ -44,7 +44,7 @@ from ipykernel.jsonutil import encode_images, json_clean
 try:
     from IPython.core.history import HistoryOutput
 except ImportError:
-    HistoryOutput = None  # type: ignore[assignment]
+    HistoryOutput: type | None = None
 
 # -----------------------------------------------------------------------------
 # Functions and classes
@@ -517,8 +517,8 @@ class ZMQInteractiveShell(InteractiveShell):
         self._parent_header = contextvars.ContextVar("parent_header")
         self._parent_header.set({})
 
-    displayhook_class = Type(ZMQShellDisplayHook)
-    display_pub_class = Type(ZMQDisplayPublisher)
+    displayhook_class = type(ZMQShellDisplayHook)
+    display_pub_class = type(ZMQDisplayPublisher)
     data_pub_class = Any()
     kernel = Any()
     _parent_header: contextvars.ContextVar[dict[str, Any]]

--- a/ipykernel/zmqshell.py
+++ b/ipykernel/zmqshell.py
@@ -26,11 +26,11 @@ from IPython.core import page
 from IPython.core.autocall import ZMQExitAutocall
 from IPython.core.displaypub import DisplayPublisher
 from IPython.core.error import UsageError
+from IPython.core.history import HistoryOutput
 from IPython.core.interactiveshell import InteractiveShell, InteractiveShellABC
 from IPython.core.magic import Magics, line_magic, magics_class
 from IPython.core.magics import CodeMagics, MacroToEdit  # type:ignore[attr-defined]
 from IPython.core.usage import default_banner
-from IPython.core.history import HistoryOutput
 from IPython.display import Javascript, display
 from IPython.utils import openpy
 from IPython.utils.process import arg_split, system  # type:ignore[attr-defined]
@@ -116,7 +116,7 @@ class ZMQDisplayPublisher(DisplayPublisher):
         update : bool, optional, keyword-only
             If True, send an update_display_data message instead of display_data.
         """
-        if self.shell is not None and hasattr(self.shell, 'history_manager'):
+        if self.shell is not None and hasattr(self.shell, "history_manager"):
             outputs = self.shell.history_manager.outputs
             outputs[self.shell.execution_count].append(
                 HistoryOutput(output_type="display_data", bundle=data)

--- a/ipykernel/zmqshell.py
+++ b/ipykernel/zmqshell.py
@@ -22,7 +22,7 @@ import typing
 import warnings
 from pathlib import Path
 
-from IPython.core import page, version_info
+from IPython.core import page
 from IPython.core.autocall import ZMQExitAutocall
 from IPython.core.displaypub import DisplayPublisher
 from IPython.core.error import UsageError
@@ -41,9 +41,9 @@ from ipykernel import connect_qtconsole, get_connection_file, get_connection_inf
 from ipykernel.displayhook import ZMQShellDisplayHook
 from ipykernel.jsonutil import encode_images, json_clean
 
-if version_info >= (9, 1, 0):
+try:
     from IPython.core.history import HistoryOutput
-else:
+except ImportError:
     HistoryOutput = None
 
 # -----------------------------------------------------------------------------

--- a/ipykernel/zmqshell.py
+++ b/ipykernel/zmqshell.py
@@ -131,7 +131,9 @@ class ZMQDisplayPublisher(DisplayPublisher):
                 exec_count -= 1
             outputs = getattr(self.shell.history_manager, "outputs", None)
             if outputs is not None:
-                outputs.append(HistoryOutput(output_type="display_data", bundle=data))
+                outputs.setdefault(exec_count, []).append(
+                    HistoryOutput(output_type="display_data", bundle=data)
+                )
         self._flush_streams()
         if metadata is None:
             metadata = {}

--- a/ipykernel/zmqshell.py
+++ b/ipykernel/zmqshell.py
@@ -44,7 +44,7 @@ from ipykernel.jsonutil import encode_images, json_clean
 try:
     from IPython.core.history import HistoryOutput
 except ImportError:
-    HistoryOutput: type | None = None
+    HistoryOutput = None  # type: ignore[assignment,misc]
 
 # -----------------------------------------------------------------------------
 # Functions and classes

--- a/ipykernel/zmqshell.py
+++ b/ipykernel/zmqshell.py
@@ -30,6 +30,7 @@ from IPython.core.interactiveshell import InteractiveShell, InteractiveShellABC
 from IPython.core.magic import Magics, line_magic, magics_class
 from IPython.core.magics import CodeMagics, MacroToEdit  # type:ignore[attr-defined]
 from IPython.core.usage import default_banner
+from IPython.core.history import HistoryOutput
 from IPython.display import Javascript, display
 from IPython.utils import openpy
 from IPython.utils.process import arg_split, system  # type:ignore[attr-defined]
@@ -115,6 +116,11 @@ class ZMQDisplayPublisher(DisplayPublisher):
         update : bool, optional, keyword-only
             If True, send an update_display_data message instead of display_data.
         """
+        if self.shell is not None and hasattr(self.shell, 'history_manager'):
+            outputs = self.shell.history_manager.outputs
+            outputs[self.shell.execution_count].append(
+                HistoryOutput(output_type="display_data", bundle=data)
+            )
         self._flush_streams()
         if metadata is None:
             metadata = {}

--- a/ipykernel/zmqshell.py
+++ b/ipykernel/zmqshell.py
@@ -35,7 +35,7 @@ from IPython.utils import openpy
 from IPython.utils.process import arg_split, system  # type:ignore[attr-defined]
 from jupyter_client.session import Session, extract_header
 from jupyter_core.paths import jupyter_runtime_dir
-from traitlets import Any, CBool, CBytes, Instance, default, observe
+from traitlets import Any, CBool, CBytes, Instance, Type, default, observe
 
 from ipykernel import connect_qtconsole, get_connection_file, get_connection_info
 from ipykernel.displayhook import ZMQShellDisplayHook
@@ -517,8 +517,8 @@ class ZMQInteractiveShell(InteractiveShell):
         self._parent_header = contextvars.ContextVar("parent_header")
         self._parent_header.set({})
 
-    displayhook_class = type(ZMQShellDisplayHook)
-    display_pub_class = type(ZMQDisplayPublisher)
+    displayhook_class = Type(ZMQShellDisplayHook)
+    display_pub_class = Type(ZMQDisplayPublisher)
     data_pub_class = Any()
     kernel = Any()
     _parent_header: contextvars.ContextVar[dict[str, Any]]

--- a/ipykernel/zmqshell.py
+++ b/ipykernel/zmqshell.py
@@ -125,10 +125,13 @@ class ZMQDisplayPublisher(DisplayPublisher):
             and hasattr(self.shell, "history_manager")
             and HistoryOutput is not None
         ):
-            outputs = self.shell.history_manager.outputs
-            outputs[self.shell.execution_count].append(
-                HistoryOutput(output_type="display_data", bundle=data)
-            )
+            # Reference: github.com/ipython/ipython/pull/14998
+            exec_count = self.shell.execution_count
+            if getattr(self.shell.display_pub, "_in_post_execute", False):
+                exec_count -= 1
+            outputs = getattr(self.shell.history_manager, "outputs", None)
+            if outputs is not None:
+                outputs.append(HistoryOutput(output_type="display_data", bundle=data))
         self._flush_streams()
         if metadata is None:
             metadata = {}

--- a/ipykernel/zmqshell.py
+++ b/ipykernel/zmqshell.py
@@ -44,7 +44,7 @@ from ipykernel.jsonutil import encode_images, json_clean
 try:
     from IPython.core.history import HistoryOutput
 except ImportError:
-    HistoryOutput = None
+    HistoryOutput = None  # type: ignore[assignment]
 
 # -----------------------------------------------------------------------------
 # Functions and classes

--- a/ipykernel/zmqshell.py
+++ b/ipykernel/zmqshell.py
@@ -22,11 +22,10 @@ import typing
 import warnings
 from pathlib import Path
 
-from IPython.core import page
+from IPython.core import page, version_info
 from IPython.core.autocall import ZMQExitAutocall
 from IPython.core.displaypub import DisplayPublisher
 from IPython.core.error import UsageError
-from IPython.core.history import HistoryOutput
 from IPython.core.interactiveshell import InteractiveShell, InteractiveShellABC
 from IPython.core.magic import Magics, line_magic, magics_class
 from IPython.core.magics import CodeMagics, MacroToEdit  # type:ignore[attr-defined]
@@ -41,6 +40,11 @@ from traitlets import Any, CBool, CBytes, Instance, Type, default, observe
 from ipykernel import connect_qtconsole, get_connection_file, get_connection_info
 from ipykernel.displayhook import ZMQShellDisplayHook
 from ipykernel.jsonutil import encode_images, json_clean
+
+if version_info >= (9, 1, 0):
+    from IPython.core.history import HistoryOutput
+else:
+    HistoryOutput = None
 
 # -----------------------------------------------------------------------------
 # Functions and classes
@@ -116,7 +120,11 @@ class ZMQDisplayPublisher(DisplayPublisher):
         update : bool, optional, keyword-only
             If True, send an update_display_data message instead of display_data.
         """
-        if self.shell is not None and hasattr(self.shell, "history_manager"):
+        if (
+            self.shell is not None
+            and hasattr(self.shell, "history_manager")
+            and HistoryOutput is not None
+        ):
             outputs = self.shell.history_manager.outputs
             outputs[self.shell.execution_count].append(
                 HistoryOutput(output_type="display_data", bundle=data)

--- a/tests/test_zmq_shell.py
+++ b/tests/test_zmq_shell.py
@@ -217,7 +217,8 @@ class ZMQDisplayPublisherTests(unittest.TestCase):
         # Mock shell with history manager
         mock_shell = MagicMock()
         mock_shell.execution_count = 1
-        mock_shell.history_manager.outputs = {1: []}
+        mock_shell.history_manager.outputs = dict()
+        mock_shell.display_pub._in_post_execute = False
 
         self.disp_pub.shell = mock_shell
 

--- a/tests/test_zmq_shell.py
+++ b/tests/test_zmq_shell.py
@@ -22,6 +22,11 @@ from ipykernel.zmqshell import (  # type:ignore
     ZMQInteractiveShell,
 )
 
+try:
+    from IPython.core.history import HistoryOutput
+except ImportError:
+    HistoryOutput = None  # type: ignore[assignment,misc]
+
 
 class NoReturnDisplayHook:
     """
@@ -209,6 +214,7 @@ class ZMQDisplayPublisherTests(unittest.TestCase):
         second = self.disp_pub.unregister_hook(hook)
         assert not bool(second)
 
+    @unittest.skipIf(HistoryOutput is None, "HistoryOutput not available")
     def test_display_stored_in_history(self):
         """
         Test that published display data gets stored in shell history

--- a/tests/test_zmq_shell.py
+++ b/tests/test_zmq_shell.py
@@ -221,7 +221,7 @@ class ZMQDisplayPublisherTests(unittest.TestCase):
 
         self.disp_pub.shell = mock_shell
 
-        data = {'text/plain': 'test output'}
+        data = {"text/plain": "test output"}
         self.disp_pub.publish(data)
 
         # Check that output was stored in history
@@ -229,6 +229,7 @@ class ZMQDisplayPublisherTests(unittest.TestCase):
         assert len(stored_outputs) == 1
         assert stored_outputs[0].output_type == "display_data"
         assert stored_outputs[0].bundle == data
+
 
 def test_magics(tmp_path):
     context = zmq.Context()

--- a/tests/test_zmq_shell.py
+++ b/tests/test_zmq_shell.py
@@ -209,6 +209,26 @@ class ZMQDisplayPublisherTests(unittest.TestCase):
         second = self.disp_pub.unregister_hook(hook)
         assert not bool(second)
 
+    def test_display_stored_in_history(self):
+        """
+        Test that published display data gets stored in shell history
+        for %notebook magic support.
+        """
+        # Mock shell with history manager
+        mock_shell = MagicMock()
+        mock_shell.execution_count = 1
+        mock_shell.history_manager.outputs = {1: []}
+
+        self.disp_pub.shell = mock_shell
+
+        data = {'text/plain': 'test output'}
+        self.disp_pub.publish(data)
+
+        # Check that output was stored in history
+        stored_outputs = mock_shell.history_manager.outputs[1]
+        assert len(stored_outputs) == 1
+        assert stored_outputs[0].output_type == "display_data"
+        assert stored_outputs[0].bundle == data
 
 def test_magics(tmp_path):
     context = zmq.Context()


### PR DESCRIPTION
## Fixes #1433 

### Summary
Fixes issue where display outputs (plots) were not included when using `%notebook` magic to save session as .ipynb file.

### Changes
- Modified `ZMQDisplayPublisher.publish()` to store display data in `history_manager.outputs`
- Added test to verify display outputs are stored in history