### PR TITLE
Switch from using nest-asyncio to nest-asyncio2

### DIFF
--- a/ipykernel/eventloops.py
+++ b/ipykernel/eventloops.py
@@ -301,9 +301,9 @@ def loop_tk(kernel):
     else:
         import asyncio
 
-        import nest_asyncio
+        import nest_asyncio2
 
-        nest_asyncio.apply()
+        nest_asyncio2.apply()
 
         # Tk uses milliseconds
         poll_interval = int(1000 * kernel._poll_interval)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "jupyter_client>=8.8.0",
     "jupyter_core>=5.1,!=6.0.*",
     # For tk event loop support only.
-    "nest_asyncio>=1.4",
+    "nest_asyncio2>=1.7.0",
     "tornado>=6.4.1",
     "matplotlib-inline>=0.1",
     'appnope>=0.1.2;platform_system=="Darwin"',


### PR DESCRIPTION
As explained in https://github.com/ipython/ipykernel/issues/1381#issuecomment-3548626525 `nest-asyncio` is  no longer maintained, so here switching to use `nest-asyncio2` which is a fork that is maintained.