### PR TITLE
validate variable names in copyToGlobals debug handler

### DIFF
--- a/ipykernel/debugger.py
+++ b/ipykernel/debugger.py
@@ -676,6 +676,15 @@ class Debugger:
         src_var_name = message["arguments"]["srcVariableName"]
         src_frame_id = message["arguments"]["srcFrameId"]
 
+        if not str.isidentifier(dst_var_name) or not str.isidentifier(src_var_name):
+            return {
+                "type": "response",
+                "request_seq": message["seq"],
+                "success": False,
+                "command": message["command"],
+                "message": "dstVariableName and srcVariableName must be valid identifiers",
+            }
+
         expression = f"globals()['{dst_var_name}']"
         seq = message["seq"]
         return await self._forward_message(

--- a/ipykernel/debugger.py
+++ b/ipykernel/debugger.py
@@ -681,6 +681,15 @@ class Debugger:
         src_var_name = message["arguments"]["srcVariableName"]
         src_frame_id = message["arguments"]["srcFrameId"]
 
+        if not str.isidentifier(dst_var_name) or not str.isidentifier(src_var_name):
+            return {
+                "type": "response",
+                "request_seq": message["seq"],
+                "success": False,
+                "command": message["command"],
+                "message": "dstVariableName and srcVariableName must be valid identifiers",
+            }
+
         expression = f"globals()['{dst_var_name}']"
         seq = message["seq"]
         return await self._forward_message(

--- a/tests/test_debugger.py
+++ b/tests/test_debugger.py
@@ -473,6 +473,24 @@ my_test()"""
     assert global_var["value"] == local_var["value"] and global_var["type"] == local_var["type"]  # noqa: PT018
 
 
+def test_copy_to_globals_rejects_non_identifier(kernel_with_debug):
+    # A dstVariableName that is not a valid identifier would break out of the
+    # single-quoted globals()['...'] expression forwarded to setExpression.
+    reply = wait_for_debug_request(
+        kernel_with_debug,
+        "copyToGlobals",
+        {
+            "srcVariableName": "src",
+            "dstVariableName": "x'] or __import__('os').system('echo pwned') or globals()['y",
+            "srcFrameId": 0,
+        },
+    )
+    # The request is rejected locally instead of being forwarded to
+    # setExpression, so the response still carries the copyToGlobals command.
+    assert reply["success"] is False
+    assert reply["command"] == "copyToGlobals"
+
+
 def test_debug_requests_sequential(kernel_with_debug):
     # Issue https://github.com/ipython/ipykernel/issues/1412
     # Control channel requests should be executed sequentially not concurrently.

--- a/tests/test_debugger.py
+++ b/tests/test_debugger.py
@@ -487,8 +487,11 @@ def test_copy_to_globals_rejects_non_identifier(kernel_with_debug):
     )
     # The request is rejected locally instead of being forwarded to
     # setExpression, so the response still carries the copyToGlobals command.
-    assert reply["success"] is False
-    assert reply["command"] == "copyToGlobals"
+    if debugpy:
+        assert reply["success"] is False
+        assert reply["command"] == "copyToGlobals"
+    else:
+        assert reply == {}
 
 
 def test_debug_requests_sequential(kernel_with_debug):


### PR DESCRIPTION
**Expression injection via unvalidated variable names in copyToGlobals**

While reading through the debug handlers I noticed `copyToGlobals` drops the client-supplied `dstVariableName` straight into `globals()['{dst_var_name}']` and forwards that to `setExpression`, and hands `srcVariableName` over as the value expression, with neither of them checked. Its sibling `richInspectVariables` already runs `str.isidentifier` over the name it evaluates, so the omission here stood out. A name such as `x'] or __import__('os').system('id') or globals()['y` closes the quoted string and injects an arbitrary expression that debugpy then evaluates in the debuggee frame; the forwarded `setExpression` payload showed the escaped quotes plainly once I logged it.

Left as is this lets a malformed or hostile debug request steer evaluation well beyond a variable copy. The change rejects any `dstVariableName`/`srcVariableName` that is not a valid identifier before the expression is built, mirroring the guard the sibling handler already applies. Added a regression under the existing debugger tests that confirms such a request is refused locally rather than forwarded.