### PR TITLE
feat(displayhook): add register_hook/unregister_hook to ZMQShellDisplayHook

### DIFF
--- a/ipykernel/displayhook.py
+++ b/ipykernel/displayhook.py
@@ -6,12 +6,13 @@ from __future__ import annotations
 
 import builtins
 import sys
+import threading
 import typing as t
 from contextvars import ContextVar
 
 from IPython.core.displayhook import DisplayHook
 from jupyter_client.session import Session, extract_header
-from traitlets import Any, Instance
+from traitlets import Any, Instance, default
 
 from ipykernel.jsonutil import encode_images, json_clean
 
@@ -80,12 +81,40 @@ class ZMQShellDisplayHook(DisplayHook):
     session = Instance(Session, allow_none=True)
     pub_socket = Any(allow_none=True)
     _parent_header: ContextVar[dict[str, Any]]
+    _thread_local = Any()
     msg: dict[str, t.Any] | None
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._parent_header = ContextVar("parent_header")
         self._parent_header.set({})
+
+    @default("_thread_local")
+    def _default_thread_local(self):
+        return threading.local()
+
+    @property
+    def _hooks(self):
+        if not hasattr(self._thread_local, "hooks"):
+            self._thread_local.hooks = []
+        return self._thread_local.hooks
+
+    def register_hook(self, hook):
+        """Register a transform hook on the execute_result message.
+
+        Mirrors ``ZMQDisplayPublisher.register_hook``. Each hook receives the
+        outbound message dict and must return either a (possibly mutated)
+        message dict to continue the chain, or ``None`` to suppress the send.
+        """
+        self._hooks.append(hook)
+
+    def unregister_hook(self, hook):
+        """Remove a previously registered hook. Returns True on success."""
+        try:
+            self._hooks.remove(hook)
+            return True
+        except ValueError:
+            return False
 
     @property
     def parent_header(self):
@@ -124,9 +153,22 @@ class ZMQShellDisplayHook(DisplayHook):
             self.msg["content"]["metadata"] = md_dict
 
     def finish_displayhook(self):
-        """Finish up all displayhook activities."""
+        """Finish up all displayhook activities.
+
+        Runs the registered hook chain before ``session.send``. Each hook
+        either returns a message (to continue) or ``None`` (to suppress the
+        send). This mirrors the transform pipeline on
+        ``ZMQDisplayPublisher.publish`` so a single hook implementation can
+        attach to both the ``display_data`` and ``execute_result`` paths.
+        """
         sys.stdout.flush()
         sys.stderr.flush()
         if self.msg and self.msg["content"]["data"] and self.session:
-            self.session.send(self.pub_socket, self.msg, ident=self.topic)
+            msg = self.msg
+            for hook in self._hooks:
+                msg = hook(msg)
+                if msg is None:
+                    self.msg = None
+                    return
+            self.session.send(self.pub_socket, msg, ident=self.topic)
         self.msg = None

--- a/tests/test_displayhook.py
+++ b/tests/test_displayhook.py
@@ -1,0 +1,207 @@
+"""Tests for the ZMQ execute_result displayhook."""
+
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+import unittest
+from queue import Queue
+from threading import Thread
+
+import zmq
+from IPython.core.interactiveshell import InteractiveShell
+from jupyter_client.session import Session
+from traitlets import Int
+
+from ipykernel.displayhook import ZMQShellDisplayHook
+
+
+class NoReturnHook:
+    call_count = 0
+
+    def __call__(self, msg):
+        self.call_count += 1
+
+
+class ReturnHook(NoReturnHook):
+    def __call__(self, msg):
+        super().__call__(msg)
+        return msg
+
+
+class MutatingHook(NoReturnHook):
+    """Attaches a buffer to the message and returns it."""
+
+    def __call__(self, msg):
+        super().__call__(msg)
+        msg.setdefault("buffers", []).append(b"arrow-bytes")
+        return msg
+
+
+class CounterSession(Session):
+    send_count = Int(0)
+    last_msg = None
+
+    def send(self, *args, **kwargs):
+        self.send_count += 1
+        # args: (stream, msg_or_type, ...)
+        if len(args) >= 2:
+            self.last_msg = args[1]
+        return super().send(*args, **kwargs)
+
+
+def _drive(hook, data=None):
+    """Run a single execute_result emission through the hook."""
+    if data is None:
+        data = {"text/plain": "1"}
+    hook.start_displayhook()
+    hook.write_format_data(data, {})
+    hook.finish_displayhook()
+
+
+class ZMQShellDisplayHookTests(unittest.TestCase):
+    def setUp(self):
+        self.context = zmq.Context()
+        self.socket = self.context.socket(zmq.PUB)
+        self.session = CounterSession()
+        self.shell = InteractiveShell()
+        self.disp = ZMQShellDisplayHook(shell=self.shell)
+        self.disp.session = self.session
+        self.disp.pub_socket = self.socket
+
+    def tearDown(self):
+        self.socket.close()
+        self.context.term()
+
+    def test_no_hooks_sends_message(self):
+        """With no hooks registered, finish_displayhook still calls send."""
+        assert self.disp._hooks == []
+        _drive(self.disp)
+        assert self.session.send_count == 1
+
+    def test_thread_local_hooks(self):
+        """_hooks is thread-local: registering on one thread doesn't leak."""
+        assert self.disp._hooks == []
+
+        def hook(msg):
+            return msg
+
+        self.disp.register_hook(hook)
+        assert self.disp._hooks == [hook]
+
+        q: Queue = Queue()
+
+        def read_other_thread():
+            q.put(self.disp._hooks)
+
+        t = Thread(target=read_other_thread)
+        t.start()
+        other = q.get(timeout=10)
+        t.join()
+        assert other == []
+
+    def test_hook_returning_none_halts_send(self):
+        """A hook that returns None suppresses session.send."""
+        hook = NoReturnHook()
+        self.disp.register_hook(hook)
+
+        _drive(self.disp)
+
+        assert hook.call_count == 1
+        assert self.session.send_count == 0
+        assert self.disp.msg is None
+
+    def test_hook_returning_msg_calls_send(self):
+        """A hook that returns the message lets it through to send."""
+        hook = ReturnHook()
+        self.disp.register_hook(hook)
+
+        _drive(self.disp)
+
+        assert hook.call_count == 1
+        assert self.session.send_count == 1
+
+    def test_hook_can_mutate_message(self):
+        """A hook can attach buffers (the original motivation)."""
+        hook = MutatingHook()
+        self.disp.register_hook(hook)
+
+        _drive(self.disp)
+
+        assert hook.call_count == 1
+        assert self.session.send_count == 1
+        sent = self.session.last_msg
+        assert sent is not None
+        assert sent.get("buffers") == [b"arrow-bytes"]
+
+    def test_hook_chain_short_circuits(self):
+        """If an early hook returns None, later hooks are not called."""
+        first = NoReturnHook()
+        second = NoReturnHook()
+        self.disp.register_hook(first)
+        self.disp.register_hook(second)
+
+        _drive(self.disp)
+
+        assert first.call_count == 1
+        assert second.call_count == 0
+        assert self.session.send_count == 0
+
+    def test_hook_chain_threads_message(self):
+        """Each hook receives the message returned by the previous hook."""
+        observed: list[dict] = []
+
+        def first(msg):
+            msg["content"]["metadata"]["seen_by_first"] = True
+            return msg
+
+        def second(msg):
+            observed.append(msg)
+            return msg
+
+        self.disp.register_hook(first)
+        self.disp.register_hook(second)
+
+        _drive(self.disp)
+
+        assert len(observed) == 1
+        assert observed[0]["content"]["metadata"].get("seen_by_first") is True
+        assert self.session.send_count == 1
+
+    def test_unregister_hook(self):
+        """Unregistered hooks no longer run; double-unregister returns False."""
+        hook = NoReturnHook()
+        self.disp.register_hook(hook)
+
+        _drive(self.disp)
+        assert hook.call_count == 1
+        assert self.session.send_count == 0
+
+        first = self.disp.unregister_hook(hook)
+        assert bool(first)
+
+        _drive(self.disp)
+        # Hook didn't run again, but the message went out via session.send.
+        assert hook.call_count == 1
+        assert self.session.send_count == 1
+
+        # Unregistering an unknown hook returns False.
+        assert not bool(self.disp.unregister_hook(hook))
+
+    def test_empty_data_skips_send_and_hooks(self):
+        """The existing guard: if content.data is empty, don't send or hook."""
+        hook = ReturnHook()
+        self.disp.register_hook(hook)
+
+        # start_displayhook initializes self.msg with empty data; if we never
+        # call write_format_data, the data dict stays empty and finish should
+        # short-circuit before calling either hooks or send.
+        self.disp.start_displayhook()
+        self.disp.finish_displayhook()
+
+        assert hook.call_count == 0
+        assert self.session.send_count == 0
+        assert self.disp.msg is None
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Mirrors the `register_hook` / `unregister_hook` / `_hooks` chain that `ZMQDisplayPublisher` already has, but on `ZMQShellDisplayHook` the displayhook used for the bare-last-expression `execute_result` path. `finish_displayhook` now runs the chain before `session.send`, with the same contract as `ZMQDisplayPublisher.publish`:

- `hook(msg) -> msg`: pass through, continue the chain, eventually `session.send`.
- `hook(msg) -> None`: hook handled the send itself; suppress the default send.

The hook list lives on a `threading.local()` so registrations don't leak across threads, matching the existing implementation on `ZMQDisplayPublisher`.

## Motivation

`DisplayFormatter` is the documented extension point for mime formatting, but inside ipykernel `display_data` and `execute_result` take different paths after formatting:

- `ZMQDisplayPublisher.publish` (used by `display()` / `display_data`) builds the message and walks `self._hooks` before calling `session.send`. That's where buffer-attaching transforms, redirectors, and similar extensions live today.
- `ZMQShellDisplayHook.finish_displayhook` (used for the bare-last-expression `execute_result` path) calls `session.send` directly with no hook chain.

So an extension that wants identical behavior on both paths, for example attaching ZMQ `buffers` to the outbound message has to subclass `ZMQShellDisplayHook` and reimplement `finish_displayhook` from scratch. This PR makes the two paths symmetric so a single hook function can `register_hook` on both seats.

## Concrete use case

Streaming Arrow IPC bytes alongside a small JSON envelope on `display_data` / `execute_result`, without going through comms or widgets. The kernel emits a normal display message whose `data` carries a structured payload (mimetype + ref) and attaches the Arrow bytes as ZMQ `buffers`; the frontend reassembles. This pattern composes naturally with `__arrow_c_stream__`, so any dataframe library that implements the protocol gets a high-fidelity representation without per-library shims.

Doing this on `display_data` works today via `ZMQDisplayPublisher.register_hook`. Doing it on `execute_result` (the bare `df` on the last line of a cell) requires the same hook to fire on `ZMQShellDisplayHook`, which it can't today. nteract currently carries a subclass to bridge the gap; with this PR upstream, the subclass goes away.

## Compatibility

- No behavior change when no hooks are registered: the existing guards (`self.msg`, `content.data` non-empty, `self.session` configured) are preserved, and `session.send` is called exactly as before.
- The hook contract is identical to `ZMQDisplayPublisher`'s, so a hook authored against `display_data` works unchanged on `execute_result`.
- Thread-local storage means existing single-threaded extensions see no difference; multi-threaded callers get the same isolation `ZMQDisplayPublisher` already provides.
