### PR TITLE
Use dependency groups (PEP 735)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,7 +163,7 @@ jobs:
 
       - name: Install the Python dependencies without debugpy
         run: |
-          pip install .[test]
+          pip install . --group test
           pip uninstall --yes debugpy
 
       - name: List installed packages

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,14 +4,10 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.13"
+  jobs:
+    install:
+      - pip install --upgrade pip
+      - pip install --group docs
 
 sphinx:
   configuration: docs/conf.py
-
-python:
-  install:
-    # install itself with pip install .
-    - method: pip
-      path: .
-      extra_requirements:
-        - docs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ ipykernel is a pure Python package, so setting up for development is the same as
 git clone https://github.com/ipython/ipykernel
 cd ipykernel
 # do a 'development' or 'editable' install with pip:
-pip install -e .
+pip install -e . --group dev
 ```
 
 ## Code Styling

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This package provides the IPython kernel for Jupyter.
 
 1. `git clone`
 1. `cd ipykernel`
-1. `pip install -e ".[test]"`
+1. `pip install -e . --group test`
 
 After that, all normal `ipython` commands will use this newly-installed version of the kernel.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,35 +41,40 @@ Source = "https://github.com/ipython/ipykernel"
 Tracker = "https://github.com/ipython/ipykernel/issues"
 
 [project.optional-dependencies]
+pyqt5 = ["pyqt5"]
+pyside6 = ["pyside6"]
+
+[dependency-groups]
 docs = [
-  "sphinx",
-  "myst_parser",
-  "pydata_sphinx_theme",
-  "sphinxcontrib_github_alt",
-  "sphinxcontrib-spelling",
-  "sphinx-autodoc-typehints",
-  "intersphinx_registry",
-  "trio"
+    "intersphinx_registry",
+    "myst_parser",
+    "pydata_sphinx_theme",
+    "sphinx",
+    "sphinxcontrib_github_alt",
+    "sphinxcontrib-spelling",
+    "sphinx-autodoc-typehints",
+    "trio"
 ]
 test = [
-    "pytest>=7.0,<10",
-    "pytest-cov",
     # 'pytest-xvfb; platform_system == "Linux"',
     "flaky",
     "ipyparallel",
-    "pre-commit",
     "psutil>=5.7",
+    "pytest>=7.0,<10",
+    "pytest-cov",
     "pytest-asyncio>=0.23.5",
     "pytest-timeout"
 ]
 cov = [
-  "coverage[toml]",
-  "pytest-cov",
-  "matplotlib",
-  "trio",
+    "coverage[toml]",
+    "matplotlib",
+    "pytest-cov",
+    "trio",
 ]
-pyqt5 = ["pyqt5"]
-pyside6 = ["pyside6"]
+dev = [
+    "pre-commit",
+    {include-group = "test"},
+]
 
 [tool.hatch.version]
 path = "ipykernel/_version.py"
@@ -84,20 +89,20 @@ path = "ipykernel/_version.py"
 "./ipykernel_launcher.py" = "ipykernel_launcher.py"
 
 [tool.hatch.envs.docs]
-features = ["docs"]
+dependency-groups = ["docs"]
 [tool.hatch.envs.docs.scripts]
 build = "make -C docs html SPHINXOPTS='-W'"
 api = "sphinx-apidoc -o docs/api -f -E ipykernel tests ipykernel/datapub.py ipykernel/pickleutil.py ipykernel/serialize.py ipykernel/gui ipykernel/pylab ipykernel/utils.py"
 
 [tool.hatch.envs.test]
-features = ["test"]
+dependency-groups = ["test"]
 [tool.hatch.envs.test.scripts]
 list = "python -m pip freeze"
 test = "python -m pytest -vv {args}"
 nowarn = "test -W default {args}"
 
 [tool.hatch.envs.cov]
-features = ["test", "cov"]
+dependency-groups = ["test", "cov"]
 [tool.hatch.envs.cov.scripts]
 test = "python -m pytest -vv --cov ipykernel --cov-branch --cov-report term-missing:skip-covered {args}"
 nowarn = "test -W default {args}"


### PR DESCRIPTION
This PR moves some dependency lists from `project.optional-dependencies` (aka "extras") to `dependency-groups`, as described by [PEP 735](https://peps.python.org/pep-0735/). Some details:

- Keep `pyqt5` and `pyside6` as "extras" intended for end-users
- Move `test`, `docs` and `cov` to dependency groups, intended for developers
  - Note that `pip install --dryrun ipykernel[test]` will show a warning that the package does not have an extra named test.
  - Developers that need this dependency will require pip [v25.1 (2025-04-26)](https://pip.pypa.io/en/stable/news/#v25-1) (or `uv`) and use the `--group test` option
- Add a `dev` group, which adds pre-commit and the test group; `uv` enables this group by default.
- Hatch has supported dependency groups since [v1.16.0](https://hatch.pypa.io/1.16/blog/2025/11/24/hatch-v1160/#dependency-groups), which is within the version specified in the build requirements
- Dependency lists are indented constantly and sorted