### PR TITLE
Fix routing of background thread output when no parent is set explicitly

### DIFF
--- a/ipykernel/displayhook.py
+++ b/ipykernel/displayhook.py
@@ -29,6 +29,7 @@ class ZMQDisplayHook:
 
         self._parent_header: ContextVar[dict[str, Any]] = ContextVar("parent_header")
         self._parent_header.set({})
+        self._parent_header_global = {}
 
     def get_execution_count(self):
         """This method is replaced in kernelapp"""
@@ -57,11 +58,16 @@ class ZMQDisplayHook:
 
     @property
     def parent_header(self):
-        return self._parent_header.get()
+        try:
+            return self._parent_header.get()
+        except LookupError:
+            return self._parent_header_global
 
     def set_parent(self, parent):
         """Set the parent header."""
-        self._parent_header.set(extract_header(parent))
+        parent_header = extract_header(parent)
+        self._parent_header.set(parent_header)
+        self._parent_header_global = parent_header
 
 
 class ZMQShellDisplayHook(DisplayHook):
@@ -83,11 +89,16 @@ class ZMQShellDisplayHook(DisplayHook):
 
     @property
     def parent_header(self):
-        return self._parent_header.get()
+        try:
+            return self._parent_header.get()
+        except LookupError:
+            return self._parent_header_global
 
     def set_parent(self, parent):
-        """Set the parent for outbound messages."""
-        self._parent_header.set(extract_header(parent))
+        """Set the parent header."""
+        parent_header = extract_header(parent)
+        self._parent_header.set(parent_header)
+        self._parent_header_global = parent_header
 
     def start_displayhook(self):
         """Start the display hook."""

--- a/ipykernel/iostream.py
+++ b/ipykernel/iostream.py
@@ -456,8 +456,6 @@ class OutStream(TextIOBase):
             "parent_header"
         )
         self._parent_header.set({})
-        self._thread_to_parent = {}
-        self._thread_to_parent_header = {}
         self._parent_header_global = {}
         self._master_pid = os.getpid()
         self._flush_pending = False
@@ -512,21 +510,11 @@ class OutStream(TextIOBase):
     @property
     def parent_header(self):
         try:
-            # asyncio-specific
+            # asyncio or thread-specific
             return self._parent_header.get()
         except LookupError:
-            try:
-                # thread-specific
-                identity = threading.current_thread().ident
-                # retrieve the outermost (oldest ancestor,
-                # discounting the kernel thread) thread identity
-                while identity in self._thread_to_parent:
-                    identity = self._thread_to_parent[identity]
-                # use the header of the oldest ancestor
-                return self._thread_to_parent_header[identity]
-            except KeyError:
-                # global (fallback)
-                return self._parent_header_global
+            # global (fallback)
+            return self._parent_header_global
 
     @parent_header.setter
     def parent_header(self, value):

--- a/ipykernel/ipkernel.py
+++ b/ipykernel/ipkernel.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import asyncio
 import builtins
-import gc
 import getpass
 import os
 import signal
@@ -17,7 +16,6 @@ from functools import partial
 import comm
 from IPython.core import release
 from IPython.utils.tokenutil import line_at_cursor, token_at_cursor
-from jupyter_client.session import extract_header
 from traitlets import Any, Bool, HasTraits, Instance, List, Type, default, observe, observe_compat
 from zmq.eventloop.zmqstream import ZMQStream
 
@@ -25,7 +23,6 @@ from .comm.comm import BaseComm
 from .comm.manager import CommManager
 from .compiler import XCachingCompiler
 from .eventloops import _use_appnope
-from .iostream import OutStream
 from .kernelbase import Kernel as KernelBase
 from .kernelbase import _accepts_parameters
 from .zmqshell import ZMQInteractiveShell
@@ -166,14 +163,6 @@ class IPythonKernel(KernelBase):
             import appnope  # type:ignore[import-untyped]
 
             appnope.nope()
-
-        self._new_threads_parent_header = {}
-        self._initialize_thread_hooks()
-
-        if hasattr(gc, "callbacks"):
-            # while `gc.callbacks` exists since Python 3.3, pypy does not
-            # implement it even as of 3.9.
-            gc.callbacks.append(self._clean_thread_parent_frames)
 
     help_links = List(
         [
@@ -374,8 +363,6 @@ class IPythonKernel(KernelBase):
 
     async def execute_request(self, stream, ident, parent):
         """Override for cell output - cell reconciliation."""
-        parent_header = extract_header(parent)
-        self._associate_new_top_level_threads_with(parent_header)
         await super().execute_request(stream, ident, parent)
 
     async def do_execute(
@@ -749,83 +736,6 @@ class IPythonKernel(KernelBase):
         if self.shell:
             self.shell.reset(False)
         return dict(status="ok")
-
-    def _associate_new_top_level_threads_with(self, parent_header):
-        """Store the parent header to associate it with new top-level threads"""
-        self._new_threads_parent_header = parent_header
-
-    def _initialize_thread_hooks(self):
-        """Store thread hierarchy and thread-parent_header associations."""
-        stdout = self._stdout
-        stderr = self._stderr
-        kernel_thread_ident = threading.get_ident()
-        kernel = self
-        _threading_Thread_run = threading.Thread.run
-        _threading_Thread__init__ = threading.Thread.__init__
-
-        def run_closure(self: threading.Thread):
-            """Wrap the `threading.Thread.start` to intercept thread identity.
-
-            This is needed because there is no "start" hook yet, but there
-            might be one in the future: https://bugs.python.org/issue14073
-
-            This is a no-op if the `self._stdout` and `self._stderr` are not
-            sub-classes of `OutStream`.
-            """
-
-            try:
-                parent = self._ipykernel_parent_thread_ident  # type:ignore[attr-defined]
-            except AttributeError:
-                return
-            for stream in [stdout, stderr]:
-                if isinstance(stream, OutStream):
-                    if parent == kernel_thread_ident:
-                        stream._thread_to_parent_header[self.ident] = (
-                            kernel._new_threads_parent_header
-                        )
-                    else:
-                        stream._thread_to_parent[self.ident] = parent
-            _threading_Thread_run(self)
-
-        def init_closure(self: threading.Thread, *args, **kwargs):
-            _threading_Thread__init__(self, *args, **kwargs)
-            self._ipykernel_parent_thread_ident = threading.get_ident()  # type:ignore[attr-defined]
-
-        threading.Thread.__init__ = init_closure  # type:ignore[method-assign]
-        threading.Thread.run = run_closure  # type:ignore[method-assign]
-
-    def _clean_thread_parent_frames(
-        self, phase: t.Literal["start", "stop"], info: dict[str, t.Any]
-    ):
-        """Clean parent frames of threads which are no longer running.
-        This is meant to be invoked by garbage collector callback hook.
-
-        The implementation enumerates the threads because there is no "exit" hook yet,
-        but there might be one in the future: https://bugs.python.org/issue14073
-
-        This is a no-op if the `self._stdout` and `self._stderr` are not
-        sub-classes of `OutStream`.
-        """
-        # Only run before the garbage collector starts
-        if phase != "start":
-            return
-        active_threads = {thread.ident for thread in threading.enumerate()}
-        for stream in [self._stdout, self._stderr]:
-            if isinstance(stream, OutStream):
-                thread_to_parent_header = stream._thread_to_parent_header
-                for identity in list(thread_to_parent_header.keys()):
-                    if identity not in active_threads:
-                        try:
-                            del thread_to_parent_header[identity]
-                        except KeyError:
-                            pass
-                thread_to_parent = stream._thread_to_parent
-                for identity in list(thread_to_parent.keys()):
-                    if identity not in active_threads:
-                        try:
-                            del thread_to_parent[identity]
-                        except KeyError:
-                            pass
 
 
 # This exists only for backwards compatibility - use IPythonKernel instead

--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -72,6 +72,8 @@ _AWAITABLE_MESSAGE: str = (
     " ipykernel 6.0 (2021). {target} does not seem to return an awaitable"
 )
 
+T = t.TypeVar("T")
+
 
 def _accepts_parameters(meth, param_names):
     parameters = inspect.signature(meth).parameters
@@ -801,7 +803,7 @@ class Kernel(SingletonConfigurable):
 
         return self._get_shell_context_var(self._shell_parent)
 
-    def _get_shell_context_var(self, var: ContextVar):
+    def _get_shell_context_var(self, var: ContextVar[T]) -> T:
         """Lookup a ContextVar, falling back on the shell context
 
         Allows for user-launched Threads to still resolve to the shell's mai context

--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -806,7 +806,7 @@ class Kernel(SingletonConfigurable):
     def _get_shell_context_var(self, var: ContextVar[T]) -> T:
         """Lookup a ContextVar, falling back on the shell context
 
-        Allows for user-launched Threads to still resolve to the shell's mai context
+        Allows for user-launched Threads to still resolve to the shell's main context
 
         necessary for e.g. display from threads.
         """

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -58,36 +58,119 @@ def test_simple_print():
         _check_master(kc, expected=True)
 
 
-def test_print_to_correct_cell_from_thread():
-    """should print to the cell that spawned the thread, not a subsequently run cell"""
-    iterations = 5
-    interval = 0.25
-    code = f"""\
-    from threading import Thread
-    from time import sleep
+def collect_outputs(get_iopub_msg, parent_msg_id, timeout=5):
+    """Collect outputs until we get an idle message
 
-    def thread_target():
-        for i in range({iterations}):
-            print(i, end='', flush=True)
-            sleep({interval})
-
-    Thread(target=thread_target).start()
+    Returns list of complete output messages.
     """
+    while True:
+        msg = get_iopub_msg(timeout=timeout)
+        msg_type = msg["msg_type"]
+        content = msg["content"]
+
+        if (
+            msg["parent_header"]["msg_id"] == parent_msg_id
+            and msg_type == "status"
+            and content["execution_state"] == "idle"
+        ):
+            # idle message signals end of output
+            break
+        elif msg["msg_type"] in {"stream", "display_data"}:
+            yield msg
+        elif msg["msg_type"] == "error":
+            tb = "\n".join(msg["content"]["traceback"])
+            raise RuntimeError(f"Error during execution: {tb}")
+        else:
+            # other output, ignored
+            print(msg["msg_type"])
+
+
+@pytest.mark.parametrize("explicit_parent", [True, False])
+def test_print_to_correct_cell_from_thread(explicit_parent: bool):
+    """should print to the current cell unless
+
+    get_ipython().set_parent sets the thread-local value,
+    which supersedes the default.
+
+    """
+    code = f"""\
+        from threading import Event, Thread
+        from time import sleep
+        from IPython.display import display
+
+        explicit_parent = {explicit_parent}
+        parent = get_ipython().get_parent()
+
+        cell_start_event = Event()
+        cell_end_event = Event()
+
+        def thread_target():
+            if explicit_parent:
+                get_ipython().set_parent(parent)
+
+            print("before", flush=True)
+            display(1)
+            cell_start_event.wait(timeout=10)
+            cell_start_event.clear()
+
+            print("during", flush=True)
+            display(2)
+            cell_end_event.set()
+            cell_start_event.wait(timeout=10)
+            cell_start_event.clear()
+            print("after", flush=True)
+            display(3)
+
+        thread = Thread(target=thread_target)
+        thread.start()
+    """
+    outputs = {}
+
+    def add_output(msg):
+        parent_id = msg["parent_header"]["msg_id"]
+        if parent_id not in outputs:
+            outputs[parent_id] = {
+                "stdout": "",
+                "stderr": "",
+                "display_data": [],
+            }
+        cell_outputs = outputs[parent_id]
+        msg_type = msg["header"]["msg_type"]
+        content = msg["content"]
+        if msg_type == "stream":
+            cell_outputs[content["name"]] += content["text"]
+        else:
+            cell_outputs[msg_type].append(msg["content"]["data"]["text/plain"])
+
     with kernel() as kc:
         thread_msg_id = kc.execute(code)
-        _ = kc.execute("pass")
+        for msg in collect_outputs(kc.get_iopub_msg, thread_msg_id):
+            add_output(msg)
 
-        received = 0
-        while received < iterations:
-            msg = kc.get_iopub_msg(timeout=interval * 2)
-            if msg["msg_type"] != "stream":
-                continue
-            content = msg["content"]
-            assert content["name"] == "stdout"
-            assert content["text"] == str(received)
-            # this is crucial as the parent header decides to which cell the output goes
-            assert msg["parent_header"]["msg_id"] == thread_msg_id
-            received += 1
+        next_cell_msg_id = kc.execute("cell_start_event.set()\ncell_end_event.wait(timeout=10)")
+        for msg in collect_outputs(kc.get_iopub_msg, next_cell_msg_id):
+            add_output(msg)
+
+        last_cell_msg_id = kc.execute("cell_start_event.set()\nthread.join()")
+        for msg in collect_outputs(kc.get_iopub_msg, last_cell_msg_id):
+            add_output(msg)
+    print(outputs)
+    if explicit_parent:
+        # assert next_cell_msg_id not in outputs
+        # assert last_cell_msg_id not in outputs
+        thread_cell_output = outputs[thread_msg_id]
+        assert thread_cell_output["stdout"] == "before\nduring\nafter\n"
+        assert thread_cell_output["display_data"] == ["1", "2", "3"]
+    else:
+        thread_cell_output = outputs[thread_msg_id]
+        assert thread_cell_output["stdout"] == "before\n"
+        assert thread_cell_output["display_data"] == ["1"]
+        next_cell_output = outputs[next_cell_msg_id]
+        assert next_cell_output["stdout"] == "during\n"
+        assert next_cell_output["display_data"] == ["2"]
+        last_cell_output = outputs[last_cell_msg_id]
+        assert last_cell_output["stdout"] == "after\n"
+        assert last_cell_output["display_data"] == ["3"]
 
 
 def test_print_to_correct_cell_from_child_thread():
@@ -98,7 +181,10 @@ def test_print_to_correct_cell_from_child_thread():
     from threading import Thread
     from time import sleep
 
+    parent = get_ipython().get_parent()
+
     def child_target():
+        get_ipython().set_parent(parent)
         for i in range({iterations}):
             print(i, end='', flush=True)
             sleep({interval})


### PR DESCRIPTION
- removes guessing about whether threads should route output to their originating cell (see #1289)
- thread-local value is persisted, if set explicitly
- if no thread-local value is set, fallback on a global value (usually the latest cell), restores longstanding default behavior

There's lots of duplication around, but I couldn't see a way to resolve that without breaking things. That can be a later goal.

closes #1450 

improves but does not quite close #1289 because there is still no explicit opt-out once a thread has set its parent (there is no `clear_parent()`), but at least the parent isn't set by default anymore, so the opt-out is less urgently needed.

To send a thread's output to a specific cell, this must now be done explicitly, which I think is a big improvement and simplification. No thread inheritance is tracked, no cell guessing occurs.

To route output to a specific cell from a thread, explicitly call `set_parent` in the thread with the parent from the outer context that should be kept for the duration of the thread:

```python
current_cell_parent = get_ipython().get_parent()

def thread_task():
    get_ipython().set_parent(current_cell_parent)
    print("...")

Thread(target=thread_task).start()
```