### PR TITLE
Make psutil optional at runtime

### DIFF
--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -36,13 +36,6 @@ except ImportError:
     # jupyter_client < 5, use local now()
     now = datetime.now
 
-try:
-    import psutil
-except ImportError:
-    psutil = None
-
-_NO_SUCH_PROCESS = () if psutil is None else psutil.NoSuchProcess
-
 import zmq
 from IPython.core.error import StdinNotImplementedError
 from jupyter_client.session import Session
@@ -67,6 +60,19 @@ from ipykernel.jsonutil import json_clean
 from ._version import kernel_protocol_version
 from .iostream import OutStream
 from .utils import LazyDict, _async_in_context
+
+psutil: t.Any | None
+try:
+    import psutil as _psutil
+except ImportError:
+    psutil = None
+else:
+    psutil = _psutil
+
+if psutil is None:
+    _NO_SUCH_PROCESS: tuple[type[BaseException], ...] = ()
+else:
+    _NO_SUCH_PROCESS = (psutil.NoSuchProcess,)
 
 _AWAITABLE_MESSAGE: str = (
     "For consistency across implementations, it is recommended that `{func_name}`"
@@ -1189,8 +1195,7 @@ class Kernel(SingletonConfigurable):
         # Ensure 1) self.processes is updated to only current subprocesses
         # and 2) we reuse processes when possible (needed for accurate CPU)
         self.processes = {
-            process.pid: self.processes.get(process.pid, process)  # type:ignore[misc,call-overload]
-            for process in all_processes
+            process.pid: self.processes.get(process.pid, process) for process in all_processes
         }
         reply_content["kernel_cpu"] = sum(
             [
@@ -1208,7 +1213,7 @@ class Kernel(SingletonConfigurable):
         cpu_percent = psutil.cpu_percent()
         # https://psutil.readthedocs.io/en/latest/index.html?highlight=cpu#psutil.cpu_percent
         # The first time cpu_percent is called it will return a meaningless 0.0 value which you are supposed to ignore.
-        if cpu_percent is not None and cpu_percent != 0.0:  # type:ignore[redundant-expr]
+        if cpu_percent is not None and cpu_percent != 0.0:
             reply_content["host_cpu_percent"] = cpu_percent
         reply_content["cpu_count"] = psutil.cpu_count(logical=True)
         reply_content["host_virtual_memory"] = dict(psutil.virtual_memory()._asdict())

--- a/ipykernel/kernelbase.py
+++ b/ipykernel/kernelbase.py
@@ -36,7 +36,13 @@ except ImportError:
     # jupyter_client < 5, use local now()
     now = datetime.now
 
-import psutil
+try:
+    import psutil
+except ImportError:
+    psutil = None
+
+_NO_SUCH_PROCESS = () if psutil is None else psutil.NoSuchProcess
+
 import zmq
 from IPython.core.error import StdinNotImplementedError
 from jupyter_client.session import Session
@@ -97,7 +103,7 @@ class Kernel(SingletonConfigurable):
     # attribute to override with a GUI
     eventloop = Any(None)
 
-    processes: dict[str, psutil.Process] = {}
+    processes: dict[int, t.Any] = {}
 
     @observe("eventloop")
     def _update_eventloop(self, change):
@@ -1172,6 +1178,12 @@ class Kernel(SingletonConfigurable):
         if not self.session:
             return
         reply_content = {"hostname": socket.gethostname(), "pid": os.getpid()}
+        if psutil is None:
+            reply_content["cpu_count"] = os.cpu_count()
+            reply_msg = self.session.send(stream, "usage_reply", reply_content, parent, ident)
+            self.log.debug("%s", reply_msg)
+            return
+
         current_process = psutil.Process()
         all_processes = [current_process, *current_process.children(recursive=True)]
         # Ensure 1) self.processes is updated to only current subprocesses
@@ -1476,7 +1488,7 @@ class Kernel(SingletonConfigurable):
                     p.kill()
                 else:
                     p.send_signal(signum)
-            except psutil.NoSuchProcess:
+            except _NO_SUCH_PROCESS:
                 pass
 
     def _process_children(self):
@@ -1486,6 +1498,9 @@ class Kernel(SingletonConfigurable):
         - including parents and self with killpg
         - including all children that may have forked-off a new group
         """
+        if psutil is None:
+            return []
+
         kernel_process = psutil.Process()
         all_children = kernel_process.children(recursive=True)
         if os.name == "nt":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ dependencies = [
     "matplotlib-inline>=0.1",
     'appnope>=0.1.2;platform_system=="Darwin"',
     "pyzmq>=25",
-    "psutil>=5.7",
     "packaging>=22",
 ]
 
@@ -59,6 +58,7 @@ test = [
     "flaky",
     "ipyparallel",
     "pre-commit",
+    "psutil>=5.7",
     "pytest-asyncio>=0.23.5",
     "pytest-timeout"
 ]

--- a/tests/test_kernel_direct.py
+++ b/tests/test_kernel_direct.py
@@ -4,6 +4,7 @@
 # Distributed under the terms of the Modified BSD License.
 
 import os
+import signal
 import warnings
 
 import pytest
@@ -150,6 +151,32 @@ async def test_publish_debug_event(kernel):
 
 async def test_connect_request(kernel):
     await kernel.connect_request(kernel.shell_stream, "foo", {})
+
+
+async def test_usage_request_without_psutil(kernel, monkeypatch):
+    import ipykernel.kernelbase as kernelbase
+
+    monkeypatch.setattr(kernelbase, "psutil", None)
+    reply = await kernel.test_control_message("usage_request", {})
+    content = reply["content"]
+
+    assert reply["header"]["msg_type"] == "usage_reply"
+    assert content["hostname"]
+    assert content["pid"] == os.getpid()
+    assert content["cpu_count"] == os.cpu_count()
+    assert "host_cpu_percent" not in content
+    assert "host_virtual_memory" not in content
+    assert "kernel_memory" not in content
+
+
+async def test_child_process_fallbacks_without_psutil(kernel, monkeypatch):
+    import ipykernel.kernelbase as kernelbase
+
+    monkeypatch.setattr(kernelbase, "psutil", None)
+
+    assert kernel._process_children() == []
+    kernel._signal_children(signal.SIGTERM)
+    await kernel._progressively_terminate_all_children()
 
 
 async def test_send_interrupt_children(kernel):


### PR DESCRIPTION
This PR makes ipykernel's direct use of psutil optional at runtime.

When psutil is installed, existing behavior is preserved. When ipykernel.kernelbase is running with psutil unavailable:
- usage_request still sends a valid usage_reply with hostname, pid, and cpu_count
- psutil-dependent CPU and memory telemetry is omitted rather than fabricated
- child-process enumeration returns an empty list
- child-process signalling and progressive termination degrade safely

psutil is moved from required runtime dependencies to the test extra so existing subprocess-shutdown coverage remains active in the test environment.

This is intended for constrained platforms where psutil may be unavailable or difficult to build. Runtime optionality is preferable to platform markers here because some constrained builds, such as Python-for-Android, may report sys.platform == "linux" while psutil is unavailable.

Validation:
- python -m pytest tests/test_kernel_direct.py -q
- python -m pytest tests/test_kernel.py -q

Addresses #1523

The remaining PyPy failures appear unrelated to this PR.

This PR only changes ipykernel's direct `psutil` usage in `kernelbase.py`, plus the corresponding dependency/test updates. It does not modify the subshell execution path, threading code, Windows-specific code, or CI workflow configuration.

One failure is in `tests/test_subshells.py::test_run_concurrently_sequence[...]`, and another appears to be a Windows+PyPy timeout while waiting on a threading condition variable. I do not see a direct connection to the changed `usage_request` fallback or child-process cleanup fallback paths.

I will leave these unchanged unless maintainers think they reproduce specifically because of this branch.

