### PR TITLE
create debugger tmp directory with 0o700 permissions

### DIFF
--- a/ipykernel/debugger.py
+++ b/ipykernel/debugger.py
@@ -426,7 +426,7 @@ class Debugger:
         if not self.debugpy_initialized:
             tmp_dir = get_tmp_directory()
             if not Path(tmp_dir).exists():
-                Path(tmp_dir).mkdir(parents=True)
+                Path(tmp_dir).mkdir(mode=0o700, parents=True)
             host, port = self.debugpy_client.get_host_port()
             code = "import debugpy;"
             code += 'debugpy.listen(("' + host + '",' + port + "))"


### PR DESCRIPTION
While looking at where the debugger persists cell sources, I noticed `Debugger.start` creates the scratch directory with `Path(tmp_dir).mkdir(parents=True)` and no mode argument. `get_tmp_directory()` returns a predictable `<tmpdir>/ipykernel_<pid>`, so on a typical umask the directory lands at 0o755 and the cell files `dumpCell` writes into it come out 0o644. On a shared host any other local user can then read the source the user is debugging. Checking the mode locally confirmed 0o755 on the directory and 0o644 on the written `.py` files.

The connection directory in `kernelapp.init_connection_file` is already created with `mode=0o700` for the same reason, so this brings the debugger scratch directory in line. Setting the mode at creation keeps the restriction next to the only place the directory is made, rather than relying on the ambient umask being tight.