### PR TITLE
Mark cell execution as failing when formatter errors out

### DIFF
--- a/ipykernel/ipkernel.py
+++ b/ipykernel/ipkernel.py
@@ -465,7 +465,9 @@ class IPythonKernel(KernelBase):
 
         err = res.error_before_exec if res.error_before_exec is not None else res.error_in_exec
 
-        if res.success:
+        displayhook_error = getattr(shell, "_last_traceback_during_displayhook", False)
+
+        if res.success and not displayhook_error:
             reply_content["status"] = "ok"
         else:
             reply_content["status"] = "error"

--- a/ipykernel/zmqshell.py
+++ b/ipykernel/zmqshell.py
@@ -661,6 +661,7 @@ class ZMQInteractiveShell(InteractiveShell):
     def run_cell(self, *args, **kwargs):
         """Run a cell."""
         self._last_traceback = None
+        self._last_traceback_during_displayhook = False
         return super().run_cell(*args, **kwargs)
 
     def _showtraceback(self, etype, evalue, stb):
@@ -675,6 +676,10 @@ class ZMQInteractiveShell(InteractiveShell):
         }
 
         dh = self.displayhook
+        if getattr(dh, "msg", None) is not None:
+            # Errors raised while formatting display output should mark the
+            # current execute_request as failed.
+            self._last_traceback_during_displayhook = True
         # Send exception info over pub socket for other clients than the caller
         # to pick up
         topic = None

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -58,6 +58,42 @@ def test_simple_print():
         _check_master(kc, expected=True)
 
 
+@pytest.mark.parametrize(
+    ("code", "expect_error_status"),
+    [
+        ("1/0", True),
+        (
+            """
+            class Test:
+                def __repr__(self):
+                    1 / 0
+
+            Test()
+            """,
+            True,
+        ),
+        (
+            """
+            ip = get_ipython()
+            try:
+                1 / 0
+            except:
+                ip.showtraceback()
+            """,
+            False,
+        ),
+    ],
+    ids=["runtime-error", "display-formatting-error", "explicit-showtraceback-ok"],
+)
+def test_execute_reply_error_status(code, expect_error_status):
+    with kernel() as kc:
+        msg_id, reply = execute(kc=kc, code=code)
+        assemble_output(kc.get_iopub_msg, parent_msg_id=msg_id, raise_error=False)
+
+        has_error_status = reply["status"] == "error"
+        assert has_error_status is expect_error_status, reply
+
+
 def collect_outputs(get_iopub_msg, parent_msg_id, timeout=5):
     """Collect outputs until we get an idle message
 


### PR DESCRIPTION
### References

- Fixes #1520

### Code changes

- [x] Adds a test case that should fail in first commit
- [x] Marks execution as failed if tracebacks are shown during display formatting phase

### User-facing changes

Notifications using plugins that check cell execution status will correctly fire on errors.

| Before | After |
|--|--|
| <img width="1455" height="482" alt="image" src="https://github.com/user-attachments/assets/25dc6ab6-664a-4a4f-9024-9ab2846654cf" /> | <img width="1455" height="598" alt="image" src="https://github.com/user-attachments/assets/137652a0-80e9-4707-b2b1-acc2ed13c5c7" /> |

### Questions

1. Should we also include sensible `ename` and `evalue`?
2. Should downstreams instead listen to [`iopub.error`](https://jupyter-client.readthedocs.io/en/stable/messaging.html#execution-errors) to determine success status instead, which is emitted by both cases already? The protocol does not clarify this.
3. When `get_ipython().showtraceback()` is used in user code, should we mark execution as failed, or not? Currently I lean towards "not".