### PR TITLE
Support new iPython system_raise_on_error flag in ZMQInteractiveShell

### DIFF
--- a/ipykernel/zmqshell.py
+++ b/ipykernel/zmqshell.py
@@ -790,8 +790,7 @@ class ZMQInteractiveShell(InteractiveShell):
             exit_code = system(self.var_expand(cmd, depth=1))
             self.user_ns["_exit_code"] = exit_code
 
-        # Raise an exception if the command failed and system_raise_on_error is True
-        if self.system_raise_on_error and exit_code != 0:
+        if getattr(self, 'system_raise_on_error', False) and exit_code != 0:
             raise CalledProcessError(exit_code, cmd)
 
     # Ensure new system_piped implementation is used

--- a/ipykernel/zmqshell.py
+++ b/ipykernel/zmqshell.py
@@ -17,11 +17,11 @@ machinery.  This should thus be thought of as scaffolding.
 import contextvars
 import os
 import sys
-from subprocess import CalledProcessError
 import threading
 import typing
 import warnings
 from pathlib import Path
+from subprocess import CalledProcessError
 
 from IPython.core import page
 from IPython.core.autocall import ZMQExitAutocall
@@ -790,7 +790,7 @@ class ZMQInteractiveShell(InteractiveShell):
             exit_code = system(self.var_expand(cmd, depth=1))
             self.user_ns["_exit_code"] = exit_code
 
-        if getattr(self, 'system_raise_on_error', False) and exit_code != 0:
+        if getattr(self, "system_raise_on_error", False) and exit_code != 0:
             raise CalledProcessError(exit_code, cmd)
 
     # Ensure new system_piped implementation is used


### PR DESCRIPTION
This PR complements iPython PR https://github.com/ipython/ipython/pull/15073 which adds a new `system_raise_on_error` configuration option that raises CalledProcessError when shell commands executed via the ! operator return non-zero exit status. This brings similar error-handling behavior to the ! operator as was added to %%bash magic in PR https://github.com/ipython/ipython/pull/11287.

Since ZMQInteractiveShell
overrides system_piped() for Windows UNC path handling, it needs to
also check the system_raise_on_error config and raise CalledProcessError
on non-zero exit status.

Changes:
- Import CalledProcessError from subprocess
- Capture exit_code from system() call
- Raise CalledProcessError when system_raise_on_error is True
  and exit_code is non-zero

This enables Jupyter notebook users to halt execution on shell
command failures when they opt-in via:
`get_ipython().system_raise_on_error = True`