### PR TITLE
Temporary pin virtualenv < 21

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Install hatch
         run: |
           python --version
-          python -m pip install hatch
+          python -m pip install hatch "virtualenv<21"
 
       - name: Run the tests
         timeout-minutes: 15

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,6 +196,10 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.10"
+
       - name: Preinstall hatch and virtualenv
         run: |
           python --version
@@ -205,7 +209,7 @@ jobs:
         uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
         with:
           dependency_type: minimum
-          python_version: "3.10"
+          python_version: ${{ matrix.python-version }}
 
       - name: List installed packages
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+
+      - name: Preinstall hatch and virtualenv
+        run: |
+          python --version
+          python -m pip install hatch "virtualenv<21"
+
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
       - name: Run Linters
         run: |
@@ -116,7 +122,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+
+      - name: Preinstall hatch and virtualenv
+        run: |
+          python --version
+          python -m pip install hatch "virtualenv<21"
+
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+
       - uses: jupyter-server/jupyter_releaser/.github/actions/check-release@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -125,7 +138,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+
+      - name: Preinstall hatch and virtualenv
+        run: |
+          python --version
+          python -m pip install hatch "virtualenv<21"
+
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+
       - name: Build API docs
         run: |
           hatch run docs:api
@@ -147,6 +167,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+
+      - name: Preinstall hatch and virtualenv
+        run: |
+          python --version
+          python -m pip install hatch "virtualenv<21"
 
       - name: Base Setup
         uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
@@ -170,6 +195,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+
+      - name: Preinstall hatch and virtualenv
+        run: |
+          python --version
+          python -m pip install hatch "virtualenv<21"
+
       - name: Base Setup
         uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
         with:
@@ -191,10 +222,17 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+
+      - name: Preinstall hatch and virtualenv
+        run: |
+          python --version
+          python -m pip install hatch "virtualenv<21"
+
       - name: Base Setup
         uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
         with:
           dependency_type: pre
+
       - name: Run the tests
         run: |
           hatch run test:nowarn

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 ### Enhancements made
 
 - Made IOPubThread constructor backward compatible [#1492](https://github.com/ipython/ipykernel/pull/1492) ([@JohanMabille](https://github.com/JohanMabille), [@SylvainCorlay](https://github.com/SylvainCorlay), [@ianthomas23](https://github.com/ianthomas23), [@minrk](https://github.com/minrk))
-- Advertizes kernel protocol 5.5 [#1488](https://github.com/ipython/ipykernel/pull/1488) ([@JohanMabille](https://github.com/JohanMabille), [@ianthomas23](https://github.com/ianthomas23))
+- Advertises kernel protocol 5.5 [#1488](https://github.com/ipython/ipykernel/pull/1488) ([@JohanMabille](https://github.com/JohanMabille), [@ianthomas23](https://github.com/ianthomas23))
 - Upgrade to jupyter_client 8.8.0 [#1487](https://github.com/ipython/ipykernel/pull/1487) ([@JohanMabille](https://github.com/JohanMabille), [@ianthomas23](https://github.com/ianthomas23))
 - Implement kernel-side callstack filtering for internal frames [#1481](https://github.com/ipython/ipykernel/pull/1481) ([@arjxn-py](https://github.com/arjxn-py), [@JohanMabille](https://github.com/JohanMabille), [@ianthomas23](https://github.com/ianthomas23))
 


### PR DESCRIPTION
The latest `virtualenv 21.0.0` does not work with `hatch` (pypa/hatch#2193), so temporarily pin `virtualenv` until the next `hatch` release.