### PR TITLE
Update the `supported_encryption` to use a list as per JEP latest state

### DIFF
--- a/hatch_build.py
+++ b/hatch_build.py
@@ -22,7 +22,7 @@ class CustomHook(BuildHookInterface):
         if version == "standard":
             overrides["metadata"] = {
                 "debugger": True,
-                "supported_encryption": "curve",
+                "supported_encryption": ["curve"],
             }
             argv = make_ipkernel_cmd(executable="python")
 

--- a/ipykernel/kernelspec.py
+++ b/ipykernel/kernelspec.py
@@ -66,7 +66,7 @@ def get_kernel_dict(
         ),
         "display_name": "Python %i (ipykernel)" % sys.version_info[0],
         "language": "python",
-        "metadata": {"debugger": True, "supported_encryption": "curve"},
+        "metadata": {"debugger": True, "supported_encryption": ["curve"]},
         "kernel_protocol_version": "5.5",
     }
 

--- a/tests/test_kernelspec.py
+++ b/tests/test_kernelspec.py
@@ -36,7 +36,7 @@ def assert_kernel_dict(d):
     assert d["display_name"] == "Python %i (ipykernel)" % sys.version_info[0]
     assert d["language"] == "python"
     assert d["metadata"]["debugger"] is True
-    assert d["metadata"]["supported_encryption"] == "curve"
+    assert d["metadata"]["supported_encryption"] == ["curve"]
     assert d["kernel_protocol_version"] == "5.5"
 
 
@@ -50,7 +50,7 @@ def assert_kernel_dict_with_profile(d):
     assert d["display_name"] == "Python %i (ipykernel)" % sys.version_info[0]
     assert d["language"] == "python"
     assert d["metadata"]["debugger"] is True
-    assert d["metadata"]["supported_encryption"] == "curve"
+    assert d["metadata"]["supported_encryption"] == ["curve"]
     assert d["kernel_protocol_version"] == "5.5"
 
 


### PR DESCRIPTION
Aligns `supported_encryption` with the state in the JEP https://github.com/jupyter/enhancement-proposals/pull/145