### PR TITLE
Fix downstream test: do not use editable install for `ipyparallel`

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -69,7 +69,7 @@ jobs:
         uses: jupyterlab/maintainer-tools/.github/actions/downstream-test@v1
         with:
           package_name: ipyparallel
-          package_spec: '-e ".[test]"'
+          package_spec: ".[test]"
 
   jupyter_kernel_test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
- Same as https://github.com/jupyter/jupyter_client/pull/1116
- Due to https://github.com/jupyterlab/maintainer-tools/pull/275