### PR TITLE
Backport PR #1435: Store display outputs in history for `%notebook` magic

### DIFF
--- a/tests/test_zmq_shell.py
+++ b/tests/test_zmq_shell.py
@@ -22,6 +22,11 @@ from ipykernel.zmqshell import (  # type:ignore
     ZMQInteractiveShell,
 )
 
+try:
+    from IPython.core.history import HistoryOutput
+except ImportError:
+    HistoryOutput = None  # type: ignore[assignment,misc]
+
 
 class NoReturnDisplayHook:
     """
@@ -208,6 +213,35 @@ class ZMQDisplayPublisherTests(unittest.TestCase):
         #
         second = self.disp_pub.unregister_hook(hook)
         assert not bool(second)
+
+    @unittest.skipIf(HistoryOutput is None, "HistoryOutput not available")
+    def test_display_stored_in_history(self):
+        """
+        Test that published display data gets stored in shell history
+        for %notebook magic support, and not stored when disabled.
+        """
+        for enable in [False, True]:
+            # Mock shell with history manager
+            mock_shell = MagicMock()
+            mock_shell.execution_count = 1
+            mock_shell.history_manager.outputs = dict()
+            mock_shell.display_pub._in_post_execute = False
+
+            self.disp_pub.shell = mock_shell
+            self.disp_pub.store_display_history = enable
+
+            data = {"text/plain": "test output"}
+            self.disp_pub.publish(data)
+
+            if enable:
+                # Check that output was stored in history
+                stored_outputs = mock_shell.history_manager.outputs[1]
+                assert len(stored_outputs) == 1
+                assert stored_outputs[0].output_type == "display_data"
+                assert stored_outputs[0].bundle == data
+            else:
+                # Should not store anything in history
+                assert mock_shell.history_manager.outputs == {}
 
 
 def test_magics(tmp_path):


### PR DESCRIPTION
Backport of #1435 from `main` to `6.x`.