### PR TITLE
bump tornado dependency to version 6.5.7 to fix 5 CVEs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "jupyter_core>=5.1,!=6.0.*",
     # For tk event loop support only.
     "nest_asyncio2>=1.7.0",
-    "tornado>=6.4.1",
+    "tornado>=6.5.7",
     "matplotlib-inline>=0.1",
     'appnope>=0.1.2;platform_system=="Darwin"',
     "pyzmq>=25",


### PR DESCRIPTION
This PR upgrades the pin to `tornado` in `pyproject.toml` requirements to exclude versions of `tornado` that contain these 5 CVEs:

```
> uv audit --preview --locked

Found 4 known vulnerabilities and no adverse project statuses in 118 packages

Vulnerabilities:

tornado 6.5.5 has 4 known vulnerabilities:

- GHSA-3x9g-8vmp-wqvf: Tornado: Authorization header forwarded across cross-origin redirects in SimpleAsyncHTTPClient

  Fixed in: 6.5.6

  Advisory information: https://github.com/tornadoweb/tornado/security/advisories/GHSA-3x9g-8vmp-wqvf

- GHSA-cx3h-4qpv-8hc9: Tornado has out-of-bounds memory access via C extension

  Fixed in: 6.5.6

  Advisory information: https://github.com/tornadoweb/tornado/security/advisories/GHSA-cx3h-4qpv-8hc9

- GHSA-mgf9-4vpg-hj56: tornado AsyncHTTPClient accumulates decompressed chunks without size limit (gzip bomb)

  Fixed in: 6.5.6

  Advisory information: https://github.com/tornadoweb/tornado/security/advisories/GHSA-mgf9-4vpg-hj56

- GHSA-pw6j-qg29-8w7f: Tornado: CurlAsyncHTTPClient leaks per-request credentials on handle reuse

  Fixed in: 6.5.7

  Advisory information: https://github.com/tornadoweb/tornado/security/advisories/GHSA-pw6j-qg29-8w7f
```

There are no explicit migrations listed in `tornado` to upgrade from 6.4.x to 6.5.x