### PR TITLE
Fix broken IPython Reference URL in help_links

### DIFF
--- a/ipykernel/ipkernel.py
+++ b/ipykernel/ipkernel.py
@@ -178,7 +178,7 @@ class IPythonKernel(KernelBase):
             },
             {
                 "text": "IPython Reference",
-                "url": "https://ipython.org/documentation.html",
+                "url": "https://ipython.readthedocs.io/en/stable/",
             },
             {
                 "text": "NumPy Reference",


### PR DESCRIPTION
The current `https://ipython.org/documentation.html` returns a 404 which no longer exists. The correct IPython documentation home is now `https://ipython.readthedocs.io/en/stable/`.

This URL is surfaced in the Jupyter Notebook / JupyterLab Help menu (under "IPython Reference") via `help_links`, so the broken link is user-visible.

```
$ curl -sI https://ipython.org/documentation.html | head -1
HTTP/2 404

$ curl -sI https://ipython.readthedocs.io/en/stable/ | head -1
HTTP/2 200
```