### PR TITLE
Remove deprecated `shell_streams` and `_parent_header` shims

### DIFF
--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -110,44 +110,9 @@ class Kernel(SingletonConfigurable):
     profile_dir = Instance("IPython.core.profiledir.ProfileDir", allow_none=True)
     shell_stream = Instance(ZMQStream, allow_none=True)
 
-    shell_streams: List[t.Any] = List(
-        help="""Deprecated shell_streams alias. Use shell_stream
-
-        .. versionchanged:: 6.0
-            shell_streams is deprecated. Use shell_stream.
-        """
-    )
-
     implementation: str
     implementation_version: str
     banner: str
-
-    @default("shell_streams")
-    def _shell_streams_default(self):  # pragma: no cover
-        warnings.warn(
-            "Kernel.shell_streams is deprecated in ipykernel 6.0. Use Kernel.shell_stream",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        if self.shell_stream is not None:
-            return [self.shell_stream]
-        return []
-
-    @observe("shell_streams")
-    def _shell_streams_changed(self, change):  # pragma: no cover
-        warnings.warn(
-            "Kernel.shell_streams is deprecated in ipykernel 6.0. Use Kernel.shell_stream",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        if len(change.new) > 1:
-            warnings.warn(
-                "Kernel only supports one shell stream. Additional streams will be ignored.",
-                RuntimeWarning,
-                stacklevel=2,
-            )
-        if change.new:
-            self.shell_stream = change.new[0]
 
     control_stream = Instance(ZMQStream, allow_none=True)
 

--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -181,15 +181,6 @@ class Kernel(SingletonConfigurable):
     # Asyncio lock for main shell thread.
     _main_asyncio_lock: asyncio.Lock
 
-    @property
-    def _parent_header(self):
-        warnings.warn(
-            "Kernel._parent_header is deprecated in ipykernel 6. Use .get_parent()",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.get_parent()
-
     # Time to sleep after flushing the stdout/err buffers in each execute
     # cycle.  While this introduces a hard limit on the minimal latency of the
     # execute cycle, it helps prevent output synchronization problems for

--- a/tests/test_kernel_direct.py
+++ b/tests/test_kernel_direct.py
@@ -4,7 +4,6 @@
 # Distributed under the terms of the Modified BSD License.
 
 import os
-import warnings
 
 import pytest
 

--- a/tests/test_kernel_direct.py
+++ b/tests/test_kernel_direct.py
@@ -103,18 +103,6 @@ async def test_direct_debug_request(kernel):
     assert reply["header"]["msg_type"] == "debug_reply"
 
 
-async def test_deprecated_features(kernel):
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", DeprecationWarning)
-        header = kernel._parent_header
-        assert isinstance(header, dict)
-        shell_streams = kernel.shell_streams
-        assert len(shell_streams) == 1
-        assert shell_streams[0] == kernel.shell_stream
-        warnings.simplefilter("ignore", RuntimeWarning)
-        kernel.shell_streams = [kernel.shell_stream, kernel.shell_stream]
-
-
 async def test_process_control(kernel):
     from jupyter_client.session import DELIM
 


### PR DESCRIPTION
## Summary

Remove two deprecated compatibility shims from ipykernel 6.0 (2021):

- `shell_streams` (plural) — deprecated in favor of `shell_stream` (singular)
- `_parent_header` property — deprecated in favor of `get_parent()`

Both have been emitting `DeprecationWarning` for 5 years.

## Changes

- Remove `shell_streams` trait, `_shell_streams_default`, and `_shell_streams_changed` from `kernelbase.py`
- Remove `_parent_header` deprecated property from `kernelbase.py`
- Remove `test_deprecated_features` test that covered both

No behavioral change — `shell_stream` and `get_parent()` remain the supported APIs.