### PR TITLE
Bump python versions in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
           - "3.11"
           - "3.12"
           - "3.13"
+          - "3.14"
           - "pypy-3.10"
     steps:
       - name: Checkout

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.12"]
+        python-version: ["3.14"]
     steps:
       - name: Checkout
         uses: actions/checkout@v5


### PR DESCRIPTION
## references
- noted on https://github.com/conda-forge/ipykernel-feedstock/pull/196

## changes
- [x] add `3.14` to CI test matrix
- [x] use `3.14` for nightly builds 