### PR TITLE
Fix output routing when threads inherit context

### DIFF
--- a/ipykernel/displayhook.py
+++ b/ipykernel/displayhook.py
@@ -28,8 +28,8 @@ class ZMQDisplayHook:
         self.session = session
         self.pub_socket = pub_socket
 
-        self._parent_header: ContextVar[dict[str, Any]] = ContextVar("parent_header")
-        self._parent_header.set({})
+        self._parent_header: ContextVar[tuple[int, dict[str, Any]]] = ContextVar("parent_header")
+        self._parent_header.set((threading.get_ident(), {}))
         self._parent_header_global = {}
 
     def get_execution_count(self):
@@ -60,18 +60,21 @@ class ZMQDisplayHook:
     @property
     def parent_header(self):
         try:
-            return self._parent_header.get()
+            thread_id, parent_header = self._parent_header.get()
         except LookupError:
             return self._parent_header_global
+        if thread_id != threading.get_ident():
+            return self._parent_header_global
+        return parent_header
 
     @parent_header.setter
     def parent_header(self, value):
-        self._parent_header.set(value)
+        self._parent_header.set((threading.get_ident(), value))
         self._parent_header_global = value
 
     def set_thread_parent(self, parent):
         """Set the parent header for the calling thread only. Returns a reset token that can be used with reset_thread_parent."""
-        return self._parent_header.set(extract_header(parent))
+        return self._parent_header.set((threading.get_ident(), extract_header(parent)))
 
     def reset_thread_parent(self, token):
         """Reset the parent header to undo the set_thread_parent call that returned the token."""
@@ -91,14 +94,14 @@ class ZMQShellDisplayHook(DisplayHook):
 
     session = Instance(Session, allow_none=True)
     pub_socket = Any(allow_none=True)
-    _parent_header: ContextVar[dict[str, Any]]
+    _parent_header: ContextVar[tuple[int, dict[str, Any]]]
     _thread_local = Any()
     msg: dict[str, t.Any] | None
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._parent_header = ContextVar("parent_header")
-        self._parent_header.set({})
+        self._parent_header.set((threading.get_ident(), {}))
         self._parent_header_global = {}
 
     @default("_thread_local")
@@ -131,18 +134,21 @@ class ZMQShellDisplayHook(DisplayHook):
     @property
     def parent_header(self):
         try:
-            return self._parent_header.get()
+            thread_id, parent_header = self._parent_header.get()
         except LookupError:
             return self._parent_header_global
+        if thread_id != threading.get_ident():
+            return self._parent_header_global
+        return parent_header
 
     @parent_header.setter
     def parent_header(self, value):
-        self._parent_header.set(value)
+        self._parent_header.set((threading.get_ident(), value))
         self._parent_header_global = value
 
     def set_thread_parent(self, parent):
         """Set the parent header for the calling thread only. Returns a reset token that can be used with reset_thread_parent."""
-        return self._parent_header.set(extract_header(parent))
+        return self._parent_header.set((threading.get_ident(), extract_header(parent)))
 
     def reset_thread_parent(self, token):
         """Reset the parent header to undo the set_thread_parent call that returned the token."""

--- a/ipykernel/iostream.py
+++ b/ipykernel/iostream.py
@@ -539,10 +539,10 @@ class OutStream(TextIOBase):
         self.pub_thread = pub_thread
         self.name = name
         self.topic = b"stream." + name.encode()
-        self._parent_header: contextvars.ContextVar[dict[str, Any]] = contextvars.ContextVar(
-            "parent_header"
+        self._parent_header: contextvars.ContextVar[tuple[int, dict[str, Any]]] = (
+            contextvars.ContextVar("parent_header")
         )
-        self._parent_header.set({})
+        self._parent_header.set((threading.get_ident(), {}))
         self._parent_header_global = {}
         self._master_pid = os.getpid()
         self._flush_pending = False
@@ -598,14 +598,19 @@ class OutStream(TextIOBase):
     def parent_header(self):
         try:
             # asyncio or thread-specific
-            return self._parent_header.get()
+            thread_id, parent_header = self._parent_header.get()
         except LookupError:
             # global (fallback)
             return self._parent_header_global
+        if thread_id != threading.get_ident():
+            # Contexts can be inherited by a new thread, but the parent is
+            # thread-specific unless explicitly set in that thread.
+            return self._parent_header_global
+        return parent_header
 
     @parent_header.setter
     def parent_header(self, value):
-        self._parent_header.set(value)
+        self._parent_header.set((threading.get_ident(), value))
         self._parent_header_global = value
 
     def isatty(self):
@@ -634,7 +639,7 @@ class OutStream(TextIOBase):
 
     def set_thread_parent(self, parent):
         """Set the parent header for the calling thread only. Returns a reset token that can be used with reset_thread_parent."""
-        return self._parent_header.set(extract_header(parent))
+        return self._parent_header.set((threading.get_ident(), extract_header(parent)))
 
     def reset_thread_parent(self, token):
         """Reset the parent header to undo the set_thread_parent call that returned the token."""

--- a/ipykernel/zmqshell.py
+++ b/ipykernel/zmqshell.py
@@ -57,7 +57,7 @@ class ZMQDisplayPublisher(DisplayPublisher):
 
     session = Instance(Session, allow_none=True)
     pub_socket = Any(allow_none=True)
-    _parent_header: contextvars.ContextVar[dict[str, Any]]
+    _parent_header: contextvars.ContextVar[tuple[int, dict[str, Any]]]
     topic = CBytes(b"display_data")
 
     store_display_history = Bool(
@@ -73,24 +73,27 @@ class ZMQDisplayPublisher(DisplayPublisher):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._parent_header = contextvars.ContextVar("parent_header")
-        self._parent_header.set({})
+        self._parent_header.set((threading.get_ident(), {}))
         self._parent_header_global = {}
 
     @property
     def parent_header(self):
         try:
-            return self._parent_header.get()
+            thread_id, parent_header = self._parent_header.get()
         except LookupError:
             return self._parent_header_global
+        if thread_id != threading.get_ident():
+            return self._parent_header_global
+        return parent_header
 
     @parent_header.setter
     def parent_header(self, value):
-        self._parent_header.set(value)
+        self._parent_header.set((threading.get_ident(), value))
         self._parent_header_global = value
 
     def set_thread_parent(self, parent):
         """Set the parent header for the calling thread only. Returns a reset token that can be used with reset_thread_parent."""
-        return self._parent_header.set(extract_header(parent))
+        return self._parent_header.set((threading.get_ident(), extract_header(parent)))
 
     def reset_thread_parent(self, token):
         """Reset the parent header to undo the set_thread_parent call that returned the token."""
@@ -546,10 +549,10 @@ class ZMQInteractiveShell(InteractiveShell):
         if "IPKernelApp" not in self.config:
             self.config.IPKernelApp.tqdm = "dummy value for https://github.com/tqdm/tqdm/pull/1628"
 
-        self._parent_header: contextvars.ContextVar[dict[str, typing.Any]] = contextvars.ContextVar(
-            "parent_header"
+        self._parent_header: contextvars.ContextVar[tuple[int, dict[str, typing.Any]]] = (
+            contextvars.ContextVar("parent_header")
         )
-        self._parent_header.set({})
+        self._parent_header.set((threading.get_ident(), {}))
         self._parent_header_global = {}
 
     displayhook_class = Type(ZMQShellDisplayHook)
@@ -732,13 +735,16 @@ class ZMQInteractiveShell(InteractiveShell):
     @property
     def parent_header(self):
         try:
-            return self._parent_header.get()
+            thread_id, parent_header = self._parent_header.get()
         except LookupError:
             return self._parent_header_global
+        if thread_id != threading.get_ident():
+            return self._parent_header_global
+        return parent_header
 
     @parent_header.setter
     def parent_header(self, value):
-        self._parent_header.set(value)
+        self._parent_header.set((threading.get_ident(), value))
         self._parent_header_global = value
 
     def set_parent(self, parent):
@@ -764,7 +770,12 @@ class ZMQInteractiveShell(InteractiveShell):
 
     def set_thread_parent(self, parent):
         """Set the parent header for only the current thread associating output with its triggering input"""
-        tokens = [(self._parent_header.reset, self._parent_header.set(parent))]
+        tokens = [
+            (
+                self._parent_header.reset,
+                self._parent_header.set((threading.get_ident(), parent)),
+            )
+        ]
         objs = [self.displayhook, self.display_pub, sys.stdout, sys.stderr]
         if hasattr(self, "_data_pub"):
             objs.append(self.data_pub)

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -131,6 +131,7 @@ def test_print_to_correct_cell_from_thread(explicit_parent: str):
     get_ipython().set_thread_parent sets the thread-local parent for only the thread.
     """
     code = f"""\
+        from contextvars import copy_context
         from threading import Event, Thread
         from time import sleep
         from IPython.display import display
@@ -162,7 +163,8 @@ def test_print_to_correct_cell_from_thread(explicit_parent: str):
             print("after", flush=True)
             display(3)
 
-        thread = Thread(target=thread_target)
+        # Free-threaded Python inherits the caller's context by default.
+        thread = Thread(target=copy_context().run, args=(thread_target,))
         thread.start()
     """
     outputs = {}


### PR DESCRIPTION
Closes #1491

A background thread can inherit the executing cell's `ContextVar` state (the default on free-threaded CPython, and also possible with `copy_context`). Because ipykernel treated any context-local parent as belonging to the current thread, a persistent worker stayed pinned to the cell that created it.

Store the setting thread ID with each context-local parent, and fall back to the current global parent when another thread observes an inherited context. Explicit `set_parent` and `set_thread_parent` calls in the worker still pin output as before.

The regression runs a worker in a copied context and covers both stream and display output across three cells, including explicit global and temporary thread-local overrides.

🤖🤖 AI-assisted contribution.