### PR TITLE
6.x: Update PEP-639 license values in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling>=1.12", "jupyter_client>=6"]
+requires = ["hatchling>=1.22", "jupyter_client>=6"]
 build-backend = "hatchling.build"
 
 [project]
@@ -7,7 +7,6 @@ name = "ipykernel"
 dynamic = ["version"]
 authors = [{name = "IPython Development Team", email = "ipython-dev@scipy.org"}]
 license = "BSD-3-Clause"
-license-files = ["LICENSE"]
 readme = "README.md"
 description = "IPython Kernel for Jupyter"
 keywords = ["Interactive", "Interpreter", "Shell", "Web"]


### PR DESCRIPTION
Thanks all!

While wading through the various CI PRs, saw errors relating to this.

I didn't fully investigate _when_ `hatchling` would properly, fully, correctly support the various fields, so I updated to what is [claimed upstream](https://hatch.pypa.io/dev/history/hatchling/#hatchling-v1.5.0) as a minimum. As a `build-system`, it's likely to have been tested with just about every version that has come out.