### PR TITLE
Support ZMQ Curve for transport encryption

### DIFF
--- a/hatch_build.py
+++ b/hatch_build.py
@@ -20,7 +20,10 @@ class CustomHook(BuildHookInterface):
 
         # When building a standard wheel, the executable specified in the kernelspec is simply 'python'.
         if version == "standard":
-            overrides["metadata"] = dict(debugger=True)
+            overrides["metadata"] = {
+                "debugger": True,
+                "supported_encryption": "curve",
+            }
             argv = make_ipkernel_cmd(executable="python")
 
         # When installing an editable wheel, the full `sys.executable` can be used.

--- a/ipykernel/heartbeat.py
+++ b/ipykernel/heartbeat.py
@@ -27,14 +27,29 @@ from jupyter_client.localinterfaces import localhost
 class Heartbeat(Thread):
     """A simple ping-pong style heartbeat that runs in a thread."""
 
-    def __init__(self, context, addr=None):
-        """Initialize the heartbeat thread."""
+    def __init__(self, context, addr=None, curve_publickey=None, curve_secretkey=None):
+        """Initialize the heartbeat thread.
+
+        Parameters
+        ----------
+        context : zmq.Context
+        addr : tuple, optional
+            (transport, ip, port)
+        curve_publickey : bytes, optional
+            Z85-encoded CurveZMQ public key.  When provided together with
+            *curve_secretkey*, the heartbeat socket will operate as a
+            CurveZMQ server so that only authenticated clients can connect.
+        curve_secretkey : bytes, optional
+            Z85-encoded CurveZMQ secret key (paired with *curve_publickey*).
+        """
         if addr is None:
             addr = ("tcp", localhost(), 0)
         Thread.__init__(self, name="Heartbeat")
         self.context = context
         self.transport, self.ip, self.port = addr
         self.original_port = self.port
+        self.curve_publickey = curve_publickey
+        self.curve_secretkey = curve_secretkey
         if self.original_port == 0:
             self.pick_port()
         self.addr = (self.ip, self.port)
@@ -94,6 +109,10 @@ class Heartbeat(Thread):
         self.name = "Heartbeat"
         self.socket = self.context.socket(zmq.ROUTER)
         self.socket.linger = 1000
+        if self.curve_secretkey is not None:
+            self.socket.curve_secretkey = self.curve_secretkey
+            self.socket.curve_publickey = self.curve_publickey
+            self.socket.curve_server = True
         try:
             self._bind_socket()
         except Exception:

--- a/ipykernel/heartbeat.py
+++ b/ipykernel/heartbeat.py
@@ -36,11 +36,11 @@ class Heartbeat(Thread):
         addr : tuple, optional
             (transport, ip, port)
         curve_publickey : bytes, optional
-            Z85-encoded CurveZMQ public key.  When provided together with
+            CurveZMQ public key (Z85). When provided together with
             *curve_secretkey*, the heartbeat socket will operate as a
             CurveZMQ server so that only authenticated clients can connect.
         curve_secretkey : bytes, optional
-            Z85-encoded CurveZMQ secret key (paired with *curve_publickey*).
+            CurveZMQ secret key (Z85, paired with *curve_publickey*).
         """
         if addr is None:
             addr = ("tcp", localhost(), 0)

--- a/ipykernel/heartbeat.py
+++ b/ipykernel/heartbeat.py
@@ -48,8 +48,8 @@ class Heartbeat(Thread):
         self.context = context
         self.transport, self.ip, self.port = addr
         self.original_port = self.port
-        self.curve_publickey = curve_publickey
-        self.curve_secretkey = curve_secretkey
+        self._curve_publickey = curve_publickey
+        self._curve_secretkey = curve_secretkey
         if self.original_port == 0:
             self.pick_port()
         self.addr = (self.ip, self.port)
@@ -109,9 +109,9 @@ class Heartbeat(Thread):
         self.name = "Heartbeat"
         self.socket = self.context.socket(zmq.ROUTER)
         self.socket.linger = 1000
-        if self.curve_secretkey is not None:
-            self.socket.curve_secretkey = self.curve_secretkey
-            self.socket.curve_publickey = self.curve_publickey
+        if self._curve_secretkey is not None:
+            self.socket.curve_secretkey = self._curve_secretkey
+            self.socket.curve_publickey = self._curve_publickey
             self.socket.curve_server = True
         try:
             self._bind_socket()
@@ -141,3 +141,6 @@ class Heartbeat(Thread):
                 raise
             else:
                 break
+
+    _curve_publickey: bytes | None
+    _curve_secretkey: bytes | None

--- a/ipykernel/heartbeat.py
+++ b/ipykernel/heartbeat.py
@@ -27,7 +27,7 @@ from jupyter_client.localinterfaces import localhost
 class Heartbeat(Thread):
     """A simple ping-pong style heartbeat that runs in a thread."""
 
-    def __init__(self, context, addr=None, curve_publickey=None, curve_secretkey=None):
+    def __init__(self, context, addr=None, *, curve_publickey=None, curve_secretkey=None):
         """Initialize the heartbeat thread.
 
         Parameters

--- a/ipykernel/inprocess/client.py
+++ b/ipykernel/inprocess/client.py
@@ -17,6 +17,7 @@ from typing import Any
 
 from jupyter_client.client import KernelClient
 from jupyter_client.clientabc import KernelClientABC
+from jupyter_client.connect import KernelConnectionInfo
 from jupyter_core.utils import run_sync
 
 # IPython imports
@@ -59,10 +60,10 @@ class InProcessKernelClient(KernelClient):
 
         return BlockingInProcessKernelClient
 
-    def get_connection_info(self, session: bool = False) -> dict[str, int | str | bytes]:
+    def get_connection_info(self, session: bool = False) -> KernelConnectionInfo:
         """Get the connection info for the client."""
         d = super().get_connection_info(session=session)
-        d["kernel"] = self.kernel  # type:ignore[assignment]
+        d["kernel"] = self.kernel  # type: ignore[typeddict-unknown-key]
         return d
 
     def start_channels(self, *args, **kwargs):

--- a/ipykernel/kernelapp.py
+++ b/ipykernel/kernelapp.py
@@ -359,6 +359,14 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp, ConnectionFileMix
         if self.enable_curve:
             self._curve_publickey, self._curve_secretkey = zmq.curve_keypair()
             self.log.debug("CurveZMQ enabled; generated server keypair")
+        elif self.transport == "tcp":
+            self.log.warning(
+                "Kernel is running over TCP without encryption."
+                " All communication (including code and outputs) is sent in plain text"
+                " and is susceptible to eavesdropping."
+                " Use IPC transport or set IPKernelApp.enable_curve=True to enable"
+                " CurveZMQ encryption."
+            )
 
         self.shell_socket = context.socket(zmq.ROUTER)
         self.shell_socket.linger = 1000

--- a/ipykernel/kernelapp.py
+++ b/ipykernel/kernelapp.py
@@ -349,7 +349,7 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp, ConnectionFileMix
         atexit.register(self.close)
 
         if self.curve_secretkey is not None:
-            self.log.debug("Detected CurveZMQ secret key; using transport encryption")
+            self.log.info("Detected CurveZMQ secret key; using transport encryption")
         elif self.transport == "tcp":
             self.log.warning(
                 "Kernel is running over TCP without encryption."

--- a/ipykernel/kernelapp.py
+++ b/ipykernel/kernelapp.py
@@ -33,6 +33,7 @@ from tornado import ioloop
 from traitlets.traitlets import (
     Any,
     Bool,
+    Bytes,
     Dict,
     DottedObjectName,
     Instance,
@@ -157,6 +158,11 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp, ConnectionFileMix
 
     # connection info:
     connection_dir = Unicode()
+
+    # Optional CurveZMQ keys loaded from the connection file (Z85-encoded bytes).
+    # None when the kernel was not started with CurveZMQ enabled.
+    curve_publickey: Bytes | None = Bytes(allow_none=True, default_value=None)
+    curve_secretkey: Bytes | None = Bytes(allow_none=True, default_value=None)
 
     @default("connection_dir")
     def _default_connection_dir(self):

--- a/ipykernel/kernelapp.py
+++ b/ipykernel/kernelapp.py
@@ -188,19 +188,6 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp, ConnectionFileMix
     """,
     ).tag(config=True)
 
-    enable_curve = Bool(
-        bool(int(os.environ.get("JUPYTER_ENABLE_CURVE", "0"))),
-        help="Enable CurveZMQ transport encryption and authentication. "
-        "When True, a keypair is generated at startup and stored in the "
-        "connection file so that clients can authenticate and encrypt "
-        "all ZMQ channels.",
-    ).tag(config=True)
-
-    # Internal CurveZMQ keypair (Z85-encoded bytes); populated in init_sockets
-    # when enable_curve is True.
-    _curve_publickey: bytes | None = None
-    _curve_secretkey: bytes | None = None
-
     # polling
     parent_handle = Integer(
         int(os.environ.get("JPY_PARENT_PID") or 0),
@@ -227,12 +214,12 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp, ConnectionFileMix
     def _apply_curve_server_options(self, socket: zmq.Socket[t.Any]) -> None:
         """Set CurveZMQ server-side options on *socket* before it is bound.
 
-        This is a no-op when enable_curve is False or keys have not been
-        generated yet, so it is safe to call unconditionally.
+        This is a no-op when Curve keys are not available yet, so it is safe
+        to call unconditionally.
         """
-        if self.enable_curve and self._curve_secretkey is not None:
-            socket.curve_secretkey = self._curve_secretkey
-            socket.curve_publickey = self._curve_publickey
+        if self.curve_secretkey is not None:
+            socket.curve_secretkey = self.curve_secretkey
+            socket.curve_publickey = self.curve_publickey
             socket.curve_server = True
 
     def init_poller(self):
@@ -298,10 +285,9 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp, ConnectionFileMix
             iopub_port=self.iopub_port,
             control_port=self.control_port,
         )
-        if self.enable_curve and self._curve_publickey is not None:
-            # write_connection_file() in jupyter-client handles JSON-safe key serialization
-            connection_info["curve_publickey"] = self._curve_publickey
-            connection_info["curve_secretkey"] = self._curve_secretkey
+        if self.curve_publickey is not None:
+            connection_info["curve_publickey"] = self.curve_publickey
+            connection_info["curve_secretkey"] = self.curve_secretkey
         if Path(cf).exists():
             # If the file exists, merge our info into it. For example, if the
             # original file had port number 0, we update with the actual port
@@ -356,16 +342,15 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp, ConnectionFileMix
         self.context = context = zmq.Context()
         atexit.register(self.close)
 
-        if self.enable_curve:
-            self._curve_publickey, self._curve_secretkey = zmq.curve_keypair()
-            self.log.debug("CurveZMQ enabled; generated server keypair")
+        if self.curve_secretkey is not None:
+            self.log.debug("Detected CurveZMQ secret key; using transport encryption")
         elif self.transport == "tcp":
             self.log.warning(
                 "Kernel is running over TCP without encryption."
                 " All communication (including code and outputs) is sent in plain text"
                 " and is susceptible to eavesdropping."
-                " Use IPC transport or set IPKernelApp.enable_curve=True to enable"
-                " CurveZMQ encryption."
+                " Use IPC transport or launch with kernel manager-provisioned"
+                " CurveZMQ keys to enable transport encryption."
             )
 
         self.shell_socket = context.socket(zmq.ROUTER)
@@ -439,8 +424,8 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp, ConnectionFileMix
         self.heartbeat = Heartbeat(
             hb_ctx,
             (self.transport, self.ip, self.hb_port),
-            curve_publickey=self._curve_publickey if self.enable_curve else None,
-            curve_secretkey=self._curve_secretkey if self.enable_curve else None,
+            curve_publickey=self.curve_publickey,
+            curve_secretkey=self.curve_secretkey,
         )
         self.hb_port = self.heartbeat.port
         self.log.debug("Heartbeat REP Channel on port: %i", self.hb_port)

--- a/ipykernel/kernelapp.py
+++ b/ipykernel/kernelapp.py
@@ -228,6 +228,14 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp, ConnectionFileMix
             socket.curve_publickey = self.curve_publickey
             socket.curve_server = True
 
+    def _apply_curve_client_options(self, socket: zmq.Socket[t.Any]) -> None:
+        """Set CurveZMQ client-side options on *socket* before it connects."""
+        if self.curve_secretkey is not None:
+            socket.curve_serverkey = self.curve_publickey
+            # Reuse manager-provisioned keypair for the in-kernel client socket.
+            socket.curve_secretkey = self.curve_secretkey
+            socket.curve_publickey = self.curve_publickey
+
     def init_poller(self):
         """Initialize the poller."""
         if sys.platform == "win32":
@@ -393,6 +401,7 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp, ConnectionFileMix
 
         self.debug_shell_socket = context.socket(zmq.DEALER)
         self.debug_shell_socket.linger = 1000
+        self._apply_curve_client_options(self.debug_shell_socket)
         if self.shell_socket.getsockopt(zmq.LAST_ENDPOINT):
             self.debug_shell_socket.connect(self.shell_socket.getsockopt(zmq.LAST_ENDPOINT))
 

--- a/ipykernel/kernelapp.py
+++ b/ipykernel/kernelapp.py
@@ -224,7 +224,7 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp, ConnectionFileMix
         # write uncaught traceback to 'real' stderr, not zmq-forwarder
         traceback.print_exception(etype, evalue, tb, file=sys.__stderr__)
 
-    def _apply_curve_server_options(self, socket: zmq.sugar.socket.Socket) -> None:
+    def _apply_curve_server_options(self, socket: zmq.Socket[t.Any]) -> None:
         """Set CurveZMQ server-side options on *socket* before it is bound.
 
         This is a no-op when enable_curve is False or keys have not been

--- a/ipykernel/kernelapp.py
+++ b/ipykernel/kernelapp.py
@@ -299,11 +299,9 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp, ConnectionFileMix
             control_port=self.control_port,
         )
         if self.enable_curve and self._curve_publickey is not None:
-            # Store Z85-encoded keys as ASCII strings alongside the HMAC key.
-            # Clients that understand CurveZMQ will use these to configure
-            # their sockets; legacy clients ignore the unknown fields.
-            connection_info["curve_publickey"] = self._curve_publickey.decode("ascii")
-            connection_info["curve_secretkey"] = self._curve_secretkey.decode("ascii")  # type: ignore[union-attr]
+            # write_connection_file() in jupyter-client handles JSON-safe key serialization
+            connection_info["curve_publickey"] = self._curve_publickey
+            connection_info["curve_secretkey"] = self._curve_secretkey
         if Path(cf).exists():
             # If the file exists, merge our info into it. For example, if the
             # original file had port number 0, we update with the actual port

--- a/ipykernel/kernelapp.py
+++ b/ipykernel/kernelapp.py
@@ -188,6 +188,19 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp, ConnectionFileMix
     """,
     ).tag(config=True)
 
+    enable_curve = Bool(
+        bool(int(os.environ.get("JUPYTER_ENABLE_CURVE", "0"))),
+        help="Enable CurveZMQ transport encryption and authentication. "
+        "When True, a keypair is generated at startup and stored in the "
+        "connection file so that clients can authenticate and encrypt "
+        "all ZMQ channels.",
+    ).tag(config=True)
+
+    # Internal CurveZMQ keypair (Z85-encoded bytes); populated in init_sockets
+    # when enable_curve is True.
+    _curve_publickey: bytes | None = None
+    _curve_secretkey: bytes | None = None
+
     # polling
     parent_handle = Integer(
         int(os.environ.get("JPY_PARENT_PID") or 0),
@@ -210,6 +223,17 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp, ConnectionFileMix
         """Handle an exception."""
         # write uncaught traceback to 'real' stderr, not zmq-forwarder
         traceback.print_exception(etype, evalue, tb, file=sys.__stderr__)
+
+    def _apply_curve_server_options(self, socket: zmq.sugar.socket.Socket) -> None:
+        """Set CurveZMQ server-side options on *socket* before it is bound.
+
+        This is a no-op when enable_curve is False or keys have not been
+        generated yet, so it is safe to call unconditionally.
+        """
+        if self.enable_curve and self._curve_secretkey is not None:
+            socket.curve_secretkey = self._curve_secretkey
+            socket.curve_publickey = self._curve_publickey
+            socket.curve_server = True
 
     def init_poller(self):
         """Initialize the poller."""
@@ -274,6 +298,12 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp, ConnectionFileMix
             iopub_port=self.iopub_port,
             control_port=self.control_port,
         )
+        if self.enable_curve and self._curve_publickey is not None:
+            # Store Z85-encoded keys as ASCII strings alongside the HMAC key.
+            # Clients that understand CurveZMQ will use these to configure
+            # their sockets; legacy clients ignore the unknown fields.
+            connection_info["curve_publickey"] = self._curve_publickey.decode("ascii")
+            connection_info["curve_secretkey"] = self._curve_secretkey.decode("ascii")  # type: ignore[union-attr]
         if Path(cf).exists():
             # If the file exists, merge our info into it. For example, if the
             # original file had port number 0, we update with the actual port
@@ -328,13 +358,19 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp, ConnectionFileMix
         self.context = context = zmq.Context()
         atexit.register(self.close)
 
+        if self.enable_curve:
+            self._curve_publickey, self._curve_secretkey = zmq.curve_keypair()
+            self.log.debug("CurveZMQ enabled; generated server keypair")
+
         self.shell_socket = context.socket(zmq.ROUTER)
         self.shell_socket.linger = 1000
+        self._apply_curve_server_options(self.shell_socket)
         self.shell_port = self._bind_socket(self.shell_socket, self.shell_port)
         self.log.debug("shell ROUTER Channel on port: %i", self.shell_port)
 
         self.stdin_socket = context.socket(zmq.ROUTER)
         self.stdin_socket.linger = 1000
+        self._apply_curve_server_options(self.stdin_socket)
         self.stdin_port = self._bind_socket(self.stdin_socket, self.stdin_port)
         self.log.debug("stdin ROUTER Channel on port: %i", self.stdin_port)
 
@@ -351,6 +387,7 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp, ConnectionFileMix
         """Initialize the control channel."""
         self.control_socket = context.socket(zmq.ROUTER)
         self.control_socket.linger = 1000
+        self._apply_curve_server_options(self.control_socket)
         self.control_port = self._bind_socket(self.control_socket, self.control_port)
         self.log.debug("control ROUTER Channel on port: %i", self.control_port)
 
@@ -379,6 +416,7 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp, ConnectionFileMix
         """Initialize the iopub channel."""
         self.iopub_socket = context.socket(zmq.XPUB)
         self.iopub_socket.linger = 1000
+        self._apply_curve_server_options(self.iopub_socket)
         self.iopub_port = self._bind_socket(self.iopub_socket, self.iopub_port)
         self.log.debug("iopub PUB Channel on port: %i", self.iopub_port)
         self.configure_tornado_logger()
@@ -392,7 +430,12 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp, ConnectionFileMix
         # heartbeat doesn't share context, because it mustn't be blocked
         # by the GIL, which is accessed by libzmq when freeing zero-copy messages
         hb_ctx = zmq.Context()
-        self.heartbeat = Heartbeat(hb_ctx, (self.transport, self.ip, self.hb_port))
+        self.heartbeat = Heartbeat(
+            hb_ctx,
+            (self.transport, self.ip, self.hb_port),
+            curve_publickey=self._curve_publickey if self.enable_curve else None,
+            curve_secretkey=self._curve_secretkey if self.enable_curve else None,
+        )
         self.hb_port = self.heartbeat.port
         self.log.debug("Heartbeat REP Channel on port: %i", self.hb_port)
         self.heartbeat.start()

--- a/ipykernel/kernelspec.py
+++ b/ipykernel/kernelspec.py
@@ -66,7 +66,7 @@ def get_kernel_dict(
         ),
         "display_name": "Python %i (ipykernel)" % sys.version_info[0],
         "language": "python",
-        "metadata": {"debugger": True},
+        "metadata": {"debugger": True, "supported_encryption": "curve"},
         "kernel_protocol_version": "5.5",
     }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "ipython>=7.23.1",
     "comm>=0.1.1",
     "traitlets>=5.4.0",
-    "jupyter_client @ git+https://github.com/krassowski/jupyter_client.git@add-curve-encryption",
+    "jupyter_client>=8.9.0",
     "jupyter_core>=5.1,!=6.0.*",
     # For tk event loop support only.
     "nest_asyncio2>=1.7.0",
@@ -70,9 +70,6 @@ cov = [
 ]
 pyqt5 = ["pyqt5"]
 pyside6 = ["pyside6"]
-
-[tool.hatch.metadata]
-allow-direct-references = true
 
 [tool.hatch.version]
 path = "ipykernel/_version.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,9 @@ cov = [
 pyqt5 = ["pyqt5"]
 pyside6 = ["pyside6"]
 
+[tool.hatch.metadata]
+allow-direct-references = true
+
 [tool.hatch.version]
 path = "ipykernel/_version.py"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "ipython>=7.23.1",
     "comm>=0.1.1",
     "traitlets>=5.4.0",
-    "jupyter_client>=8.8.0",
+    "jupyter_client @ git+https://github.com/krassowski/jupyter_client.git@add-curve-encryption",
     "jupyter_core>=5.1,!=6.0.*",
     # For tk event loop support only.
     "nest_asyncio2>=1.7.0",

--- a/tests/test_curve.py
+++ b/tests/test_curve.py
@@ -220,7 +220,7 @@ def _make_app(tmp_path, *, enable_curve=False, **kwargs):
             kernel_name=kernel_name,
             kernel_spec_manager=KernelSpecManager(kernel_dirs=[str(kernels_dir)]),
         )
-        km.transport_encryption = "enabled"
+        km.transport_encryption = "auto"
         km.pre_start_kernel()
 
     app = IPKernelApp(connection_file=connection_file_path, **kwargs)

--- a/tests/test_curve.py
+++ b/tests/test_curve.py
@@ -3,11 +3,11 @@
 
 import json
 import time
-from pathlib import Path
 
 import pytest
 import zmq
 from jupyter_client import KernelManager
+from jupyter_client.kernelspec import KernelSpecManager
 
 from ipykernel.kernelapp import IPKernelApp
 
@@ -28,6 +28,8 @@ def curve_enabled_kernel_app(tmp_path):
         yield app, connection_file_path
     finally:
         app.close()
+        if hasattr(app, "_curve_seed_manager"):
+            app._curve_seed_manager.cleanup_connection_file()
 
 
 def test_connection_file_no_curve_keys_by_default(curve_disabled_kernel_app):
@@ -195,17 +197,38 @@ def test_curve_debug_shell_socket_can_communicate(curve_enabled_kernel_app):
 def _make_app(tmp_path, *, enable_curve=False, **kwargs):
     """Return a minimal IPKernelApp rooted in temporary directory *tmp_path*."""
     connection_file_path = str(tmp_path / "kernel.json")
+    km = None
     if enable_curve:
+        kernel_name = "curve-test"
+        kernels_dir = tmp_path / "kernels"
+        kernel_dir = kernels_dir / kernel_name
+        kernel_dir.mkdir(parents=True)
+        with (kernel_dir / "kernel.json").open("w") as f:
+            json.dump(
+                {
+                    "argv": ["python", "-m", "ipykernel_launcher", "-f", "{connection_file}"],
+                    "display_name": "curve-test",
+                    "language": "python",
+                    "metadata": {"supported_encryption": "curve"},
+                },
+                f,
+            )
+
         # Populate the Curve keys into the connection file
-        km = KernelManager(connection_file=connection_file_path)
+        km = KernelManager(
+            connection_file=connection_file_path,
+            kernel_name=kernel_name,
+            kernel_spec_manager=KernelSpecManager(kernel_dirs=[str(kernels_dir)]),
+        )
         km.transport_encryption = "enabled"
         km.pre_start_kernel()
-        for _ in range(100):
-            if Path(connection_file_path).exists():
-                break
-            time.sleep(0.01)
 
     app = IPKernelApp(connection_file=connection_file_path, **kwargs)
+    if km is not None:
+        # Keep the seeding manager alive for the test lifetime.
+        # Its destructor cleans up the connection file, which is otherwise
+        # timing-dependent across Python versions.
+        app._curve_seed_manager = km
     # Replicate the subset of initialize() that sets up connection info
     # without importing IPython shell machinery.
     super(IPKernelApp, app).initialize(argv=[""])

--- a/tests/test_curve.py
+++ b/tests/test_curve.py
@@ -3,6 +3,7 @@
 
 import json
 import time
+from pathlib import Path
 
 import pytest
 import zmq
@@ -199,6 +200,10 @@ def _make_app(tmp_path, *, enable_curve=False, **kwargs):
         km = KernelManager(connection_file=connection_file_path)
         km.transport_encryption = "enabled"
         km.pre_start_kernel()
+        for _ in range(100):
+            if Path(connection_file_path).exists():
+                break
+            time.sleep(0.01)
 
     app = IPKernelApp(connection_file=connection_file_path, **kwargs)
     # Replicate the subset of initialize() that sets up connection info

--- a/tests/test_curve.py
+++ b/tests/test_curve.py
@@ -72,7 +72,7 @@ def test_curve_connection_file_has_keys(curve_enabled_kernel_app):
 
 def test_curve_keys_are_stable_per_startup(curve_enabled_kernel_app):
     """Keys generated at startup stay the same throughout the process lifetime."""
-    app, connection_file_path = curve_enabled_kernel_app
+    app, _connection_file_path = curve_enabled_kernel_app
     app.init_sockets()
     pub1 = app._curve_publickey
     # Writing the file twice should not regenerate keys.
@@ -83,7 +83,7 @@ def test_curve_keys_are_stable_per_startup(curve_enabled_kernel_app):
 
 def test_curve_socket_server_options(curve_enabled_kernel_app):
     """Bound sockets must have CURVE_SERVER=True when Curve is enabled."""
-    app, connection_file_path = curve_enabled_kernel_app
+    app, _connection_file_path = curve_enabled_kernel_app
     app.init_sockets()
     # shell and stdin are ROUTER sockets configured directly.
     assert app.shell_socket.curve_server, "shell_socket missing curve_server"
@@ -95,7 +95,7 @@ def test_curve_socket_server_options(curve_enabled_kernel_app):
 
 def test_no_curve_socket_options_when_disabled(curve_disabled_kernel_app):
     """No CURVE options are set when Curve is disabled (default)."""
-    app, connection_file_path = curve_disabled_kernel_app
+    app, _connection_file_path = curve_disabled_kernel_app
     app.init_sockets()
     # curve_server defaults to 0/False; key options are write-only.
     assert not app.shell_socket.curve_server
@@ -109,7 +109,7 @@ def test_curve_unauthenticated_socket_messages_dropped(curve_enabled_kernel_app)
     with test_transport_security.py in jupyter-client which shows the *absence*
     of this property today.
     """
-    app, connection_file_path = curve_enabled_kernel_app
+    app, _connection_file_path = curve_enabled_kernel_app
     app.init_sockets()
 
     # Build the endpoint URL from the bound port.
@@ -136,7 +136,7 @@ def test_curve_unauthenticated_socket_messages_dropped(curve_enabled_kernel_app)
 
 def test_curve_authenticated_socket_can_communicate(curve_enabled_kernel_app):
     """With CurveZMQ, a correctly-keyed client socket can reach the kernel."""
-    app, connection_file_path = curve_enabled_kernel_app
+    app, _connection_file_path = curve_enabled_kernel_app
     app.init_sockets()
 
     endpoint = f"tcp://{app.ip}:{app.shell_port}"

--- a/tests/test_curve.py
+++ b/tests/test_curve.py
@@ -1,0 +1,179 @@
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+import json
+import os
+import time
+
+import pytest
+import zmq
+
+from ipykernel.kernelapp import IPKernelApp
+
+
+@pytest.fixture
+def temp_folder_path(tmp_path):
+    return str(tmp_path)
+
+
+@pytest.fixture
+def curve_disabled_kernel_app(temp_folder_path):
+    app, connection_file_path = _make_app(temp_folder_path, enable_curve=False)
+    try:
+        yield app, connection_file_path
+    finally:
+        app.close()
+
+
+@pytest.fixture
+def curve_enabled_kernel_app(temp_folder_path):
+    app, connection_file_path = _make_app(temp_folder_path, enable_curve=True)
+    try:
+        yield app, connection_file_path
+    finally:
+        app.close()
+
+
+def test_curve_disabled_by_default():
+    """CurveZMQ must be off by default so existing kernels are unaffected."""
+    app = IPKernelApp()
+    assert app.enable_curve is False
+
+
+def test_connection_file_no_curve_keys_by_default(curve_disabled_kernel_app):
+    """Connection file must not contain curve keys when Curve is disabled."""
+    app, connection_file_path = curve_disabled_kernel_app
+    app.init_sockets()
+    app.init_heartbeat()
+    app.write_connection_file()
+    with open(connection_file_path) as f:
+        info = json.load(f)
+    assert "curve_publickey" not in info
+    assert "curve_secretkey" not in info
+
+
+def test_curve_connection_file_has_keys(curve_enabled_kernel_app):
+    """When Curve is enabled the connection file must carry both keys."""
+    app, connection_file_path = curve_enabled_kernel_app
+    app.init_sockets()
+    app.init_heartbeat()
+    app.write_connection_file()
+    with open(connection_file_path) as f:
+        info = json.load(f)
+    assert "curve_publickey" in info, "curve_publickey missing from connection file"
+    assert "curve_secretkey" in info, "curve_secretkey missing from connection file"
+    # Keys are Z85-encoded ASCII strings - always exactly 40 characters.
+    assert len(info["curve_publickey"]) == 40
+    assert len(info["curve_secretkey"]) == 40
+    # Existing fields must still be present (backward-compat check).
+    assert "key" in info
+    assert "shell_port" in info
+
+
+def test_curve_keys_are_stable_per_startup(curve_enabled_kernel_app):
+    """Keys generated at startup stay the same throughout the process lifetime."""
+    app, connection_file_path = curve_enabled_kernel_app
+    app.init_sockets()
+    pub1 = app._curve_publickey
+    # Writing the file twice should not regenerate keys.
+    app.init_heartbeat()
+    app.write_connection_file()
+    assert app._curve_publickey == pub1
+
+
+def test_curve_socket_server_options(curve_enabled_kernel_app):
+    """Bound sockets must have CURVE_SERVER=True when Curve is enabled."""
+    app, connection_file_path = curve_enabled_kernel_app
+    app.init_sockets()
+    # shell and stdin are ROUTER sockets configured directly.
+    assert app.shell_socket.curve_server, "shell_socket missing curve_server"
+    assert app.stdin_socket.curve_server, "stdin_socket missing curve_server"
+    assert app.control_socket.curve_server, "control_socket missing curve_server"
+    # Key material is write-only in pyzmq; we verify it was applied
+    # through the curve_server flag and the reject test below.
+
+
+def test_no_curve_socket_options_when_disabled(curve_disabled_kernel_app):
+    """No CURVE options are set when Curve is disabled (default)."""
+    app, connection_file_path = curve_disabled_kernel_app
+    app.init_sockets()
+    # curve_server defaults to 0/False; key options are write-only.
+    assert not app.shell_socket.curve_server
+
+
+def test_curve_unauthenticated_socket_messages_dropped(curve_enabled_kernel_app):
+    """With CurveZMQ, frames from a socket without the server key are dropped.
+
+    This is the core security property: a raw DEALER socket that connects to
+    a CURVE_SERVER-enabled ROUTER cannot deliver messages to it.  Compare
+    with test_transport_security.py in jupyter-client which shows the *absence*
+    of this property today.
+    """
+    app, connection_file_path = curve_enabled_kernel_app
+    app.init_sockets()
+
+    # Build the endpoint URL from the bound port.
+    endpoint = f"tcp://{app.ip}:{app.shell_port}"
+
+    ctx = zmq.Context()
+    unauth = ctx.socket(zmq.DEALER)
+    try:
+        unauth.connect(endpoint)
+        # ZMQ delivers the connect synchronously, but the curve
+        # handshake silently drops the message.
+        unauth.send(b"probe", flags=zmq.NOBLOCK)
+
+        poller = zmq.Poller()
+        poller.register(app.shell_socket, zmq.POLLIN)
+        events = dict(poller.poll(timeout=300))
+        assert app.shell_socket not in events, (
+            "Unauthenticated message reached the kernel socket - "
+            "CurveZMQ should have dropped it"
+        )
+    finally:
+        unauth.close(linger=0)
+        ctx.term()
+
+
+def test_curve_authenticated_socket_can_communicate(curve_enabled_kernel_app):
+    """With CurveZMQ, a correctly-keyed client socket can reach the kernel."""
+    app, connection_file_path = curve_enabled_kernel_app
+    app.init_sockets()
+
+    endpoint = f"tcp://{app.ip}:{app.shell_port}"
+    server_public = app._curve_publickey
+
+    ctx = zmq.Context()
+    auth_client = ctx.socket(zmq.DEALER)
+    # Client uses the server's public key as CURVE_SERVERKEY; its own
+    # keypair is used only for encryption, not for access control.
+    client_pub, client_sec = zmq.curve_keypair()
+    auth_client.curve_secretkey = client_sec
+    auth_client.curve_publickey = client_pub
+    auth_client.curve_serverkey = server_public
+    try:
+        auth_client.connect(endpoint)
+        # Allow the handshake to complete.
+        time.sleep(0.05)
+        auth_client.send(b"probe", flags=zmq.NOBLOCK)
+
+        poller = zmq.Poller()
+        poller.register(app.shell_socket, zmq.POLLIN)
+        events = dict(poller.poll(timeout=1000))
+        assert app.shell_socket in events, (
+            "Authenticated client message was not received by kernel socket"
+        )
+    finally:
+        auth_client.close(linger=0)
+        ctx.term()
+
+
+def _make_app(temp_folder_path, **kwargs):
+    """Return a minimal IPKernelApp rooted in temporary directory *temp_folder_path*."""
+    connection_file_path = os.path.join(temp_folder_path, "kernel.json")
+    app = IPKernelApp(connection_file=connection_file_path, **kwargs)
+    # Replicate the subset of initialize() that sets up connection info
+    # without importing IPython shell machinery.
+    super(IPKernelApp, app).initialize(argv=[""])
+    app.init_connection_file()
+    return app, connection_file_path

--- a/tests/test_curve.py
+++ b/tests/test_curve.py
@@ -6,6 +6,7 @@ import time
 
 import pytest
 import zmq
+from jupyter_client import KernelManager
 
 from ipykernel.kernelapp import IPKernelApp
 
@@ -26,12 +27,6 @@ def curve_enabled_kernel_app(tmp_path):
         yield app, connection_file_path
     finally:
         app.close()
-
-
-def test_curve_disabled_by_default():
-    """CurveZMQ must be off by default so existing kernels are unaffected."""
-    app = IPKernelApp()
-    assert app.enable_curve is False
 
 
 def test_connection_file_no_curve_keys_by_default(curve_disabled_kernel_app):
@@ -65,14 +60,14 @@ def test_curve_connection_file_has_keys(curve_enabled_kernel_app):
 
 
 def test_curve_keys_are_stable_per_startup(curve_enabled_kernel_app):
-    """Keys generated at startup stay the same throughout the process lifetime."""
+    """Provisioned keys stay unchanged throughout the kernel process lifetime."""
     app, _connection_file_path = curve_enabled_kernel_app
     app.init_sockets()
-    pub1 = app._curve_publickey
+    pub1 = app.curve_publickey
     # Writing the file twice should not regenerate keys.
     app.init_heartbeat()
     app.write_connection_file()
-    assert app._curve_publickey == pub1
+    assert app.curve_publickey == pub1
 
 
 def test_curve_socket_server_options(curve_enabled_kernel_app):
@@ -134,7 +129,7 @@ def test_curve_authenticated_socket_can_communicate(curve_enabled_kernel_app):
     app.init_sockets()
 
     endpoint = f"tcp://{app.ip}:{app.shell_port}"
-    server_public = app._curve_publickey
+    server_public = app.curve_publickey
 
     ctx = zmq.Context()
     auth_client = ctx.socket(zmq.DEALER)
@@ -161,9 +156,33 @@ def test_curve_authenticated_socket_can_communicate(curve_enabled_kernel_app):
         ctx.term()
 
 
-def _make_app(tmp_path, **kwargs):
+def test_manager_provisioned_curve_keys_are_used(curve_enabled_kernel_app):
+    """Kernel uses manager-provisioned Curve keys exactly as provided."""
+    app, _connection_file_path = curve_enabled_kernel_app
+    try:
+        with open(_connection_file_path) as f:
+            info = json.load(f)
+
+        app.init_sockets()
+
+        assert app.curve_publickey == info["curve_publickey"].encode()
+        assert app.curve_secretkey == info["curve_secretkey"].encode()
+        assert app.shell_socket.curve_server
+        assert app.stdin_socket.curve_server
+        assert app.control_socket.curve_server
+    finally:
+        app.close()
+
+
+def _make_app(tmp_path, *, enable_curve=False, **kwargs):
     """Return a minimal IPKernelApp rooted in temporary directory *tmp_path*."""
     connection_file_path = str(tmp_path / "kernel.json")
+    if enable_curve:
+        # Populate the Curve keys into the connection file
+        km = KernelManager(connection_file=connection_file_path)
+        km.transport_encryption = True
+        km.pre_start_kernel()
+
     app = IPKernelApp(connection_file=connection_file_path, **kwargs)
     # Replicate the subset of initialize() that sets up connection info
     # without importing IPython shell machinery.

--- a/tests/test_curve.py
+++ b/tests/test_curve.py
@@ -2,7 +2,6 @@
 # Distributed under the terms of the Modified BSD License.
 
 import json
-import os
 import time
 
 import pytest
@@ -12,13 +11,8 @@ from ipykernel.kernelapp import IPKernelApp
 
 
 @pytest.fixture
-def temp_folder_path(tmp_path):
-    return str(tmp_path)
-
-
-@pytest.fixture
-def curve_disabled_kernel_app(temp_folder_path):
-    app, connection_file_path = _make_app(temp_folder_path, enable_curve=False)
+def curve_disabled_kernel_app(tmp_path):
+    app, connection_file_path = _make_app(tmp_path, enable_curve=False)
     try:
         yield app, connection_file_path
     finally:
@@ -26,8 +20,8 @@ def curve_disabled_kernel_app(temp_folder_path):
 
 
 @pytest.fixture
-def curve_enabled_kernel_app(temp_folder_path):
-    app, connection_file_path = _make_app(temp_folder_path, enable_curve=True)
+def curve_enabled_kernel_app(tmp_path):
+    app, connection_file_path = _make_app(tmp_path, enable_curve=True)
     try:
         yield app, connection_file_path
     finally:
@@ -167,9 +161,9 @@ def test_curve_authenticated_socket_can_communicate(curve_enabled_kernel_app):
         ctx.term()
 
 
-def _make_app(temp_folder_path, **kwargs):
-    """Return a minimal IPKernelApp rooted in temporary directory *temp_folder_path*."""
-    connection_file_path = os.path.join(temp_folder_path, "kernel.json")
+def _make_app(tmp_path, **kwargs):
+    """Return a minimal IPKernelApp rooted in temporary directory *tmp_path*."""
+    connection_file_path = str(tmp_path / "kernel.json")
     app = IPKernelApp(connection_file=connection_file_path, **kwargs)
     # Replicate the subset of initialize() that sets up connection info
     # without importing IPython shell machinery.

--- a/tests/test_curve.py
+++ b/tests/test_curve.py
@@ -127,8 +127,7 @@ def test_curve_unauthenticated_socket_messages_dropped(curve_enabled_kernel_app)
         poller.register(app.shell_socket, zmq.POLLIN)
         events = dict(poller.poll(timeout=300))
         assert app.shell_socket not in events, (
-            "Unauthenticated message reached the kernel socket - "
-            "CurveZMQ should have dropped it"
+            "Unauthenticated message reached the kernel socket - CurveZMQ should have dropped it"
         )
     finally:
         unauth.close(linger=0)

--- a/tests/test_curve.py
+++ b/tests/test_curve.py
@@ -174,6 +174,23 @@ def test_manager_provisioned_curve_keys_are_used(curve_enabled_kernel_app):
         app.close()
 
 
+def test_curve_debug_shell_socket_can_communicate(curve_enabled_kernel_app):
+    """Debugger shell socket can talk to the shell ROUTER when Curve is enabled."""
+    app, _connection_file_path = curve_enabled_kernel_app
+    app.init_sockets()
+
+    # Allow the Curve handshake to complete before sending a probe.
+    time.sleep(0.05)
+    app.debug_shell_socket.send(b"debug-probe", flags=zmq.NOBLOCK)
+
+    poller = zmq.Poller()
+    poller.register(app.shell_socket, zmq.POLLIN)
+    events = dict(poller.poll(timeout=1000))
+    assert app.shell_socket in events, (
+        "debug_shell_socket could not reach shell_socket with Curve enabled"
+    )
+
+
 def _make_app(tmp_path, *, enable_curve=False, **kwargs):
     """Return a minimal IPKernelApp rooted in temporary directory *tmp_path*."""
     connection_file_path = str(tmp_path / "kernel.json")

--- a/tests/test_curve.py
+++ b/tests/test_curve.py
@@ -180,7 +180,7 @@ def _make_app(tmp_path, *, enable_curve=False, **kwargs):
     if enable_curve:
         # Populate the Curve keys into the connection file
         km = KernelManager(connection_file=connection_file_path)
-        km.transport_encryption = True
+        km.transport_encryption = "enabled"
         km.pre_start_kernel()
 
     app = IPKernelApp(connection_file=connection_file_path, **kwargs)

--- a/tests/test_kernelapp.py
+++ b/tests/test_kernelapp.py
@@ -129,3 +129,27 @@ def test_trio_loop():
     app.io_loop.add_callback(app.io_loop.stop)
     app.kernel.destroy()
     app.close()
+
+
+def test_init_sockets_curve_enabled_logs_debug():
+    app = IPKernelApp(enable_curve=True)
+    with patch.object(app.log, "debug") as mock_debug:
+        app.init_sockets()
+    app.cleanup_connection_file()
+    app.close()
+    messages = [str(call) for call in mock_debug.call_args_list]
+    assert any("CurveZMQ enabled" in m for m in messages), (
+        "Expected a debug log mentioning CurveZMQ when enable_curve=True"
+    )
+
+
+def test_init_sockets_tcp_without_curve_logs_warning():
+    app = IPKernelApp(transport="tcp", enable_curve=False)
+    with patch.object(app.log, "warning") as mock_warning:
+        app.init_sockets()
+    app.cleanup_connection_file()
+    app.close()
+    messages = [str(call) for call in mock_warning.call_args_list]
+    assert any("Kernel is running over TCP without encryption" in m for m in messages), (
+        "Expected a warning about missing encryption when transport=tcp and enable_curve=False"
+    )

--- a/tests/test_kernelapp.py
+++ b/tests/test_kernelapp.py
@@ -155,7 +155,7 @@ def test_init_sockets_curve_enabled_logs_debug(tmp_path):
         kernel_name=kernel_name,
         kernel_spec_manager=KernelSpecManager(kernel_dirs=[str(kernels_dir)]),
     )
-    km.transport_encryption = "enabled"
+    km.transport_encryption = "auto"
     km.pre_start_kernel()
 
     app = IPKernelApp(connection_file=connection_file)

--- a/tests/test_kernelapp.py
+++ b/tests/test_kernelapp.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 
 import pytest
 from jupyter_client import KernelManager
+from jupyter_client.kernelspec import KernelSpecManager
 from jupyter_core.paths import secure_write
 from traitlets.config.loader import Config
 
@@ -133,19 +134,38 @@ def test_trio_loop():
 
 
 def test_init_sockets_curve_enabled_logs_debug(tmp_path):
+    kernel_name = "curve-test"
+    kernels_dir = tmp_path / "kernels"
+    kernel_dir = kernels_dir / kernel_name
+    kernel_dir.mkdir(parents=True)
+    with (kernel_dir / "kernel.json").open("w") as f:
+        json.dump(
+            {
+                "argv": ["python", "-m", "ipykernel_launcher", "-f", "{connection_file}"],
+                "display_name": "curve-test",
+                "language": "python",
+                "metadata": {"supported_encryption": "curve"},
+            },
+            f,
+        )
+
     connection_file = str(tmp_path / "kernel.json")
-    km = KernelManager(connection_file=connection_file)
-    km.transport_encryption = True
+    km = KernelManager(
+        connection_file=connection_file,
+        kernel_name=kernel_name,
+        kernel_spec_manager=KernelSpecManager(kernel_dirs=[str(kernels_dir)]),
+    )
+    km.transport_encryption = "enabled"
     km.pre_start_kernel()
 
     app = IPKernelApp(connection_file=connection_file)
     super(IPKernelApp, app).initialize(argv=[""])
     app.init_connection_file()
-    with patch.object(app.log, "debug") as mock_debug:
+    with patch.object(app.log, "info") as mock_info:
         app.init_sockets()
     app.cleanup_connection_file()
     app.close()
-    messages = [str(call) for call in mock_debug.call_args_list]
+    messages = [str(call) for call in mock_info.call_args_list]
     assert any("Detected CurveZMQ secret key; using transport encryption" in m for m in messages), (
         "Expected a debug log mentioning CurveZMQ when keys are provided"
     )

--- a/tests/test_kernelapp.py
+++ b/tests/test_kernelapp.py
@@ -5,6 +5,7 @@ import time
 from unittest.mock import patch
 
 import pytest
+from jupyter_client import KernelManager
 from jupyter_core.paths import secure_write
 from traitlets.config.loader import Config
 
@@ -131,25 +132,32 @@ def test_trio_loop():
     app.close()
 
 
-def test_init_sockets_curve_enabled_logs_debug():
-    app = IPKernelApp(enable_curve=True)
+def test_init_sockets_curve_enabled_logs_debug(tmp_path):
+    connection_file = str(tmp_path / "kernel.json")
+    km = KernelManager(connection_file=connection_file)
+    km.transport_encryption = True
+    km.pre_start_kernel()
+
+    app = IPKernelApp(connection_file=connection_file)
+    super(IPKernelApp, app).initialize(argv=[""])
+    app.init_connection_file()
     with patch.object(app.log, "debug") as mock_debug:
         app.init_sockets()
     app.cleanup_connection_file()
     app.close()
     messages = [str(call) for call in mock_debug.call_args_list]
-    assert any("CurveZMQ enabled" in m for m in messages), (
-        "Expected a debug log mentioning CurveZMQ when enable_curve=True"
+    assert any("Detected CurveZMQ secret key; using transport encryption" in m for m in messages), (
+        "Expected a debug log mentioning CurveZMQ when keys are provided"
     )
 
 
 def test_init_sockets_tcp_without_curve_logs_warning():
-    app = IPKernelApp(transport="tcp", enable_curve=False)
+    app = IPKernelApp(transport="tcp")
     with patch.object(app.log, "warning") as mock_warning:
         app.init_sockets()
     app.cleanup_connection_file()
     app.close()
     messages = [str(call) for call in mock_warning.call_args_list]
     assert any("Kernel is running over TCP without encryption" in m for m in messages), (
-        "Expected a warning about missing encryption when transport=tcp and enable_curve=False"
+        "Expected a warning about missing encryption when transport=tcp without curve keys"
     )

--- a/tests/test_kernelspec.py
+++ b/tests/test_kernelspec.py
@@ -35,6 +35,8 @@ def assert_kernel_dict(d):
     assert d["argv"] == make_ipkernel_cmd()
     assert d["display_name"] == "Python %i (ipykernel)" % sys.version_info[0]
     assert d["language"] == "python"
+    assert d["metadata"]["debugger"] is True
+    assert d["metadata"]["supported_encryption"] == "curve"
     assert d["kernel_protocol_version"] == "5.5"
 
 
@@ -47,6 +49,8 @@ def assert_kernel_dict_with_profile(d):
     assert d["argv"] == make_ipkernel_cmd(extra_arguments=["--profile", "test"])
     assert d["display_name"] == "Python %i (ipykernel)" % sys.version_info[0]
     assert d["language"] == "python"
+    assert d["metadata"]["debugger"] is True
+    assert d["metadata"]["supported_encryption"] == "curve"
     assert d["kernel_protocol_version"] == "5.5"
 
 


### PR DESCRIPTION
This PR adds support for ZMQ Curve cryptography to encrypt kernel communications over TCP, addressing the current limitation of all code and outputs being transmitted in plaintext.

What's changed

- Curve key support in IPKernelApp: Loads `curve_publickey` / `curve_secretkey` from   connection files and applies them to all ZMQ sockets (`iopub`, `shell`, `control`,  `stdin`, `heartbeat`) via new `_apply_curve_server_options()` /  `_apply_curve_client_options()` helpers.
- Kernelspec metadata: Advertises `"supported_encryption": "curve"` so frontends can discover and negotiate encryption capability.
- Emits a warning when TCP transport is used without encryption, guiding users toward IPC or CurveZMQ.
- Heartbeat thread: Extended to accept and apply curve keys to its ROUTER socket.


### References

- Depends on https://github.com/jupyter/jupyter_client/pull/1110
- Enables https://github.com/jupyter/jupyter_client/issues/808
- PoC for https://github.com/jupyter/enhancement-proposals/issues/75
- Toggle on server-level: https://github.com/jupyter-server/jupyter_server/pull/1638

### Code changes

- [x] tests
- [x] additions