### PR TITLE
Bugfix: Ensure that we take a copy of the sys.modules before iterating over it

### DIFF
--- a/ipykernel/debugger.py
+++ b/ipykernel/debugger.py
@@ -693,7 +693,7 @@ class Debugger:
 
     async def modules(self, message):
         """Handle a modules message."""
-        modules = list(sys.modules.values())
+        modules = list(sys.modules.copy().values())
         startModule = message.get("startModule", 0)
         moduleCount = message.get("moduleCount", len(modules))
         mods = []

--- a/ipykernel/ipkernel.py
+++ b/ipykernel/ipkernel.py
@@ -120,7 +120,7 @@ class IPythonKernel(KernelBase):
         from .debugger import _is_debugpy_available
 
         self._kernel_modules = [
-            m.__file__ for m in sys.modules.values() if hasattr(m, "__file__") and m.__file__
+            m.__file__ for m in sys.modules.copy().values() if hasattr(m, "__file__") and m.__file__
         ]
 
         # Initialize the Debugger


### PR DESCRIPTION
:wave:

I encountered an issue in the CERN Python distribution when running IPykernel, caused by the fact that Python invocations in our distribution trigger a Python thread which does some logging. The issue:

```
[I 2026-05-04 15:47:50.633 ServerApp] AsyncIOLoopKernelRestarter: restarting kernel (3/5), new random ports
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/tmp/venv26/lib/python3.14/site-packages/ipykernel_launcher.py", line 18, in <module>
    app.launch_new_instance()
    ~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/tmp/venv26/lib/python3.14/site-packages/traitlets/config/application.py", line 1074, in launch_instance
    app.initialize(argv)
    ~~~~~~~~~~~~~~^^^^^^
  File "/tmp/venv26/lib/python3.14/site-packages/traitlets/config/application.py", line 118, in inner
    return method(app, *args, **kwargs)
  File "/tmp/venv26/lib/python3.14/site-packages/ipykernel/kernelapp.py", line 726, in initialize
    self.init_kernel()
    ~~~~~~~~~~~~~~~~^^
  File "/tmp/venv26/lib/python3.14/site-packages/ipykernel/kernelapp.py", line 573, in init_kernel
    kernel = kernel_factory(
        parent=self,
    ...<12 lines>...
        user_ns=self.user_ns,
    )
  File "/tmp/venv26/lib/python3.14/site-packages/traitlets/config/configurable.py", line 583, in instance
    inst = cls(*args, **kwargs)
  File "/tmp/venv26/lib/python3.14/site-packages/ipykernel/ipkernel.py", line 123, in __init__
    m.__file__ for m in sys.modules.values() if hasattr(m, "__file__") and m.__file__
                        ~~~~~~~~~~~~~~~~~~^^
RuntimeError: dictionary keys changed during iteration
```

Boils down to the fact that `sys.modules` is a shared, mutable dictionary that can be modified by background threads. Any mutation during iteration raises `RuntimeError: dictionary keys changed during iteration` on Python 3.14, which tightened its detection of this condition.
                                                                                                                                                                                
Using .copy() the recommended solution as per bugs.python.org/issue40327, so I applied it to one existing location too.