### PR TITLE
Revert warning suppresion in docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -124,12 +124,6 @@ pygments_style = "sphinx"
 # If true, keep warnings as "system message" paragraphs in the built documents.
 # keep_warnings = False
 
-suppress_warnings = [
-    # Remove both once fix for https://github.com/ipython/ipython/issues/15202 is released
-    "sphinx_autodoc_typehints.forward_reference",
-    "sphinx_autodoc_typehints.guarded_import",
-]
-
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = False
 


### PR DESCRIPTION
To be merged once https://github.com/ipython/ipython/pull/15203 is released and CI passes after re-trigger.

Follow-up to #1517 