### PR TITLE
Add env var to shut down kernel immediately after start for benchmarking

### DIFF
--- a/ipykernel/kernelapp.py
+++ b/ipykernel/kernelapp.py
@@ -755,6 +755,10 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp, ConnectionFileMix
             self.poller.start()
         self.kernel.start()
         self.io_loop = ioloop.IOLoop.current()
+        if os.environ.get("IPYKERNEL_BENCHMARK_STARTUP_SHUTDOWN"):
+            # Shut down immediately after entering the event loop, for
+            # benchmarking kernel startup time end-to-end.
+            self.io_loop.add_callback(self.io_loop.stop)
         if self.trio_loop:
             from ipykernel.trio_runner import TrioRunner
 


### PR DESCRIPTION
Setting IPYKERNEL_BENCHMARK_STARTUP_SHUTDOWN stops the event loop right after it starts, so total process wall-clock time measures kernel startup without needing an actual client to send a shutdown request.

This can be used in conjunction with -X importtime and profile viewer like tuna to work on speeding up importing and starting a kernel