### PR TITLE
Preserve async shell context across cells

### DIFF
--- a/ipykernel/ipkernel.py
+++ b/ipykernel/ipkernel.py
@@ -438,7 +438,8 @@ class IPythonKernel(KernelBase):
                     **do_execute_args,
                 )
 
-                coro_future = asyncio.ensure_future(coro)
+                coro_future = asyncio.current_task()
+                assert coro_future is not None
 
                 cm = (
                     self._cancel_on_sigint
@@ -448,7 +449,7 @@ class IPythonKernel(KernelBase):
                 with cm(coro_future):
                     res = None
                     try:
-                        res = await coro_future
+                        res = await coro
                     finally:
                         shell.events.trigger("post_execute")
                         if not silent:

--- a/ipykernel/utils.py
+++ b/ipykernel/utils.py
@@ -52,26 +52,26 @@ def _async_in_context(
     if context is None:
         context = copy_context()
 
+    # Keep the context created by one shell request for subsequent requests. This is
+    # needed because an async cell runs in a task context, and changes made after an
+    # await would otherwise be discarded when that task finishes.
+    context_holder = [context]
+
+    async def preserve_context(f, *args, **kwargs):
+        """Call a coroutine in a persistent ContextVar context."""
+        try:
+            return await f(*args, **kwargs)
+        finally:
+            context_holder[0] = copy_context()
+
     if sys.version_info >= (3, 11):
 
         @wraps(f)
         async def run_in_context(*args, **kwargs):
-            coro = f(*args, **kwargs)
-            return await asyncio.create_task(coro, context=context)
+            coro = preserve_context(f, *args, **kwargs)
+            return await asyncio.create_task(coro, context=context_holder[0])
 
         return run_in_context
-
-    # don't need this backport when we require 3.11
-    # context_holder so we have a modifiable container for later calls
-    context_holder = [context]  # type: ignore[unreachable]
-
-    async def preserve_context(f, *args, **kwargs):
-        """call a coroutine, preserving the context after it is called"""
-        try:
-            return await f(*args, **kwargs)
-        finally:
-            # persist changes to the context for future calls
-            context_holder[0] = copy_context()
 
     @wraps(f)
     async def run_in_context_pre311(*args, **kwargs):

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -910,7 +910,13 @@ def test_context_vars():
 
         msg_id, _ = execute(
             kc=kc,
+            code="async def produce_result():\n    return 'set after await'\nresult = await produce_result(); ctxvar.set(result)",
+        )
+        stdout, _ = assemble_output(kc.get_iopub_msg, parent_msg_id=msg_id)
+
+        msg_id, _ = execute(
+            kc=kc,
             code="print(ctxvar.get())",
         )
         stdout, _ = assemble_output(kc.get_iopub_msg, parent_msg_id=msg_id)
-        assert stdout.strip() == "set"
+        assert stdout.strip() == "set after await"


### PR DESCRIPTION
Fixes #749

## Summary

The asynchronous cell runner created a separate task for the cell coroutine. ContextVar updates made after an `await` therefore remained in that task and were not available to the next execute request. The SIGINT cancellation hook also tracked the separate task.

This change runs the cell coroutine in the current execute task while retaining the cancellation hook, and persists the resulting async context for subsequent requests. The regression test sets a ContextVar after an await and verifies that the value is available in the next cell.

## Validation

- ContextVar regression test passed
- Kernel and direct-kernel related tests passed after installing the declared `ipyparallel` test dependency
- Pre-commit/Ruff checks passed
- `git diff --check` passed