### PR TITLE
Fix downstream test: install ipykernel from source for `jupyter_kernel_test`

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -97,5 +97,7 @@ jobs:
         run: |
           git clone https://github.com/jupyter/jupyter_kernel_test.git
           cd jupyter_kernel_test
+          pip install ..
           pip install -e ".[test]"
+          python -c "import importlib.metadata as m; assert m.distribution('ipykernel').read_text('direct_url.json'), 'ipykernel under test is not this checkout'"
           python test_ipykernel.py


### PR DESCRIPTION
The `jupyter_kernel_test` job in [`downstream.yml`](https://github.com/ipython/ipykernel/blob/ec804fb0db7a975c9a8ab1079160a8433141eb37/.github/workflows/downstream.yml#L96-L101) never installs this checkout. `pip install -e ".[test]"` inside the clone pulls `ipykernel` from PyPI, so on every pull request and every push to main the kernel conformance suite runs against the released wheel (currently 7.3.0) instead of the code under review. The step used to rely on a global `pip install . --force-reinstall`, which 2d0f2ddf60 (Dec 2021) removed when the other downstream jobs moved to `downstream-test`; that action installs the checkout for them, but this job doesn't use it.

In main's [latest run of the job](https://github.com/ipython/ipykernel/actions/runs/34354652917/job/102476150307), the only local install is the `jupyter_kernel_test` clone itself, `ipykernel` comes from `Using cached ipykernel-7.3.0-py3-none-any.whl (120 kB)`, and there is no `Processing /home/runner/work/ipykernel/ipykernel` line. main's `_version.py` also says 7.3.0, so the version number alone can't tell the two apart.

This change installs the checkout first, so the `ipykernel` that jupyter_kernel_test's `[test]` extra asks for is already satisfied by it. It also adds an assertion that fails when ipykernel was installed from an index, as it is on main today: pip writes a `direct_url.json` only for path and URL installs. That way the job can't quietly go back to testing PyPI.



🤖 Generated with [Claude Code](https://claude.com/claude-code)
